### PR TITLE
display error for invalid Sulong option names

### DIFF
--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -31,6 +31,7 @@ package com.oracle.truffle.llvm.runtime;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 public class LLVMOptions {
 
@@ -129,11 +130,48 @@ public class LLVMOptions {
         public String toString() {
             return String.format(FORMAT_STRING, getKey(), getDefaultValue(), getDescription());
         }
+
+        public static Property fromKey(String key) {
+            for (Property p : values()) {
+                if (p.getKey().equals(key)) {
+                    return p;
+                }
+            }
+            return null;
+        }
+
     }
 
     private static Map<Property, Object> parsedProperties = new HashMap<>();
 
     static {
+        parseOptions();
+        checkForInvalidOptionNames();
+    }
+
+    private static void checkForInvalidOptionNames() {
+        boolean wrongOptionName = false;
+        Properties allProperties = System.getProperties();
+        for (String key : allProperties.stringPropertyNames()) {
+            if (key.startsWith(OPTION_PREFIX)) {
+                if (Property.fromKey(key) == null) {
+                    wrongOptionName = true;
+                    // Checkstyle: stop
+                    System.err.println(key + " is an invalid option!");
+                    // Checkstyle: resume
+                }
+            }
+        }
+        if (wrongOptionName) {
+            // Checkstyle: stop
+            System.err.println("\nvalid options:");
+            // Checkstyle: resume
+            LLVMOptions.main(new String[0]);
+            System.exit(-1);
+        }
+    }
+
+    private static void parseOptions() {
         Property[] properties = Property.values();
         for (Property prop : properties) {
             parsedProperties.put(prop, prop.parse());


### PR DESCRIPTION
With this change an invalid option name, i.e., a system property that starts with `sulong.`, will cause an error:

```
mx su-run -Dsulong.Print=true test.ll
sulong.Print is an invalid option!
valid options:

                            sulong.Debug (default = false) Turns debugging on/off
                        sulong.PrintASTs (default = false) Prints the Truffle ASTs for the parsed functions
               sulong.TestRemoteBootPath (default =  null) The boot classpath for the remote JVM used to capture native printf and other output.
                sulong.TestDiscoveryPath (default =  null) Looks for newly supported test cases in the specified path. E.g., when executing the GCC test cases you can use /gcc.c-torture/execute to discover newly working torture test cases.
         sulong.DynamicNativeLibraryPath (default =  null) The native library search paths delimited by :
                      sulong.ProjectRoot (default =     .) Overrides the root of the project. This option exists to set the project root from mx
        sulong.SpecializeExpectIntrinsic (default =  true) Specialize the llvm.expect intrinsic
          sulong.ValueProfileMemoryReads (default =  true) Enable value profiling for memory reads
          sulong.InjectProbabilitySelect (default =  true) Inject branch probabilities for select
             sulong.IntrinsifyCFunctions (default =  true) Substitute C functions by Java equivalents where possible
              sulong.InjectProbabilityBr (default =  true) Inject branch probabilities for conditional branches
           sulong.EnableLifetimeAnalysis (default =  true) Performs a lifetime analysis to set dead frame slots to null to assist the PE
             sulong.PrintNativeCallStats (default = false) Outputs stats about native call site frequencies
         sulong.PrintNativeAnalysisStats (default = false) Outputs the results of the lifetime analysis (if enabled)

```