### PR TITLE
basic C++ support

### DIFF
--- a/projects/com.oracle.truffle.llvm.test/suites-configs/llvm/SingleSource/UnitTests/working.include
+++ b/projects/com.oracle.truffle.llvm.test/suites-configs/llvm/SingleSource/UnitTests/working.include
@@ -85,7 +85,6 @@ test-suite-3.2.src/SingleSource/UnitTests/Integer/structInit.c
 test-suite-3.2.src/SingleSource/UnitTests/Integer/local-array.c
 test-suite-3.2.src/SingleSource/UnitTests/Integer/cppfield.cpp
 test-suite-3.2.src/SingleSource/UnitTests/Integer/union-init.c
-test-suite-3.2.src/SingleSource/UnitTests/ObjC/bitfield-access.m
 test-suite-3.2.src/SingleSource/Regression/C/sumarraymalloc.c
 test-suite-3.2.src/SingleSource/UnitTests/2006-12-04-DynAllocAndRestore.cpp
 test-suite-3.2.src/SingleSource/UnitTests/2006-01-23-UnionInit.c

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMFunctionRegistry.java
@@ -58,10 +58,12 @@ import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMSqrt
 import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMTanFactory;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMTanhFactory;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMCallocFactory;
+import com.oracle.truffle.llvm.intrinsics.c.LLVMCxaExitFactory;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMExitFactory;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMFreeFactory;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMMallocFactory;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.base.LLVMFunctionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.base.floating.LLVMDoubleNode;
 import com.oracle.truffle.llvm.nodes.base.floating.LLVMFloatNode;
@@ -89,6 +91,9 @@ public class LLVMFunctionRegistry {
         // C
         intrinsics.put("@abort", LLVMAbortFactory.getInstance());
         intrinsics.put("@exit", LLVMExitFactory.getInstance());
+
+        // C++
+        intrinsics.put("@__cxa_atexit", LLVMCxaExitFactory.getInstance());
 
         if (optimizationConfig.intrinsifyCLibraryFunctions()) {
             // math.h
@@ -165,6 +170,8 @@ public class LLVMFunctionRegistry {
             argNode = LLVMArgNodeFactory.LLVMDoubleArgNodeGen.create(i);
         } else if (clazz.equals(LLVMAddressNode.class)) {
             argNode = LLVMArgNodeFactory.LLVMAddressArgNodeGen.create(i);
+        } else if (clazz.equals(LLVMFunctionNode.class)) {
+            argNode = LLVMArgNodeFactory.LLVMFunctionArgNodeGen.create(i);
         } else {
             throw new AssertionError(clazz);
         }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMIntrinsic.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMIntrinsic.java
@@ -33,6 +33,7 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.base.floating.LLVMDoubleNode;
+import com.oracle.truffle.llvm.nodes.base.integers.LLVMI32Node;
 
 public interface LLVMIntrinsic {
 
@@ -48,6 +49,11 @@ public interface LLVMIntrinsic {
 
     @GenerateNodeFactory
     abstract class LLVMVoidIntrinsic extends LLVMNode implements LLVMIntrinsic {
+
+    }
+
+    @GenerateNodeFactory
+    abstract class LLVMI32Intrinsic extends LLVMI32Node implements LLVMIntrinsic {
 
     }
 

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMNativeCallConvertNode.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMNativeCallConvertNode.java
@@ -46,8 +46,8 @@ public abstract class LLVMNativeCallConvertNode {
     // FIXME: do not use inheritance
     public static class LLVMResolvedNativeAddressCallNode extends LLVMResolvedDirectNativeCallNode {
 
-        public LLVMResolvedNativeAddressCallNode(LLVMFunction function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args) {
-            super(function, nativeFunctionHandle, args);
+        public LLVMResolvedNativeAddressCallNode(LLVMFunction function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args, LLVMContext context) {
+            super(function, nativeFunctionHandle, args, context);
             assert function.getLlvmReturnType() == LLVMRuntimeType.ADDRESS;
         }
 
@@ -60,8 +60,8 @@ public abstract class LLVMNativeCallConvertNode {
 
     public static class LLVMResolvedNative80BitFloatCallNode extends LLVMResolvedDirectNativeCallNode {
 
-        public LLVMResolvedNative80BitFloatCallNode(LLVMFunction function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args) {
-            super(function, nativeFunctionHandle, args);
+        public LLVMResolvedNative80BitFloatCallNode(LLVMFunction function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args, LLVMContext context) {
+            super(function, nativeFunctionHandle, args, context);
             assert function.getLlvmReturnType() == LLVMRuntimeType.X86_FP80;
         }
 

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/intrinsics/c/LLVMCxaExit.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/intrinsics/c/LLVMCxaExit.java
@@ -27,46 +27,26 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.oracle.truffle.llvm.parser.factories;
+package com.oracle.truffle.llvm.intrinsics.c;
 
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.LLVMIntrinsic.LLVMI32Intrinsic;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
-import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMFunctionNode;
-import com.oracle.truffle.llvm.nodes.base.floating.LLVM80BitFloatNode;
-import com.oracle.truffle.llvm.nodes.base.floating.LLVMDoubleNode;
-import com.oracle.truffle.llvm.nodes.base.floating.LLVMFloatNode;
-import com.oracle.truffle.llvm.nodes.base.integers.LLVMI16Node;
-import com.oracle.truffle.llvm.nodes.base.integers.LLVMI1Node;
-import com.oracle.truffle.llvm.nodes.base.integers.LLVMI32Node;
-import com.oracle.truffle.llvm.nodes.base.integers.LLVMI64Node;
-import com.oracle.truffle.llvm.nodes.base.integers.LLVMI8Node;
+import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.LLVMFunction;
 
-public class LLVMNativeFactory {
+// see http://refspecs.linuxbase.org/LSB_3.1.0/LSB-Core-generic/LSB-Core-generic/baselib---cxa-atexit.html
+@NodeChildren({@NodeChild(type = LLVMFunctionNode.class), @NodeChild(type = LLVMAddressNode.class), @NodeChild(type = LLVMAddressNode.class)})
+public abstract class LLVMCxaExit extends LLVMI32Intrinsic {
 
-    public static Class<?> getJavaClass(LLVMExpressionNode node) {
-        if (node instanceof LLVMI1Node) {
-            return boolean.class;
-        } else if (node instanceof LLVMI8Node) {
-            return byte.class;
-        } else if (node instanceof LLVMI16Node) {
-            return short.class;
-        } else if (node instanceof LLVMI32Node) {
-            return int.class;
-        } else if (node instanceof LLVMI64Node) {
-            return long.class;
-        } else if (node instanceof LLVMFloatNode) {
-            return float.class;
-        } else if (node instanceof LLVMDoubleNode) {
-            return double.class;
-        } else if (node instanceof LLVMAddressNode) {
-            return long.class;
-        } else if (node instanceof LLVM80BitFloatNode) {
-            return byte[].class;
-        } else if (node instanceof LLVMFunctionNode) {
-            return long.class;
-        } else {
-            throw new AssertionError(node);
-        }
+    @SuppressWarnings("unused")
+    @Specialization
+    public int executeI32(LLVMFunction func, LLVMAddress addr, LLVMAddress addr2) {
+        // FIXME we should call the destructor function here
+        return 0;
     }
 
 }


### PR DESCRIPTION
This change adds support for iostream and other library functions by implementing [constructor calls](http://llvm.org/docs/LangRef.html#the-llvm-global-ctors-global-variable). Also, this change made it possible to have external function pointers in the program that can be passed to other native functions.