### PR TITLE
move stack into context

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
@@ -42,6 +42,7 @@ import com.oracle.truffle.llvm.parser.NodeFactoryFacade;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
 public class LLVMContext extends ExecutionContext {
 
@@ -52,6 +53,8 @@ public class LLVMContext extends ExecutionContext {
     private LLVMAddress[] deallocations;
 
     private final NativeLookup nativeLookup;
+
+    private final LLVMStack stack = new LLVMStack();
 
     public LLVMContext(NodeFactoryFacade facade, LLVMOptimizationConfiguration optimizationConfig) {
         nativeLookup = new NativeLookup(facade);
@@ -91,6 +94,10 @@ public class LLVMContext extends ExecutionContext {
 
     public Map<LLVMFunction, Integer> getNativeFunctionLookupStats() {
         return nativeLookup.getNativeFunctionLookupStats();
+    }
+
+    public LLVMStack getStack() {
+        return stack;
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/LLVMStackRestore.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/LLVMStackRestore.java
@@ -30,18 +30,22 @@
 package com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm;
 
 import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
 @NodeChild(type = LLVMAddressNode.class)
+@NodeField(type = LLVMContext.class, name = "context")
 public abstract class LLVMStackRestore extends LLVMNode {
+
+    abstract LLVMContext getContext();
 
     @Specialization
     public void executeVoid(LLVMAddress addr) {
-        LLVMStack.setStackPointer(addr);
+        getContext().getStack().setStackPointer(addr);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/LLVMStackSave.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/LLVMStackSave.java
@@ -29,16 +29,20 @@
  */
 package com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm;
 
-import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.dsl.NodeField;
+import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
-public class LLVMStackSave extends LLVMAddressNode {
+@NodeField(type = LLVMContext.class, name = "context")
+public abstract class LLVMStackSave extends LLVMAddressNode {
 
-    @Override
-    public LLVMAddress executePointee(VirtualFrame frame) {
-        return LLVMStack.getStackPointer();
+    abstract LLVMContext getContext();
+
+    @Specialization
+    public LLVMAddress executePointee() {
+        return getContext().getStack().getStackPointer();
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/LLVMAllocInstruction.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/LLVMAllocInstruction.java
@@ -34,22 +34,24 @@ import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.NodeFields;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
-@NodeFields({@NodeField(type = int.class, name = "size"), @NodeField(type = int.class, name = "alignment")})
+@NodeFields({@NodeField(type = int.class, name = "size"), @NodeField(type = int.class, name = "alignment"), @NodeField(type = LLVMContext.class, name = "context")})
 public abstract class LLVMAllocInstruction extends LLVMAddressNode {
 
-    public abstract int getSize();
+    abstract int getSize();
 
-    public abstract int getAlignment();
+    abstract int getAlignment();
+
+    abstract LLVMContext getContext();
 
     public abstract static class LLVMAllocaInstruction extends LLVMAllocInstruction {
         @Specialization
         public LLVMAddress execute() {
-            return LLVMStack.allocateMemory(getSize(), getAlignment());
+            return getContext().getStack().allocateMemory(getSize(), getAlignment());
         }
     }
 
@@ -57,7 +59,7 @@ public abstract class LLVMAllocInstruction extends LLVMAddressNode {
     public abstract static class LLVMI32AllocaInstruction extends LLVMAllocInstruction {
         @Specialization
         public LLVMAddress execute(int nr) {
-            return LLVMStack.allocateMemory(getSize() * nr, getAlignment());
+            return getContext().getStack().allocateMemory(getSize() * nr, getAlignment());
         }
     }
 
@@ -65,7 +67,7 @@ public abstract class LLVMAllocInstruction extends LLVMAddressNode {
     public abstract static class LLVMI64AllocaInstruction extends LLVMAllocInstruction {
         @Specialization
         public LLVMAddress execute(long nr) {
-            return LLVMStack.allocateMemory(getSize() * nr, getAlignment());
+            return getContext().getStack().allocateMemory(getSize() * nr, getAlignment());
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/LLVMStackDeallocNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/LLVMStackDeallocNode.java
@@ -30,18 +30,22 @@
 package com.oracle.truffle.llvm.nodes.impl.memory;
 
 import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
 @NodeChild(type = LLVMAddressNode.class)
+@NodeField(type = LLVMContext.class, name = "context")
 public abstract class LLVMStackDeallocNode extends LLVMNode {
+
+    abstract LLVMContext getContext();
 
     @Specialization
     public void executeVoid(LLVMAddress addr) {
-        LLVMStack.setStackPointer(addr);
+        getContext().getStack().setStackPointer(addr);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAllocFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAllocFactory.java
@@ -30,6 +30,8 @@
 package com.oracle.truffle.llvm.parser.factories;
 
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.memory.LLVMAllocInstruction.LLVMAllocaInstruction;
@@ -41,18 +43,20 @@ import com.oracle.truffle.llvm.parser.LLVMBaseType;
 public class LLVMAllocFactory {
 
     public static LLVMExpressionNode createAlloc(LLVMBaseType llvmType, LLVMExpressionNode numElements, int byteSize, int alignment) {
+        LLVMContext context = LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0());
         switch (llvmType) {
             case I32:
-                return LLVMI32AllocaInstructionNodeGen.create((LLVMI32Node) numElements, byteSize, alignment);
+                return LLVMI32AllocaInstructionNodeGen.create((LLVMI32Node) numElements, byteSize, alignment, context);
             case I64:
-                return LLVMI64AllocaInstructionNodeGen.create((LLVMI64Node) numElements, byteSize, alignment);
+                return LLVMI64AllocaInstructionNodeGen.create((LLVMI64Node) numElements, byteSize, alignment, context);
             default:
                 throw new AssertionError(llvmType);
         }
     }
 
     public static LLVMAllocaInstruction createAlloc(int size, int alignment) {
-        return LLVMAllocaInstructionNodeGen.create(size, alignment);
+        LLVMContext context = LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0());
+        return LLVMAllocaInstructionNodeGen.create(size, alignment, context);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMIntrinsicFactory.java
@@ -39,6 +39,8 @@ import com.intel.llvm.ireditor.lLVM_IR.Parameter;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI1Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
@@ -64,7 +66,7 @@ import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMNoOpFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMPrefetchFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMReturnAddressFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMStackRestoreNodeGen;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMStackSave;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMStackSaveNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMTrapFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.arith.LLVMPowFactory.LLVMPowDoubleFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.arith.LLVMPowFactory.LLVMPowFloatFactory;
@@ -145,13 +147,14 @@ public final class LLVMIntrinsicFactory {
     public static LLVMNode create(String functionName, Object[] argNodes, FunctionDef functionDef, LLVMParserRuntime runtime) {
         NodeFactory<? extends LLVMNode> factory = factories.get(functionName);
         EList<Parameter> paramList = functionDef.getHeader().getParameters().getParameters();
+        LLVMContext context = LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0());
         if (factory == null) {
             if (functionName.equals("@llvm.uadd.with.overflow.i32")) {
                 return LLVMUAddWithOverflowI32NodeGen.create((LLVMI32Node) argNodes[1], (LLVMI32Node) argNodes[2], (LLVMAddressNode) argNodes[0]);
             } else if (functionName.equals("@llvm.stacksave")) {
-                return new LLVMStackSave();
+                return LLVMStackSaveNodeGen.create(context);
             } else if (functionName.equals("@llvm.stackrestore")) {
-                return LLVMStackRestoreNodeGen.create((LLVMAddressNode) argNodes[0]);
+                return LLVMStackRestoreNodeGen.create((LLVMAddressNode) argNodes[0], context);
             } else if (functionName.equals("@llvm.frameaddress")) {
                 return LLVMFrameAddressNodeGen.create((LLVMI32Node) argNodes[0], runtime.getStackPointerSlot());
             } else if (functionName.startsWith("@llvm.va_start")) {

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -132,6 +132,7 @@ import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMMetadataNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMStatementNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMStructWriteNode;
@@ -420,7 +421,8 @@ public class LLVMVisitor implements LLVMParserRuntime {
         LLVMFunctionBodyNode functionBodyNode = new LLVMFunctionBodyNode(block, retSlot);
         LLVMNode[] beforeFunction = formalParameters.toArray(new LLVMNode[formalParameters.size()]);
         LLVMNode[] afterFunction = functionEpilogue.toArray(new LLVMNode[functionEpilogue.size()]);
-        LLVMFunctionStartNode rootNode = new LLVMFunctionStartNode(functionBodyNode, stackPointerSlot, beforeFunction, afterFunction, frameDescriptor, functionName);
+        LLVMContext context = LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0());
+        LLVMFunctionStartNode rootNode = new LLVMFunctionStartNode(functionBodyNode, stackPointerSlot, beforeFunction, afterFunction, frameDescriptor, functionName, context);
         if (LLVMOptions.printFunctionASTs()) {
             NodeUtil.printTree(System.out, rootNode);
         }

--- a/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/Opt.java
+++ b/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/Opt.java
@@ -54,7 +54,8 @@ public class Opt {
             FUNC_ATTRS("functionattrs"),
             JUMP_THREADING("jump-threading"),
             SCALAR_REPLACEMENT_AGGREGATES("scalarrepl"),
-            ALWAYS_INLINE("always-inline");
+            ALWAYS_INLINE("always-inline"),
+            GVN("gvn");
 
             private final String option;
 

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
@@ -42,26 +42,33 @@ public class LLVMStack extends LLVMMemory {
 
     private static final int STACK_SIZE_BYTE = STACK_SIZE_KB * 1024;
 
-    private static long stackPointer;
+    private long stackPointer;
 
-    @CompilationFinal private static long lowerBounds;
-    @CompilationFinal private static long upperBounds;
+    @CompilationFinal private long lowerBounds;
+    @CompilationFinal private long upperBounds;
+
+    public LLVMStack() {
+        allocate();
+    }
 
     /**
      * Allocates the stack memory.
      */
-    public static void allocate() {
+    private void allocate() {
         CompilerDirectives.transferToInterpreterAndInvalidate();
         final long stackAllocation = UNSAFE.allocateMemory(STACK_SIZE_BYTE);
         lowerBounds = stackAllocation;
         upperBounds = stackAllocation + STACK_SIZE_BYTE;
+    }
+
+    public void reset() {
         stackPointer = upperBounds;
     }
 
     /**
      * Deallocates the stack memory.
      */
-    public static void free() {
+    public void free() {
         UNSAFE.freeMemory(lowerBounds);
         lowerBounds = 0;
         upperBounds = 0;
@@ -77,7 +84,7 @@ public class LLVMStack extends LLVMMemory {
      * @param alignment the alignment, either {@link #NO_ALIGNMENT_REQUIREMENTS} or a power of two.
      * @return the allocated memory, satisfying the alignment requirements
      */
-    public static LLVMAddress allocateMemory(final long size, final int alignment) {
+    public LLVMAddress allocateMemory(final long size, final int alignment) {
         assert size >= 0;
         assert alignment != 0 && powerOfTo(alignment);
         final long alignedAllocation = (stackPointer - size) & -alignment;
@@ -94,11 +101,11 @@ public class LLVMStack extends LLVMMemory {
         return (value & -value) == value;
     }
 
-    public static LLVMAddress getStackPointer() {
+    public LLVMAddress getStackPointer() {
         return LLVMAddress.fromLong(stackPointer);
     }
 
-    public static void setStackPointer(final LLVMAddress addr) {
+    public void setStackPointer(final LLVMAddress addr) {
         assert stackPointer <= addr.getVal();
         assert lowerBounds < addr.getVal();
         assert upperBounds >= addr.getVal();

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -169,17 +169,20 @@ public class LLVM {
             LLVMFunction mainSignature = module.getMainSignature();
             int argParamCount = mainSignature.getLlvmParamTypes().length;
             LLVMGlobalRootNode globalFunction;
+            LLVMContext context = module.getContext();
             if (argParamCount == 0) {
-                globalFunction = LLVMGlobalRootNode.createNoArgumentsMain(module.getStaticInits(), originalCallTarget, module.getAllocatedAddresses());
+                globalFunction = LLVMGlobalRootNode.createNoArgumentsMain(context, module.getStaticInits(), originalCallTarget, module.getAllocatedAddresses());
             } else if (argParamCount == 1) {
-                globalFunction = LLVMGlobalRootNode.createArgsCountMain(module.getStaticInits(), originalCallTarget, module.getAllocatedAddresses(), args.length + 1);
+                globalFunction = LLVMGlobalRootNode.createArgsCountMain(context, module.getStaticInits(), originalCallTarget, module.getAllocatedAddresses(), args.length + 1);
             } else {
                 LLVMAddress allocatedArgsStartAddress = getArgsAsStringArray(fileSource, args);
                 if (argParamCount == 2) {
-                    globalFunction = LLVMGlobalRootNode.createArgsMain(module.getStaticInits(), originalCallTarget, module.getAllocatedAddresses(), args.length + 1, allocatedArgsStartAddress);
+                    globalFunction = LLVMGlobalRootNode.createArgsMain(context, module.getStaticInits(), originalCallTarget, module.getAllocatedAddresses(), args.length + 1,
+                                    allocatedArgsStartAddress);
                 } else if (argParamCount == THREE_ARGS) {
                     LLVMAddress posixEnvPointer = LLVMAddress.NULL_POINTER;
-                    globalFunction = LLVMGlobalRootNode.createArgsEnvMain(module.getStaticInits(), originalCallTarget, module.getAllocatedAddresses(), args.length + 1, allocatedArgsStartAddress,
+                    globalFunction = LLVMGlobalRootNode.createArgsEnvMain(context, module.getStaticInits(), originalCallTarget, module.getAllocatedAddresses(), args.length + 1,
+                                    allocatedArgsStartAddress,
                                     posixEnvPointer);
                 } else {
                     throw new AssertionError(argParamCount);


### PR DESCRIPTION
This change assigns each context its own stack. This allows to run multiple Sulong instances at once, and also improves performance since the stack pointer can be escape analyzed.