### PR TITLE
constructor support and passing of external function pointers to nati…

### DIFF
--- a/projects/com.oracle.truffle.llvm.test/suites-configs/llvm/SingleSource/UnitTests/working.include
+++ b/projects/com.oracle.truffle.llvm.test/suites-configs/llvm/SingleSource/UnitTests/working.include
@@ -85,7 +85,6 @@ test-suite-3.2.src/SingleSource/UnitTests/Integer/structInit.c
 test-suite-3.2.src/SingleSource/UnitTests/Integer/local-array.c
 test-suite-3.2.src/SingleSource/UnitTests/Integer/cppfield.cpp
 test-suite-3.2.src/SingleSource/UnitTests/Integer/union-init.c
-test-suite-3.2.src/SingleSource/UnitTests/ObjC/bitfield-access.m
 test-suite-3.2.src/SingleSource/Regression/C/sumarraymalloc.c
 test-suite-3.2.src/SingleSource/UnitTests/2006-12-04-DynAllocAndRestore.cpp
 test-suite-3.2.src/SingleSource/UnitTests/2006-01-23-UnionInit.c

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMFunctionRegistry.java
@@ -62,6 +62,7 @@ import com.oracle.truffle.llvm.intrinsics.c.LLVMExitFactory;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMFreeFactory;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMMallocFactory;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.base.LLVMFunctionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.base.floating.LLVMDoubleNode;
 import com.oracle.truffle.llvm.nodes.base.floating.LLVMFloatNode;
@@ -165,6 +166,8 @@ public class LLVMFunctionRegistry {
             argNode = LLVMArgNodeFactory.LLVMDoubleArgNodeGen.create(i);
         } else if (clazz.equals(LLVMAddressNode.class)) {
             argNode = LLVMArgNodeFactory.LLVMAddressArgNodeGen.create(i);
+        } else if (clazz.equals(LLVMFunctionNode.class)) {
+            argNode = LLVMArgNodeFactory.LLVMFunctionArgNodeGen.create(i);
         } else {
             throw new AssertionError(clazz);
         }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMIntrinsic.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMIntrinsic.java
@@ -33,6 +33,7 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.base.floating.LLVMDoubleNode;
+import com.oracle.truffle.llvm.nodes.base.integers.LLVMI32Node;
 
 public interface LLVMIntrinsic {
 
@@ -48,6 +49,11 @@ public interface LLVMIntrinsic {
 
     @GenerateNodeFactory
     abstract class LLVMVoidIntrinsic extends LLVMNode implements LLVMIntrinsic {
+
+    }
+
+    @GenerateNodeFactory
+    abstract class LLVMI32Intrinsic extends LLVMI32Node implements LLVMIntrinsic {
 
     }
 

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMNativeCallConvertNode.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMNativeCallConvertNode.java
@@ -46,8 +46,8 @@ public abstract class LLVMNativeCallConvertNode {
     // FIXME: do not use inheritance
     public static class LLVMResolvedNativeAddressCallNode extends LLVMResolvedDirectNativeCallNode {
 
-        public LLVMResolvedNativeAddressCallNode(LLVMFunction function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args) {
-            super(function, nativeFunctionHandle, args);
+        public LLVMResolvedNativeAddressCallNode(LLVMFunction function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args, LLVMContext context) {
+            super(function, nativeFunctionHandle, args, context);
             assert function.getLlvmReturnType() == LLVMRuntimeType.ADDRESS;
         }
 
@@ -60,8 +60,8 @@ public abstract class LLVMNativeCallConvertNode {
 
     public static class LLVMResolvedNative80BitFloatCallNode extends LLVMResolvedDirectNativeCallNode {
 
-        public LLVMResolvedNative80BitFloatCallNode(LLVMFunction function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args) {
-            super(function, nativeFunctionHandle, args);
+        public LLVMResolvedNative80BitFloatCallNode(LLVMFunction function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args, LLVMContext context) {
+            super(function, nativeFunctionHandle, args, context);
             assert function.getLlvmReturnType() == LLVMRuntimeType.X86_FP80;
         }
 

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/parser/factories/LLVMNativeFactory.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/parser/factories/LLVMNativeFactory.java
@@ -40,8 +40,6 @@ import com.oracle.truffle.llvm.nodes.base.integers.LLVMI1Node;
 import com.oracle.truffle.llvm.nodes.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.base.integers.LLVMI8Node;
-import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
-import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
 
 public class LLVMNativeFactory {
 
@@ -65,7 +63,7 @@ public class LLVMNativeFactory {
         } else if (node instanceof LLVM80BitFloatNode) {
             return byte[].class;
         } else if (node instanceof LLVMFunctionNode) {
-            throw new LLVMUnsupportedException(UnsupportedReason.FUNCTION_POINTER_ESCAPES_TO_NATIVE);
+            return long.class;
         } else {
             throw new AssertionError(node);
         }


### PR DESCRIPTION
This change adds support C++ constructors by implementing LLVM [constructor calls](http://llvm.org/docs/LangRef.html#the-llvm-global-ctors-global-variable). Also, this change made it possible to have external function pointers in the program that can be passed to other native functions.