### PR TITLE
implement I8 and I16 intrinsic nodes and override toString for intrinsics

### DIFF
--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMFunctionRegistry.java
@@ -44,8 +44,10 @@ import com.oracle.truffle.llvm.LLVMIntrinsicRootNode.LLVMIntrinsicVoidNode;
 import com.oracle.truffle.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicAddressNodeGen;
 import com.oracle.truffle.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicDoubleNodeGen;
 import com.oracle.truffle.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicFloatNodeGen;
+import com.oracle.truffle.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI16NodeGen;
 import com.oracle.truffle.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI32NodeGen;
 import com.oracle.truffle.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI64NodeGen;
+import com.oracle.truffle.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI8NodeGen;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMAbortFactory;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMACosFactory;
 import com.oracle.truffle.llvm.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMASinFactory;
@@ -66,8 +68,10 @@ import com.oracle.truffle.llvm.nodes.base.LLVMFunctionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.base.floating.LLVMDoubleNode;
 import com.oracle.truffle.llvm.nodes.base.floating.LLVMFloatNode;
+import com.oracle.truffle.llvm.nodes.base.integers.LLVMI16Node;
 import com.oracle.truffle.llvm.nodes.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.base.integers.LLVMI64Node;
+import com.oracle.truffle.llvm.nodes.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.nodes.func.LLVMArgNodeFactory;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.types.LLVMFunction;
@@ -176,7 +180,11 @@ public class LLVMFunctionRegistry {
 
     private static RootNode getRootNode(LLVMIntrinsic intrinsicNode) throws AssertionError {
         RootNode functionRoot;
-        if (intrinsicNode instanceof LLVMI32Node) {
+        if (intrinsicNode instanceof LLVMI8Node) {
+            functionRoot = LLVMIntrinsicI8NodeGen.create((LLVMI8Node) intrinsicNode);
+        } else if (intrinsicNode instanceof LLVMI16Node) {
+            functionRoot = LLVMIntrinsicI16NodeGen.create((LLVMI16Node) intrinsicNode);
+        } else if (intrinsicNode instanceof LLVMI32Node) {
             functionRoot = LLVMIntrinsicI32NodeGen.create((LLVMI32Node) intrinsicNode);
         } else if (intrinsicNode instanceof LLVMI64Node) {
             functionRoot = LLVMIntrinsicI64NodeGen.create((LLVMI64Node) intrinsicNode);

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMIntrinsicRootNode.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVMIntrinsicRootNode.java
@@ -38,14 +38,26 @@ import com.oracle.truffle.llvm.nodes.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.base.floating.LLVMDoubleNode;
 import com.oracle.truffle.llvm.nodes.base.floating.LLVMFloatNode;
+import com.oracle.truffle.llvm.nodes.base.integers.LLVMI16Node;
 import com.oracle.truffle.llvm.nodes.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.base.integers.LLVMI64Node;
+import com.oracle.truffle.llvm.nodes.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 
+/**
+ * This class is the entry point for every intrinsified (substituted) function.
+ */
 public abstract class LLVMIntrinsicRootNode extends RootNode {
 
     LLVMIntrinsicRootNode() {
         super(LLVMLanguage.class, null, new FrameDescriptor());
+    }
+
+    public abstract LLVMNode getNode();
+
+    @Override
+    public String toString() {
+        return getNode().getClass().getSimpleName();
     }
 
     public static class LLVMIntrinsicVoidNode extends LLVMIntrinsicRootNode {
@@ -61,9 +73,32 @@ public abstract class LLVMIntrinsicRootNode extends RootNode {
             node.executeVoid(frame);
             return null;
         }
+
+        @Override
+        public LLVMNode getNode() {
+            return node;
+        }
     }
 
-    @NodeChild(type = LLVMI32Node.class)
+    @NodeChild(type = LLVMI8Node.class, value = "node")
+    public abstract static class LLVMIntrinsicI8Node extends LLVMIntrinsicRootNode {
+
+        @Specialization
+        public Object execute(byte val) {
+            return val;
+        }
+    }
+
+    @NodeChild(type = LLVMI16Node.class, value = "node")
+    public abstract static class LLVMIntrinsicI16Node extends LLVMIntrinsicRootNode {
+
+        @Specialization
+        public Object execute(short val) {
+            return val;
+        }
+    }
+
+    @NodeChild(type = LLVMI32Node.class, value = "node")
     public abstract static class LLVMIntrinsicI32Node extends LLVMIntrinsicRootNode {
 
         @Specialization
@@ -72,7 +107,7 @@ public abstract class LLVMIntrinsicRootNode extends RootNode {
         }
     }
 
-    @NodeChild(type = LLVMI64Node.class)
+    @NodeChild(type = LLVMI64Node.class, value = "node")
     public abstract static class LLVMIntrinsicI64Node extends LLVMIntrinsicRootNode {
 
         @Specialization
@@ -81,7 +116,7 @@ public abstract class LLVMIntrinsicRootNode extends RootNode {
         }
     }
 
-    @NodeChild(type = LLVMFloatNode.class)
+    @NodeChild(type = LLVMFloatNode.class, value = "node")
     public abstract static class LLVMIntrinsicFloatNode extends LLVMIntrinsicRootNode {
 
         @Specialization
@@ -90,7 +125,7 @@ public abstract class LLVMIntrinsicRootNode extends RootNode {
         }
     }
 
-    @NodeChild(type = LLVMDoubleNode.class)
+    @NodeChild(type = LLVMDoubleNode.class, value = "node")
     public abstract static class LLVMIntrinsicDoubleNode extends LLVMIntrinsicRootNode {
 
         @Specialization
@@ -99,13 +134,14 @@ public abstract class LLVMIntrinsicRootNode extends RootNode {
         }
     }
 
-    @NodeChild(type = LLVMAddressNode.class)
+    @NodeChild(type = LLVMAddressNode.class, value = "node")
     public abstract static class LLVMIntrinsicAddressNode extends LLVMIntrinsicRootNode {
 
         @Specialization
         public Object execute(LLVMAddress value) {
             return value;
         }
+
     }
 
 }


### PR DESCRIPTION
This changes improves the display of LLVM intrinsics in IGV and implements I8 and I16 intrinsic nodes.