### PR TITLE
set optimization options with system properties

### DIFF
--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptimizationConfiguration.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptimizationConfiguration.java
@@ -27,49 +27,37 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.oracle.truffle.llvm.parser;
+package com.oracle.truffle.llvm.runtime;
 
-import org.eclipse.emf.ecore.EObject;
-
-import com.intel.llvm.ireditor.lLVM_IR.GlobalVariable;
-import com.intel.llvm.ireditor.types.ResolvedType;
-import com.oracle.truffle.api.frame.FrameSlot;
-import com.oracle.truffle.llvm.LLVMContext;
-import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
-import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
-import com.oracle.truffle.llvm.types.LLVMAddress;
-
-public interface LLVMParserRuntime {
-
-    ResolvedType resolve(EObject e);
+/**
+ * This class specifies which optimizations are used for a Sulong instance.
+ */
+public interface LLVMOptimizationConfiguration {
 
     /**
-     * Performs an <code>alloc</code> style allocation. At the begin of a function (or the global
-     * scope) the memory is allocated and again released when leaving the function (or the global
-     * scope). The intrinsic <code>@llvm.stacksave</code> might also cause the allocation to be
-     * released earlier.
-     *
-     * @see <a href="http://llvm.org/docs/LangRef.html#llvm-stacksave-intrinsic">llvm.stacksave
-     *      intrinsic</a>
-     * @param size the bytes to be allocated
-     * @return a node that allocates the requested memory.
+     * Speculation based on the <code>llvm.expect</code> intrinsic.
      */
-    LLVMAddressNode allocateFunctionLifetime(int size, int alignment);
+    boolean specializeForExpectIntrinsic();
 
     /**
-     * Gets the return slot where the function return value is stored.
-     *
-     * @return the return slot.
+     * Speculates that memory reads always return the same result.
      */
-    FrameSlot getReturnSlot();
+    boolean valueProfileMemoryReads();
 
-    LLVMAddressNode allocateVectorResult(EObject type);
+    /**
+     * Record branch probabilities for the LLVM <code>select</code> instruction.
+     */
+    boolean injectBranchProbabilitiesForSelect();
 
-    LLVMContext getContext();
+    /**
+     * Substitute common C library functions by Java implementations. Note that some functions such
+     * as exit or abort are substituted in each case, to allow the VM to terminate gracefully.
+     */
+    boolean intrinsifyCLibraryFunctions();
 
-    LLVMAddress getGlobalAddress(GlobalVariable var);
+    /**
+     * Record branch probabilities for the LLVM <code>br</code> instruction.
+     */
+    boolean injectBranchProbabilitiesForConditionalBranch();
 
-    FrameSlot getStackPointerSlot();
-
-    LLVMOptimizationConfiguration getOptimizationConfiguration();
 }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMPropertyOptimizationConfiguration.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMPropertyOptimizationConfiguration.java
@@ -27,36 +27,31 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.oracle.truffle.llvm;
+package com.oracle.truffle.llvm.runtime;
 
-public final class LLVMOptimizations {
+/**
+ * Provides a optimization configuration based on Java properties.
+ */
+public class LLVMPropertyOptimizationConfiguration implements LLVMOptimizationConfiguration {
 
-    private LLVMOptimizations() {
+    public boolean specializeForExpectIntrinsic() {
+        return LLVMOptions.specializeForExpectIntrinsic();
     }
 
-    /**
-     * Speculation based on the <code>llvm.expect</code> intrinsic.
-     */
-    public static final boolean VALUE_SPECIALIZATION_EXPECT_INTRINSIC = true;
+    public boolean valueProfileMemoryReads() {
+        return LLVMOptions.valueProfileMemoryReads();
+    }
 
-    /**
-     * Speculates that memory reads always return the same result.
-     */
-    public static final boolean VALUE_PROFILING_MEMORY_READS = true;
+    public boolean injectBranchProbabilitiesForSelect() {
+        return LLVMOptions.injectBranchProbabilitiesForSelect();
+    }
 
-    /**
-     * Record branch probabilities for the LLVM <code>select</code> instruction.
-     */
-    public static final boolean BRANCH_INJECTION_SELECT_INSTRUCTION = true;
+    public boolean intrinsifyCLibraryFunctions() {
+        return LLVMOptions.intrinsifyCLibraryFunctions();
+    }
 
-    /**
-     * Record branch probabilities for the LLVM <code>br</code> instruction.
-     */
-    public static final boolean BRANCH_INJECTION_CONDITIONAL_BRANCH = true;
+    public boolean injectBranchProbabilitiesForConditionalBranch() {
+        return LLVMOptions.injectBranchProbabilitiesForConditionalBranch();
+    }
 
-    /**
-     * Substitute common C library functions by Java implementations. Note that some functions such
-     * as exit or abort are substituted in each case, to allow the VM to terminate gracefully.
-     */
-    public static final boolean INTRINSIFY_C_LIBRARY_FUNCTIONS = true;
 }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -56,6 +56,7 @@ import com.oracle.truffle.llvm.parser.LLVMVisitor;
 import com.oracle.truffle.llvm.parser.factories.NodeFactoryFacade;
 import com.oracle.truffle.llvm.parser.factories.NodeFactoryFacadeImpl;
 import com.oracle.truffle.llvm.runtime.LLVMOptions;
+import com.oracle.truffle.llvm.runtime.LLVMPropertyOptimizationConfiguration;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunction;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
@@ -66,6 +67,8 @@ import com.oracle.truffle.llvm.types.memory.LLVMMemory;
  * This is the main LLVM execution class.
  */
 public class LLVM {
+
+    static final LLVMPropertyOptimizationConfiguration OPTIMIZATION_CONFIGURATION = new LLVMPropertyOptimizationConfiguration();
 
     private static final int THREE_ARGS = 3;
 
@@ -116,7 +119,7 @@ public class LLVM {
             throw new IllegalStateException("empty file?");
         }
         Model model = (Model) contents.get(0);
-        LLVMVisitor llvmVisitor = new LLVMVisitor(context);
+        LLVMVisitor llvmVisitor = new LLVMVisitor(context, OPTIMIZATION_CONFIGURATION);
         NodeFactoryFacade facade = provider.getFacade(llvmVisitor);
         List<LLVMFunction> llvmFunctions = llvmVisitor.visit(model, facade);
         return llvmFunctions;

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMContext.java
@@ -44,6 +44,7 @@ import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.parser.factories.NodeFactoryFacade;
+import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.runtime.LLVMOptions;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
@@ -53,11 +54,18 @@ import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
 
 public class LLVMContext extends ExecutionContext {
 
-    private final LLVMFunctionRegistry registry = new LLVMFunctionRegistry();
+    private final LLVMFunctionRegistry registry;
+
+    private final NodeFactoryFacade facade;
 
     private LLVMNode[] staticInits;
 
     private LLVMAddress[] deallocations;
+
+    public LLVMContext(NodeFactoryFacade facade, LLVMOptimizationConfiguration optimizationConfig) {
+        this.facade = facade;
+        this.registry = new LLVMFunctionRegistry(optimizationConfig);
+    }
 
     public RootCallTarget getFunction(LLVMFunction function) {
         return LLVMFunctionRegistry.lookup(function);
@@ -134,12 +142,6 @@ public class LLVMContext extends ExecutionContext {
             types[i] = facade.getJavaClass(args[i]);
         }
         return types;
-    }
-
-    private final NodeFactoryFacade facade;
-
-    public LLVMContext(NodeFactoryFacade facade) {
-        this.facade = facade;
     }
 
     private static Class<?> getJavaClass(LLVMRuntimeType type) {

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMLanguage.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMLanguage.java
@@ -51,7 +51,7 @@ public final class LLVMLanguage extends TruffleLanguage<LLVMContext> {
 
     @Override
     protected LLVMContext createContext(com.oracle.truffle.api.TruffleLanguage.Env env) {
-        return new LLVMContext(LLVM.provider.getFacade(null));
+        return new LLVMContext(LLVM.provider.getFacade(null), LLVM.OPTIMIZATION_CONFIGURATION);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/parser/factories/LLVMMemoryReadWriteFactory.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/parser/factories/LLVMMemoryReadWriteFactory.java
@@ -30,7 +30,6 @@
 package com.oracle.truffle.llvm.parser.factories;
 
 import com.intel.llvm.ireditor.types.ResolvedType;
-import com.oracle.truffle.llvm.LLVMOptimizations;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMFunctionNode;
@@ -80,6 +79,7 @@ import com.oracle.truffle.llvm.nodes.memory.LLVMStoreNodeFactory.LLVMIVarBitStor
 import com.oracle.truffle.llvm.nodes.memory.LLVMStoreNodeFactory.LLVMStructStoreNodeGen;
 import com.oracle.truffle.llvm.nodes.memory.LLVMStoreVectorNodeGen;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
+import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
 
 public final class LLVMMemoryReadWriteFactory {
@@ -87,7 +87,7 @@ public final class LLVMMemoryReadWriteFactory {
     private LLVMMemoryReadWriteFactory() {
     }
 
-    public static LLVMExpressionNode createLoad(ResolvedType resolvedResultType, LLVMAddressNode loadTarget) throws AssertionError {
+    public static LLVMExpressionNode createLoad(ResolvedType resolvedResultType, LLVMAddressNode loadTarget, LLVMParserRuntime runtime) {
         LLVMBaseType resultType = LLVMTypeHelper.getLLVMType(resolvedResultType);
         switch (resultType) {
             case I1:
@@ -97,13 +97,13 @@ public final class LLVMMemoryReadWriteFactory {
             case I16:
                 return LLVMLoadI16NodeGen.create(loadTarget);
             case I32:
-                if (LLVMOptimizations.VALUE_PROFILING_MEMORY_READS) {
+                if (runtime.getOptimizationConfiguration().valueProfileMemoryReads()) {
                     return new LLVMUninitializedLoadI32Node(loadTarget);
                 } else {
                     return LLVMLoadI32NodeGen.create(loadTarget);
                 }
             case I64:
-                if (LLVMOptimizations.VALUE_PROFILING_MEMORY_READS) {
+                if (runtime.getOptimizationConfiguration().valueProfileMemoryReads()) {
                     return new LLVMUninitializedLoadI64Node(loadTarget);
                 } else {
                     return LLVMLoadI64NodeGen.create(loadTarget);

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/parser/factories/LLVMSelectFactory.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/parser/factories/LLVMSelectFactory.java
@@ -29,7 +29,6 @@
  */
 package com.oracle.truffle.llvm.parser.factories;
 
-import com.oracle.truffle.llvm.LLVMOptimizations;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMFunctionNode;
@@ -62,11 +61,12 @@ import com.oracle.truffle.llvm.nodes.others.LLVMSelectNodeFactory.LLVMI32SelectN
 import com.oracle.truffle.llvm.nodes.others.LLVMSelectNodeFactory.LLVMI64SelectNodeGen;
 import com.oracle.truffle.llvm.nodes.others.LLVMSelectNodeFactory.LLVMI8SelectNodeGen;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
+import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 
 public class LLVMSelectFactory {
 
-    public static LLVMExpressionNode createSelect(LLVMBaseType llvmType, LLVMI1Node condition, LLVMExpressionNode trueValue, LLVMExpressionNode falseValue) {
-        if (LLVMOptimizations.BRANCH_INJECTION_SELECT_INSTRUCTION) {
+    public static LLVMExpressionNode createSelect(LLVMBaseType llvmType, LLVMI1Node condition, LLVMExpressionNode trueValue, LLVMExpressionNode falseValue, LLVMParserRuntime runtime) {
+        if (runtime.getOptimizationConfiguration().injectBranchProbabilitiesForSelect()) {
             switch (llvmType) {
                 case I1:
                     return LLVMI1ProfilingSelectNodeGen.create(condition, (LLVMI1Node) trueValue, (LLVMI1Node) falseValue);

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -90,7 +90,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
 
     @Override
     public LLVMExpressionNode createLoad(ResolvedType resolvedResultType, LLVMAddressNode loadTarget) {
-        return LLVMMemoryReadWriteFactory.createLoad(resolvedResultType, loadTarget);
+        return LLVMMemoryReadWriteFactory.createLoad(resolvedResultType, loadTarget, runtime);
     }
 
     @Override
@@ -252,7 +252,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     public LLVMExpressionNode createSelect(LLVMBaseType llvmType, LLVMI1Node condition, LLVMExpressionNode trueValue, LLVMExpressionNode falseValue) {
-        return LLVMSelectFactory.createSelect(llvmType, condition, trueValue, falseValue);
+        return LLVMSelectFactory.createSelect(llvmType, condition, trueValue, falseValue, runtime);
     }
 
 }


### PR DESCRIPTION
This change lets a user set optimization flags over Java system properties. Whether an optimization is enabled is represented by a Configuration Object so that later on the Java system properties can be transparently replaced by a per Sulong instance option system.

I also started refactoring the option system, with more fixes to come.