### PR TITLE
option for printing function names and number of native call sites

### DIFF
--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -89,7 +89,8 @@ public class LLVMOptions {
         OPTIMIZATION_VALUE_PROFILE_MEMORY_READS("llvm-opt-valueprofiling", "Enable value profiling for memory reads", "true", LLVMOptions::parseBoolean),
         OPTIMIZATION_INJECT_PROBS_SELECT("llvm-opt-select", "Inject branch probabilities for select", "true", LLVMOptions::parseBoolean),
         OPTIMIZATION_INTRINSIFY_C_FUNCTIONS("llvm-opt-cintrinsics", "Substitute C functions by Java equivalents where possible", "true", LLVMOptions::parseBoolean),
-        OPTIMIZATION_INJECT_PROBS_COND_BRANCH("llvm-opt-br", "Inject branch probabilities for conditional branches", "true", LLVMOptions::parseBoolean);
+        OPTIMIZATION_INJECT_PROBS_COND_BRANCH("llvm-opt-br", "Inject branch probabilities for conditional branches", "true", LLVMOptions::parseBoolean),
+        NATIVE_CALL_STATS("llvm-native-call-stats", "Outputs stats about native call site frequencies", "false", LLVMOptions::parseBoolean);
 
         Property(String key, String description, String defaultValue, OptionParser parser) {
             this.key = key;
@@ -206,6 +207,10 @@ public class LLVMOptions {
 
     public static boolean injectBranchProbabilitiesForConditionalBranch() {
         return getParsedProperty(Property.OPTIMIZATION_INJECT_PROBS_COND_BRANCH);
+    }
+
+    public static boolean isNativeCallStats() {
+        return getParsedProperty(Property.NATIVE_CALL_STATS);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunction.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunction.java
@@ -37,7 +37,7 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.interop.ForeignAccess;
 import com.oracle.truffle.api.interop.TruffleObject;
 
-public final class LLVMFunction implements TruffleObject {
+public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunction> {
 
     public static final int FRAME_START_INDEX = 2;
 
@@ -181,6 +181,10 @@ public final class LLVMFunction implements TruffleObject {
 
     public static int getNumberRegisteredFunctions() {
         return functionCounter;
+    }
+
+    public int compareTo(LLVMFunction o) {
+        return getName().compareTo(o.getName());
     }
 
 }


### PR DESCRIPTION
This change allows the user to print native call sites, e.g., for performance debugging.

This an example of the output:

```
==========================
native function sites:
==========================
  @gettimeofday:   2
        @printf:   4
          @puts:   2
        @strlen:   1
==========================
```
