### PR TITLE
fix linking of extern global variables

### DIFF
--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMContext.java
@@ -101,10 +101,16 @@ public class LLVMContext extends ExecutionContext {
             HotSpotNativeFunctionPointer result = (HotSpotNativeFunctionPointer) method.invoke(face, name, new HotSpotNativeLibraryHandle("", 0), false);
             return result.getRawValue();
         } catch (Exception e) {
-            throw new AssertionError(e);
+            return 0;
         }
     }
 
+    /**
+     * Looks the symbol address up. Returns 0 if no address is found.
+     *
+     * @param name the name of the symbol to look up.
+     * @return the address or 0, if the symbol is not found
+     */
     public long getNativeHandle(String name) {
         return lookupSymbol(name.substring(1));
     }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/parser/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/parser/LLVMVisitor.java
@@ -1068,13 +1068,15 @@ public class LLVMVisitor implements LLVMParserRuntime {
             } else if (constant.getRef() instanceof GlobalVariable) {
                 GlobalVariable globalVariable = (GlobalVariable) constant.getRef();
                 String globalVarName = globalVariable.getName();
-                if (globalVarName.equals("@stdout") || globalVarName.equals("@stdin") || globalVarName.equals("@stderr")) {
+                String linkage = globalVariable.getLinkage();
+                if ("external".equals(linkage)) {
                     long getNativeSymbol = getContext().getNativeHandle(globalVarName);
                     return new LLVMAddressLiteralNode(LLVMAddress.fromLong(getNativeSymbol));
+                } else {
+                    LLVMAddress findOrAllocateGlobal = findOrAllocateGlobal(globalVariable);
+                    assert findOrAllocateGlobal != null;
+                    return new LLVMAddressLiteralNode(findOrAllocateGlobal);
                 }
-                LLVMAddress findOrAllocateGlobal = findOrAllocateGlobal(globalVariable);
-                assert findOrAllocateGlobal != null;
-                return new LLVMAddressLiteralNode(findOrAllocateGlobal);
             } else if (constant instanceof ZeroInitializer) {
                 return visitZeroInitializer(type);
             } else if (constant instanceof ConstantExpression_convert) {


### PR DESCRIPTION
Before, linking of extern variables only worked for the C stdout, stdin, and stderr. This change implements linking for all external global variables. If an external variable cannot be linked, no exception should be thrown. This is also the behavior implemented in lli.

The change passed all Sulong test cases.