### PR TITLE
lifetime analysis print option

### DIFF
--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -90,7 +90,8 @@ public class LLVMOptions {
         OPTIMIZATION_INJECT_PROBS_SELECT("llvm-opt-select", "Inject branch probabilities for select", "true", LLVMOptions::parseBoolean),
         OPTIMIZATION_INTRINSIFY_C_FUNCTIONS("llvm-opt-cintrinsics", "Substitute C functions by Java equivalents where possible", "true", LLVMOptions::parseBoolean),
         OPTIMIZATION_INJECT_PROBS_COND_BRANCH("llvm-opt-br", "Inject branch probabilities for conditional branches", "true", LLVMOptions::parseBoolean),
-        NATIVE_CALL_STATS("llvm-native-call-stats", "Outputs stats about native call site frequencies", "false", LLVMOptions::parseBoolean);
+        NATIVE_CALL_STATS("llvm-native-call-stats", "Outputs stats about native call site frequencies", "false", LLVMOptions::parseBoolean),
+        LIFE_TIME_ANALYSIS_STATS("llvm-lifetime-analysis-stats", "Outputs the results of the lifetime analysis", "false", LLVMOptions::parseBoolean);
 
         Property(String key, String description, String defaultValue, OptionParser parser) {
             this.key = key;
@@ -211,6 +212,10 @@ public class LLVMOptions {
 
     public static boolean isNativeCallStats() {
         return getParsedProperty(Property.NATIVE_CALL_STATS);
+    }
+
+    public static boolean isNativeAnalysisStats() {
+        return getParsedProperty(Property.LIFE_TIME_ANALYSIS_STATS);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/parser/LLVMLifeTimeAnalysisVisitor.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/parser/LLVMLifeTimeAnalysisVisitor.java
@@ -55,8 +55,15 @@ import com.intel.llvm.ireditor.lLVM_IR.TerminatorInstruction;
 import com.intel.llvm.ireditor.lLVM_IR.impl.Instruction_brImpl;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.llvm.runtime.LLVMOptions;
 
+/**
+ * This class determines which variables are dead after each basic block.
+ */
 public class LLVMLifeTimeAnalysisVisitor {
+
+    private static final String FUNCTION_FORMAT = "%s:\n";
+    private static final String AFTER_BLOCK_FORMAT = "\t dead after bb %4s:";
 
     private final FunctionDef function;
     private final FrameDescriptor frameDescriptor;
@@ -69,7 +76,29 @@ public class LLVMLifeTimeAnalysisVisitor {
     }
 
     public static Map<BasicBlock, FrameSlot[]> visit(FunctionDef function, FrameDescriptor frameDescriptor) {
-        return new LLVMLifeTimeAnalysisVisitor(function, frameDescriptor).visit();
+        Map<BasicBlock, FrameSlot[]> mapping = new LLVMLifeTimeAnalysisVisitor(function, frameDescriptor).visit();
+        if (LLVMOptions.isNativeAnalysisStats()) {
+            printAnalysisResults(function, mapping);
+        }
+        return mapping;
+    }
+
+    private static void printAnalysisResults(FunctionDef analyzedFunction, Map<BasicBlock, FrameSlot[]> mapping) {
+        System.out.print(String.format(FUNCTION_FORMAT, analyzedFunction.getHeader().getName()));
+        for (BasicBlock b : mapping.keySet()) {
+            System.out.print(String.format(AFTER_BLOCK_FORMAT, b.getName()));
+            FrameSlot[] variables = mapping.get(b);
+            if (variables.length != 0) {
+                System.out.print("\t");
+                for (int i = 0; i < variables.length; i++) {
+                    if (i != 0) {
+                        System.out.print(", ");
+                    }
+                    System.out.print(variables[i].getIdentifier());
+                }
+            }
+            System.out.println();
+        }
     }
 
     private Map<BasicBlock, FrameSlot[]> visit() {


### PR DESCRIPTION
This change introduces an option for printing the results of the lifetime analysis. Below is an example of its output:

```
@NewTreeNode:
	 dead after bb   %0:	%1, %2, %3, %4, %5
@ItemCheck:
	 dead after bb   %0:
	 dead after bb   %7:	%8, %9, %10, %11, %12, %13, %14, %15, %16, %17
	 dead after bb  %18:	%8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %1, %2, %3, %5, %6
	 dead after bb   %4:	%5, %6
@BottomUpTree:
	 dead after bb   %2:	%3, %4, %5, %6, %7, %8, %9, %10
	 dead after bb  %13:	%12, %1, %3, %4, %5, %6, %7, %8, %9, %10
	 dead after bb   %0:
	 dead after bb  %11:	%12
@DeleteTree:
	 dead after bb   %4:	%5, %6, %7, %8
	 dead after bb   %0:
	 dead after bb   %9:	%10, %5, %6, %7, %8, %1, %2, %3, %1, %2, %3
```
