### PR TITLE
update .gitignore to exclude IGV files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,11 @@ mx.sulong/eclipse-launches/**
 build.xml
 workingsets.xml
 hs_err_pid*.log
+compilations-*.cfg
 lib/**
 mxbuild/**
+mx.imports/**
+.idea/**
 build/**
 graal/**
 projects/*/nbproject/


### PR DESCRIPTION
With this change, IGV graph files and some other mx files are excluded from Git.