### PR TITLE
value profiling for float, double, and remaining integer types

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadDoubleNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadDoubleNode.java
@@ -81,7 +81,7 @@ public abstract class LLVMLoadDoubleNode extends LLVMDoubleNode {
         @Override
         public double executeDouble(VirtualFrame frame) {
             double value = LLVMMemory.getDouble(addressNode.executePointee(frame));
-            if (value == profiledValue) {
+            if (Double.doubleToRawLongBits(value) == Double.doubleToRawLongBits(profiledValue)) {
                 return profiledValue;
             } else {
                 CompilerDirectives.transferToInterpreterAndInvalidate();

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadDoubleNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadDoubleNode.java
@@ -29,67 +29,65 @@
  */
 package com.oracle.truffle.llvm.nodes.memory.load;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
-import com.oracle.truffle.llvm.nodes.base.LLVMFunctionNode;
-import com.oracle.truffle.llvm.nodes.base.floating.LLVM80BitFloatNode;
-import com.oracle.truffle.llvm.nodes.base.integers.LLVMIVarBitNode;
+import com.oracle.truffle.llvm.nodes.base.floating.LLVMDoubleNode;
+import com.oracle.truffle.llvm.nodes.memory.load.LLVMLoadDoubleNodeFactory.LLVMLoadDirectDoubleNodeGen;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
-import com.oracle.truffle.llvm.types.LLVMIVarBit;
-import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
-import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 
-public abstract class LLVMLoadDirectNode {
+public abstract class LLVMLoadDoubleNode extends LLVMDoubleNode {
 
     @NodeChild(type = LLVMAddressNode.class)
-    @NodeField(name = "bitWidth", type = int.class)
-    public abstract static class LLVMLoadDirectIVarBitNode extends LLVMIVarBitNode {
-
-        public abstract int getBitWidth();
+    public abstract static class LLVMLoadDirectDoubleNode extends LLVMLoadDoubleNode {
 
         @Specialization
-        public LLVMIVarBit executeI64(LLVMAddress addr) {
-            return LLVMMemory.getIVarBit(addr, getBitWidth());
+        public double executeDouble(LLVMAddress addr) {
+            return LLVMMemory.getDouble(addr);
         }
     }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirect80BitFloatNode extends LLVM80BitFloatNode {
+    public static class LLVMUninitializedLoadDoubleNode extends LLVMLoadDoubleNode {
 
-        @Specialization
-        public LLVM80BitFloat executeDouble(LLVMAddress addr) {
-            return LLVMMemory.get80BitFloat(addr);
+        @Child private LLVMAddressNode addressNode;
+
+        public LLVMUninitializedLoadDoubleNode(LLVMAddressNode addressNode) {
+            this.addressNode = addressNode;
         }
+
+        @Override
+        public double executeDouble(VirtualFrame frame) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            double val = LLVMMemory.getDouble(addressNode.executePointee(frame));
+            replace(new LLVMLoadValueProfiledDoubleNode(addressNode, val));
+            return val;
+        }
+
     }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectFunctionNode extends LLVMFunctionNode {
+    public static class LLVMLoadValueProfiledDoubleNode extends LLVMLoadDoubleNode {
 
-        @Specialization
-        public LLVMFunction executeAddress(LLVMAddress addr) {
-            return LLVMHeap.getFunction(addr);
+        private final double profiledValue;
+        @Child private LLVMAddressNode addressNode;
+
+        public LLVMLoadValueProfiledDoubleNode(LLVMAddressNode addressNode, double profiledValue) {
+            this.addressNode = addressNode;
+            this.profiledValue = profiledValue;
         }
-    }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectAddressNode extends LLVMAddressNode {
-
-        @Specialization
-        public LLVMAddress executeAddress(LLVMAddress addr) {
-            return LLVMMemory.getAddress(addr);
-        }
-    }
-
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectStructNode extends LLVMAddressNode {
-
-        @Specialization
-        public LLVMAddress executeAddress(LLVMAddress addr) {
-            return addr; // we do not actually load the struct into a virtual register
+        @Override
+        public double executeDouble(VirtualFrame frame) {
+            double value = LLVMMemory.getDouble(addressNode.executePointee(frame));
+            if (value == profiledValue) {
+                return profiledValue;
+            } else {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                replace(LLVMLoadDirectDoubleNodeGen.create(addressNode));
+                return value;
+            }
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadFloatNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadFloatNode.java
@@ -81,7 +81,7 @@ public abstract class LLVMLoadFloatNode extends LLVMFloatNode {
         @Override
         public float executeFloat(VirtualFrame frame) {
             float value = LLVMMemory.getFloat(addressNode.executePointee(frame));
-            if (value == profiledValue) {
+            if (Float.floatToRawIntBits(value) == Float.floatToRawIntBits(profiledValue)) {
                 return profiledValue;
             } else {
                 CompilerDirectives.transferToInterpreterAndInvalidate();

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadFloatNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadFloatNode.java
@@ -29,67 +29,65 @@
  */
 package com.oracle.truffle.llvm.nodes.memory.load;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
-import com.oracle.truffle.llvm.nodes.base.LLVMFunctionNode;
-import com.oracle.truffle.llvm.nodes.base.floating.LLVM80BitFloatNode;
-import com.oracle.truffle.llvm.nodes.base.integers.LLVMIVarBitNode;
+import com.oracle.truffle.llvm.nodes.base.floating.LLVMFloatNode;
+import com.oracle.truffle.llvm.nodes.memory.load.LLVMLoadFloatNodeFactory.LLVMLoadDirectFloatNodeGen;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
-import com.oracle.truffle.llvm.types.LLVMIVarBit;
-import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
-import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 
-public abstract class LLVMLoadDirectNode {
+public abstract class LLVMLoadFloatNode extends LLVMFloatNode {
 
     @NodeChild(type = LLVMAddressNode.class)
-    @NodeField(name = "bitWidth", type = int.class)
-    public abstract static class LLVMLoadDirectIVarBitNode extends LLVMIVarBitNode {
-
-        public abstract int getBitWidth();
+    public abstract static class LLVMLoadDirectFloatNode extends LLVMLoadFloatNode {
 
         @Specialization
-        public LLVMIVarBit executeI64(LLVMAddress addr) {
-            return LLVMMemory.getIVarBit(addr, getBitWidth());
+        public float executeFloat(LLVMAddress addr) {
+            return LLVMMemory.getFloat(addr);
         }
     }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirect80BitFloatNode extends LLVM80BitFloatNode {
+    public static class LLVMUninitializedLoadFloatNode extends LLVMLoadFloatNode {
 
-        @Specialization
-        public LLVM80BitFloat executeDouble(LLVMAddress addr) {
-            return LLVMMemory.get80BitFloat(addr);
+        @Child private LLVMAddressNode addressNode;
+
+        public LLVMUninitializedLoadFloatNode(LLVMAddressNode addressNode) {
+            this.addressNode = addressNode;
         }
+
+        @Override
+        public float executeFloat(VirtualFrame frame) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            float val = LLVMMemory.getFloat(addressNode.executePointee(frame));
+            replace(new LLVMLoadValueProfiledFloatNode(addressNode, val));
+            return val;
+        }
+
     }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectFunctionNode extends LLVMFunctionNode {
+    public static class LLVMLoadValueProfiledFloatNode extends LLVMLoadFloatNode {
 
-        @Specialization
-        public LLVMFunction executeAddress(LLVMAddress addr) {
-            return LLVMHeap.getFunction(addr);
+        private final float profiledValue;
+        @Child private LLVMAddressNode addressNode;
+
+        public LLVMLoadValueProfiledFloatNode(LLVMAddressNode addressNode, float profiledValue) {
+            this.addressNode = addressNode;
+            this.profiledValue = profiledValue;
         }
-    }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectAddressNode extends LLVMAddressNode {
-
-        @Specialization
-        public LLVMAddress executeAddress(LLVMAddress addr) {
-            return LLVMMemory.getAddress(addr);
-        }
-    }
-
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectStructNode extends LLVMAddressNode {
-
-        @Specialization
-        public LLVMAddress executeAddress(LLVMAddress addr) {
-            return addr; // we do not actually load the struct into a virtual register
+        @Override
+        public float executeFloat(VirtualFrame frame) {
+            float value = LLVMMemory.getFloat(addressNode.executePointee(frame));
+            if (value == profiledValue) {
+                return profiledValue;
+            } else {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                replace(LLVMLoadDirectFloatNodeGen.create(addressNode));
+                return value;
+            }
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadI1Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadI1Node.java
@@ -29,68 +29,68 @@
  */
 package com.oracle.truffle.llvm.nodes.memory.load;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
-import com.oracle.truffle.llvm.nodes.base.LLVMFunctionNode;
-import com.oracle.truffle.llvm.nodes.base.floating.LLVM80BitFloatNode;
-import com.oracle.truffle.llvm.nodes.base.integers.LLVMIVarBitNode;
+import com.oracle.truffle.llvm.nodes.base.integers.LLVMI1Node;
+import com.oracle.truffle.llvm.nodes.memory.load.LLVMLoadI1NodeFactory.LLVMLoadDirectI1NodeGen;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
-import com.oracle.truffle.llvm.types.LLVMIVarBit;
-import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
-import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 
-public abstract class LLVMLoadDirectNode {
+public abstract class LLVMLoadI1Node extends LLVMI1Node {
 
     @NodeChild(type = LLVMAddressNode.class)
-    @NodeField(name = "bitWidth", type = int.class)
-    public abstract static class LLVMLoadDirectIVarBitNode extends LLVMIVarBitNode {
-
-        public abstract int getBitWidth();
+    public abstract static class LLVMLoadDirectI1Node extends LLVMLoadI1Node {
 
         @Specialization
-        public LLVMIVarBit executeI64(LLVMAddress addr) {
-            return LLVMMemory.getIVarBit(addr, getBitWidth());
+        public boolean executeI1(LLVMAddress addr) {
+            return LLVMMemory.getI1(addr);
         }
+
     }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirect80BitFloatNode extends LLVM80BitFloatNode {
+    public static class LLVMUninitializedLoadI1Node extends LLVMLoadI1Node {
 
-        @Specialization
-        public LLVM80BitFloat executeDouble(LLVMAddress addr) {
-            return LLVMMemory.get80BitFloat(addr);
+        @Child private LLVMAddressNode addressNode;
+
+        public LLVMUninitializedLoadI1Node(LLVMAddressNode addressNode) {
+            this.addressNode = addressNode;
         }
+
+        @Override
+        public boolean executeI1(VirtualFrame frame) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            boolean val = LLVMMemory.getI1(addressNode.executePointee(frame));
+            replace(new LLVMLoadValueProfiledI1Node(addressNode, val));
+            return val;
+        }
+
     }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectFunctionNode extends LLVMFunctionNode {
+    public static class LLVMLoadValueProfiledI1Node extends LLVMLoadI1Node {
 
-        @Specialization
-        public LLVMFunction executeAddress(LLVMAddress addr) {
-            return LLVMHeap.getFunction(addr);
+        private final boolean profiledValue;
+        @Child private LLVMAddressNode addressNode;
+
+        public LLVMLoadValueProfiledI1Node(LLVMAddressNode addressNode, boolean profiledValue) {
+            this.addressNode = addressNode;
+            this.profiledValue = profiledValue;
         }
-    }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectAddressNode extends LLVMAddressNode {
-
-        @Specialization
-        public LLVMAddress executeAddress(LLVMAddress addr) {
-            return LLVMMemory.getAddress(addr);
+        @Override
+        public boolean executeI1(VirtualFrame frame) {
+            boolean value = LLVMMemory.getI1(addressNode.executePointee(frame));
+            if (value == profiledValue) {
+                return profiledValue;
+            } else {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                replace(LLVMLoadDirectI1NodeGen.create(addressNode));
+                return value;
+            }
         }
-    }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectStructNode extends LLVMAddressNode {
-
-        @Specialization
-        public LLVMAddress executeAddress(LLVMAddress addr) {
-            return addr; // we do not actually load the struct into a virtual register
-        }
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadI32Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadI32Node.java
@@ -29,68 +29,68 @@
  */
 package com.oracle.truffle.llvm.nodes.memory.load;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
-import com.oracle.truffle.llvm.nodes.base.LLVMFunctionNode;
-import com.oracle.truffle.llvm.nodes.base.floating.LLVM80BitFloatNode;
-import com.oracle.truffle.llvm.nodes.base.integers.LLVMIVarBitNode;
+import com.oracle.truffle.llvm.nodes.base.integers.LLVMI32Node;
+import com.oracle.truffle.llvm.nodes.memory.load.LLVMLoadI32NodeFactory.LLVMLoadDirectI32NodeGen;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
-import com.oracle.truffle.llvm.types.LLVMIVarBit;
-import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
-import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 
-public abstract class LLVMLoadDirectNode {
+public abstract class LLVMLoadI32Node extends LLVMI32Node {
 
     @NodeChild(type = LLVMAddressNode.class)
-    @NodeField(name = "bitWidth", type = int.class)
-    public abstract static class LLVMLoadDirectIVarBitNode extends LLVMIVarBitNode {
-
-        public abstract int getBitWidth();
+    public abstract static class LLVMLoadDirectI32Node extends LLVMLoadI32Node {
 
         @Specialization
-        public LLVMIVarBit executeI64(LLVMAddress addr) {
-            return LLVMMemory.getIVarBit(addr, getBitWidth());
+        public int executeI32(LLVMAddress addr) {
+            return LLVMMemory.getI32(addr);
         }
+
     }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirect80BitFloatNode extends LLVM80BitFloatNode {
+    public static class LLVMUninitializedLoadI32Node extends LLVMLoadI32Node {
 
-        @Specialization
-        public LLVM80BitFloat executeDouble(LLVMAddress addr) {
-            return LLVMMemory.get80BitFloat(addr);
+        @Child private LLVMAddressNode addressNode;
+
+        public LLVMUninitializedLoadI32Node(LLVMAddressNode addressNode) {
+            this.addressNode = addressNode;
         }
+
+        @Override
+        public int executeI32(VirtualFrame frame) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            int val = LLVMMemory.getI32(addressNode.executePointee(frame));
+            replace(new LLVMLoadValueProfiledI32Node(addressNode, val));
+            return val;
+        }
+
     }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectFunctionNode extends LLVMFunctionNode {
+    public static class LLVMLoadValueProfiledI32Node extends LLVMLoadI32Node {
 
-        @Specialization
-        public LLVMFunction executeAddress(LLVMAddress addr) {
-            return LLVMHeap.getFunction(addr);
+        private final int profiledValue;
+        @Child private LLVMAddressNode addressNode;
+
+        public LLVMLoadValueProfiledI32Node(LLVMAddressNode addressNode, int profiledValue) {
+            this.addressNode = addressNode;
+            this.profiledValue = profiledValue;
         }
-    }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectAddressNode extends LLVMAddressNode {
-
-        @Specialization
-        public LLVMAddress executeAddress(LLVMAddress addr) {
-            return LLVMMemory.getAddress(addr);
+        @Override
+        public int executeI32(VirtualFrame frame) {
+            int value = LLVMMemory.getI32(addressNode.executePointee(frame));
+            if (value == profiledValue) {
+                return profiledValue;
+            } else {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                replace(LLVMLoadDirectI32NodeGen.create(addressNode));
+                return value;
+            }
         }
-    }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectStructNode extends LLVMAddressNode {
-
-        @Specialization
-        public LLVMAddress executeAddress(LLVMAddress addr) {
-            return addr; // we do not actually load the struct into a virtual register
-        }
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadI64Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadI64Node.java
@@ -29,68 +29,65 @@
  */
 package com.oracle.truffle.llvm.nodes.memory.load;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
-import com.oracle.truffle.llvm.nodes.base.LLVMFunctionNode;
-import com.oracle.truffle.llvm.nodes.base.floating.LLVM80BitFloatNode;
-import com.oracle.truffle.llvm.nodes.base.integers.LLVMIVarBitNode;
+import com.oracle.truffle.llvm.nodes.base.integers.LLVMI64Node;
+import com.oracle.truffle.llvm.nodes.memory.load.LLVMLoadI64NodeFactory.LLVMLoadDirectI64NodeGen;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
-import com.oracle.truffle.llvm.types.LLVMIVarBit;
-import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
-import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 
-public abstract class LLVMLoadDirectNode {
+public abstract class LLVMLoadI64Node extends LLVMI64Node {
 
     @NodeChild(type = LLVMAddressNode.class)
-    @NodeField(name = "bitWidth", type = int.class)
-    public abstract static class LLVMLoadDirectIVarBitNode extends LLVMIVarBitNode {
-
-        public abstract int getBitWidth();
+    public abstract static class LLVMLoadDirectI64Node extends LLVMLoadI64Node {
 
         @Specialization
-        public LLVMIVarBit executeI64(LLVMAddress addr) {
-            return LLVMMemory.getIVarBit(addr, getBitWidth());
+        public long executeI64(LLVMAddress addr) {
+            return LLVMMemory.getI64(addr);
         }
     }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirect80BitFloatNode extends LLVM80BitFloatNode {
+    public static class LLVMUninitializedLoadI64Node extends LLVMLoadI64Node {
 
-        @Specialization
-        public LLVM80BitFloat executeDouble(LLVMAddress addr) {
-            return LLVMMemory.get80BitFloat(addr);
+        @Child private LLVMAddressNode addressNode;
+
+        public LLVMUninitializedLoadI64Node(LLVMAddressNode addressNode) {
+            this.addressNode = addressNode;
         }
+
+        @Override
+        public long executeI64(VirtualFrame frame) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            long val = LLVMMemory.getI64(addressNode.executePointee(frame));
+            replace(new LLVMLoadValueProfiledI64Node(addressNode, val));
+            return val;
+        }
+
     }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectFunctionNode extends LLVMFunctionNode {
+    public static class LLVMLoadValueProfiledI64Node extends LLVMLoadI64Node {
 
-        @Specialization
-        public LLVMFunction executeAddress(LLVMAddress addr) {
-            return LLVMHeap.getFunction(addr);
+        private final long profiledValue;
+        @Child private LLVMAddressNode addressNode;
+
+        public LLVMLoadValueProfiledI64Node(LLVMAddressNode addressNode, long profiledValue) {
+            this.addressNode = addressNode;
+            this.profiledValue = profiledValue;
+        }
+
+        @Override
+        public long executeI64(VirtualFrame frame) {
+            long value = LLVMMemory.getI64(addressNode.executePointee(frame));
+            if (value == profiledValue) {
+                return profiledValue;
+            } else {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                replace(LLVMLoadDirectI64NodeGen.create(addressNode));
+                return value;
+            }
         }
     }
-
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectAddressNode extends LLVMAddressNode {
-
-        @Specialization
-        public LLVMAddress executeAddress(LLVMAddress addr) {
-            return LLVMMemory.getAddress(addr);
-        }
-    }
-
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectStructNode extends LLVMAddressNode {
-
-        @Specialization
-        public LLVMAddress executeAddress(LLVMAddress addr) {
-            return addr; // we do not actually load the struct into a virtual register
-        }
-    }
-
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadI8Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/load/LLVMLoadI8Node.java
@@ -29,68 +29,68 @@
  */
 package com.oracle.truffle.llvm.nodes.memory.load;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
-import com.oracle.truffle.llvm.nodes.base.LLVMFunctionNode;
-import com.oracle.truffle.llvm.nodes.base.floating.LLVM80BitFloatNode;
-import com.oracle.truffle.llvm.nodes.base.integers.LLVMIVarBitNode;
+import com.oracle.truffle.llvm.nodes.base.integers.LLVMI8Node;
+import com.oracle.truffle.llvm.nodes.memory.load.LLVMLoadI8NodeFactory.LLVMLoadDirectI8NodeGen;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
-import com.oracle.truffle.llvm.types.LLVMIVarBit;
-import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
-import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 
-public abstract class LLVMLoadDirectNode {
+public abstract class LLVMLoadI8Node extends LLVMI8Node {
 
     @NodeChild(type = LLVMAddressNode.class)
-    @NodeField(name = "bitWidth", type = int.class)
-    public abstract static class LLVMLoadDirectIVarBitNode extends LLVMIVarBitNode {
-
-        public abstract int getBitWidth();
+    public abstract static class LLVMLoadDirectI8Node extends LLVMLoadI8Node {
 
         @Specialization
-        public LLVMIVarBit executeI64(LLVMAddress addr) {
-            return LLVMMemory.getIVarBit(addr, getBitWidth());
+        public byte executeI8(LLVMAddress addr) {
+            return LLVMMemory.getI8(addr);
         }
+
     }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirect80BitFloatNode extends LLVM80BitFloatNode {
+    public static class LLVMUninitializedLoadI8Node extends LLVMLoadI8Node {
 
-        @Specialization
-        public LLVM80BitFloat executeDouble(LLVMAddress addr) {
-            return LLVMMemory.get80BitFloat(addr);
+        @Child private LLVMAddressNode addressNode;
+
+        public LLVMUninitializedLoadI8Node(LLVMAddressNode addressNode) {
+            this.addressNode = addressNode;
         }
+
+        @Override
+        public byte executeI8(VirtualFrame frame) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            byte val = LLVMMemory.getI8(addressNode.executePointee(frame));
+            replace(new LLVMLoadValueProfiledI8Node(addressNode, val));
+            return val;
+        }
+
     }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectFunctionNode extends LLVMFunctionNode {
+    public static class LLVMLoadValueProfiledI8Node extends LLVMLoadI8Node {
 
-        @Specialization
-        public LLVMFunction executeAddress(LLVMAddress addr) {
-            return LLVMHeap.getFunction(addr);
+        private final byte profiledValue;
+        @Child private LLVMAddressNode addressNode;
+
+        public LLVMLoadValueProfiledI8Node(LLVMAddressNode addressNode, byte profiledValue) {
+            this.addressNode = addressNode;
+            this.profiledValue = profiledValue;
         }
-    }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectAddressNode extends LLVMAddressNode {
-
-        @Specialization
-        public LLVMAddress executeAddress(LLVMAddress addr) {
-            return LLVMMemory.getAddress(addr);
+        @Override
+        public byte executeI8(VirtualFrame frame) {
+            byte value = LLVMMemory.getI8(addressNode.executePointee(frame));
+            if (value == profiledValue) {
+                return profiledValue;
+            } else {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                replace(LLVMLoadDirectI8NodeGen.create(addressNode));
+                return value;
+            }
         }
-    }
 
-    @NodeChild(type = LLVMAddressNode.class)
-    public abstract static class LLVMLoadDirectStructNode extends LLVMAddressNode {
-
-        @Specialization
-        public LLVMAddress executeAddress(LLVMAddress addr) {
-            return addr; // we do not actually load the struct into a virtual register
-        }
     }
 
 }


### PR DESCRIPTION
Previously, value profiling for memory loads has only been performed for I32 and I64 types. This changes adds value profiling for float, double, and the remaining integer types. There are still other loads which are not profiled because it is unclear if there is a benefit (e.g., for pointers).