### PR TITLE
intrinsify some of the C math.h functions

### DIFF
--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
@@ -51,6 +51,12 @@ public class LLVMHeap extends LLVMMemory {
         return LLVMAddress.fromLong(allocateMemory);
     }
 
+    public static LLVMAddress allocateZeroedMemory(long l) {
+        long allocateMemory = UNSAFE.allocateMemory(l);
+        UNSAFE.setMemory(allocateMemory, l, (byte) 0);
+        return LLVMAddress.fromLong(allocateMemory);
+    }
+
     public static void freeMemory(LLVMAddress addr) {
         UNSAFE.freeMemory(extractAddrNullPointerAllowed(addr));
     }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMFunctionRegistry.java
@@ -47,10 +47,20 @@ import com.oracle.truffle.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicFloatNo
 import com.oracle.truffle.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI32NodeGen;
 import com.oracle.truffle.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI64NodeGen;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMAbortFactory;
+import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMACosFactory;
+import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMASinFactory;
+import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMATanFactory;
+import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMCosFactory;
+import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMExpFactory;
+import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMLogFactory;
+import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMSinFactory;
+import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMSqrtFactory;
+import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMTanFactory;
+import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMTanhFactory;
+import com.oracle.truffle.llvm.intrinsics.c.LLVMCallocFactory;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMExitFactory;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMFreeFactory;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMMallocFactory;
-import com.oracle.truffle.llvm.intrinsics.c.LLVMSqrtFactory;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.base.floating.LLVMDoubleNode;
@@ -81,9 +91,22 @@ public class LLVMFunctionRegistry {
         intrinsics.put("@exit", LLVMExitFactory.getInstance());
 
         if (optimizationConfig.intrinsifyCLibraryFunctions()) {
+            // math.h
+            intrinsics.put("@acos", LLVMACosFactory.getInstance());
+            intrinsics.put("@asin", LLVMASinFactory.getInstance());
+            intrinsics.put("@atan", LLVMATanFactory.getInstance());
+            intrinsics.put("@cos", LLVMCosFactory.getInstance());
+            intrinsics.put("@exp", LLVMExpFactory.getInstance());
+            intrinsics.put("@log", LLVMLogFactory.getInstance());
             intrinsics.put("@sqrt", LLVMSqrtFactory.getInstance());
+            intrinsics.put("@sin", LLVMSinFactory.getInstance());
+            intrinsics.put("@tan", LLVMTanFactory.getInstance());
+            intrinsics.put("@tanh", LLVMTanhFactory.getInstance());
+
+            // other libraries
             intrinsics.put("@malloc", LLVMMallocFactory.getInstance());
             intrinsics.put("@free", LLVMFreeFactory.getInstance());
+            intrinsics.put("@calloc", LLVMCallocFactory.getInstance());
         }
     }
 

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/intrinsics/c/LLVMCMathsIntrinsics.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/intrinsics/c/LLVMCMathsIntrinsics.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.intrinsics.c;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.LLVMIntrinsic.LLVMDoubleIntrinsic;
+import com.oracle.truffle.llvm.nodes.base.floating.LLVMDoubleNode;
+
+/**
+ * C functions from math.h
+ */
+public abstract class LLVMCMathsIntrinsics {
+
+    // acos
+    @NodeChild(type = LLVMDoubleNode.class)
+    public abstract static class LLVMACos extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double value) {
+            return Math.acos(value);
+        }
+    }
+
+    // asin
+    @NodeChild(type = LLVMDoubleNode.class)
+    public abstract static class LLVMASin extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double value) {
+            return Math.asin(value);
+        }
+    }
+
+    // atan
+    @NodeChild(type = LLVMDoubleNode.class)
+    public abstract static class LLVMATan extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double value) {
+            return Math.atan(value);
+        }
+    }
+
+    // cos
+    @NodeChild(type = LLVMDoubleNode.class)
+    public abstract static class LLVMCos extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double value) {
+            return Math.cos(value);
+        }
+
+    }
+
+    // exp
+    @NodeChild(type = LLVMDoubleNode.class)
+    public abstract static class LLVMExp extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double value) {
+            return Math.exp(value);
+        }
+    }
+
+    // log
+    @NodeChild(type = LLVMDoubleNode.class)
+    public abstract static class LLVMLog extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double value) {
+            return Math.log(value);
+        }
+    }
+
+    // sqrt
+    @NodeChild(type = LLVMDoubleNode.class)
+    public abstract static class LLVMSqrt extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double value) {
+            return Math.sqrt(value);
+        }
+
+    }
+
+    // sin
+    @NodeChild(type = LLVMDoubleNode.class)
+    public abstract static class LLVMSin extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double value) {
+            return Math.sin(value);
+        }
+
+    }
+
+    // tan
+    @NodeChild(type = LLVMDoubleNode.class)
+    public abstract static class LLVMTan extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double value) {
+            return Math.tan(value);
+        }
+
+    }
+
+    // tanh
+    @NodeChild(type = LLVMDoubleNode.class)
+    public abstract static class LLVMTanh extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double value) {
+            return Math.tanh(value);
+        }
+
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/intrinsics/c/LLVMCMathsIntrinsics.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/intrinsics/c/LLVMCMathsIntrinsics.java
@@ -35,7 +35,7 @@ import com.oracle.truffle.llvm.LLVMIntrinsic.LLVMDoubleIntrinsic;
 import com.oracle.truffle.llvm.nodes.base.floating.LLVMDoubleNode;
 
 /**
- * C functions from math.h
+ * Implements the C functions from math.h.
  */
 public abstract class LLVMCMathsIntrinsics {
 

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/intrinsics/c/LLVMCMathsIntrinsics.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/intrinsics/c/LLVMCMathsIntrinsics.java
@@ -39,7 +39,6 @@ import com.oracle.truffle.llvm.nodes.base.floating.LLVMDoubleNode;
  */
 public abstract class LLVMCMathsIntrinsics {
 
-    // acos
     @NodeChild(type = LLVMDoubleNode.class)
     public abstract static class LLVMACos extends LLVMDoubleIntrinsic {
 
@@ -49,7 +48,6 @@ public abstract class LLVMCMathsIntrinsics {
         }
     }
 
-    // asin
     @NodeChild(type = LLVMDoubleNode.class)
     public abstract static class LLVMASin extends LLVMDoubleIntrinsic {
 
@@ -59,7 +57,6 @@ public abstract class LLVMCMathsIntrinsics {
         }
     }
 
-    // atan
     @NodeChild(type = LLVMDoubleNode.class)
     public abstract static class LLVMATan extends LLVMDoubleIntrinsic {
 
@@ -69,7 +66,6 @@ public abstract class LLVMCMathsIntrinsics {
         }
     }
 
-    // cos
     @NodeChild(type = LLVMDoubleNode.class)
     public abstract static class LLVMCos extends LLVMDoubleIntrinsic {
 
@@ -80,7 +76,6 @@ public abstract class LLVMCMathsIntrinsics {
 
     }
 
-    // exp
     @NodeChild(type = LLVMDoubleNode.class)
     public abstract static class LLVMExp extends LLVMDoubleIntrinsic {
 
@@ -90,7 +85,6 @@ public abstract class LLVMCMathsIntrinsics {
         }
     }
 
-    // log
     @NodeChild(type = LLVMDoubleNode.class)
     public abstract static class LLVMLog extends LLVMDoubleIntrinsic {
 
@@ -100,7 +94,6 @@ public abstract class LLVMCMathsIntrinsics {
         }
     }
 
-    // sqrt
     @NodeChild(type = LLVMDoubleNode.class)
     public abstract static class LLVMSqrt extends LLVMDoubleIntrinsic {
 
@@ -111,7 +104,6 @@ public abstract class LLVMCMathsIntrinsics {
 
     }
 
-    // sin
     @NodeChild(type = LLVMDoubleNode.class)
     public abstract static class LLVMSin extends LLVMDoubleIntrinsic {
 
@@ -122,7 +114,6 @@ public abstract class LLVMCMathsIntrinsics {
 
     }
 
-    // tan
     @NodeChild(type = LLVMDoubleNode.class)
     public abstract static class LLVMTan extends LLVMDoubleIntrinsic {
 
@@ -133,7 +124,6 @@ public abstract class LLVMCMathsIntrinsics {
 
     }
 
-    // tanh
     @NodeChild(type = LLVMDoubleNode.class)
     public abstract static class LLVMTanh extends LLVMDoubleIntrinsic {
 

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/intrinsics/c/LLVMCalloc.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/intrinsics/c/LLVMCalloc.java
@@ -30,16 +30,19 @@
 package com.oracle.truffle.llvm.intrinsics.c;
 
 import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.llvm.LLVMIntrinsic.LLVMDoubleIntrinsic;
-import com.oracle.truffle.llvm.nodes.base.floating.LLVMDoubleNode;
+import com.oracle.truffle.llvm.LLVMIntrinsic.LLVMAddressIntrinsic;
+import com.oracle.truffle.llvm.nodes.base.integers.LLVMI64Node;
+import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 
-@NodeChild(type = LLVMDoubleNode.class)
-public abstract class LLVMSqrt extends LLVMDoubleIntrinsic {
+@NodeChildren({@NodeChild(type = LLVMI64Node.class), @NodeChild(type = LLVMI64Node.class)})
+public abstract class LLVMCalloc extends LLVMAddressIntrinsic {
 
     @Specialization
-    public double executeIntrinsic(double value) {
-        return Math.sqrt(value);
+    public LLVMAddress executeIntrinsic(long numberItems, long size) {
+        return LLVMHeap.allocateZeroedMemory(numberItems * size);
     }
 
 }


### PR DESCRIPTION
This change intrinsifies some of the C maths functions to improve performance on benchmarks such as whetstone. I am not sure whether the semantics of the Java Math methods are exactly the same as the C functions. The calls to Math delegate to StrictMath. The methods are then implemented on the native side. The StrictMath documentation states:

> The Java math library is defined with respect to fdlibm version 5.3. Where fdlibm provides more than one definition for a function (such as acos), use the "IEEE 754 core function" version (residing in a file whose name begins with the letter e). The methods which require fdlibm semantics are sin, cos, tan, asin, acos, atan, exp, log, log10, cbrt, atan2, pow, sinh, cosh, tanh, hypot, expm1, and log1p. 

For now, all test cases still pass. I would suggest to let the functions intrinsified as long as we do not run into problems. If we run into problems, we can easily determine whether they stem from the intrinsics by turning them off.