### PR TITLE
Fix mixed native and Sulong calls in indirect calls

### DIFF
--- a/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
+++ b/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
@@ -123,6 +123,7 @@ public class NativeLookup {
         Class<?>[] paramTypes = getJavaClassses(args, function.getLlvmParamTypes());
         String functionName = function.getName().substring(1);
         if (cachedHandles.containsKey(functionName)) {
+            recordFoundFunctionHandle(function, cachedHandles.get(functionName));
             return cachedHandles.get(functionName);
         } else {
             NativeFunctionHandle functionHandle;
@@ -135,11 +136,17 @@ public class NativeLookup {
                 NativeLibraryHandle[] handles = getNativeFunctionHandles();
                 functionHandle = nfi.getFunctionHandle(handles, functionName, retType, paramTypes);
             }
-            if (LLVMOptions.printNativeCallStats() && functionHandle != null) {
-                recordNativeFunctionCallSite(function);
+            recordFoundFunctionHandle(function, functionHandle);
+            if (functionHandle != null) {
+                cachedHandles.put(functionName, functionHandle);
             }
-            cachedHandles.put(functionName, functionHandle);
             return functionHandle;
+        }
+    }
+
+    private void recordFoundFunctionHandle(LLVMFunction function, NativeFunctionHandle functionHandle) {
+        if (LLVMOptions.printNativeCallStats() && functionHandle != null) {
+            recordNativeFunctionCallSite(function);
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
+++ b/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
@@ -122,7 +122,7 @@ public class NativeLookup {
         Class<?> retType = getJavaClass(function.getLlvmReturnType());
         Class<?>[] paramTypes = getJavaClassses(args, function.getLlvmParamTypes());
         String functionName = function.getName().substring(1);
-        if (cachedHandles.containsKey(functionName)) {
+        if (!function.isVarArgs() && cachedHandles.containsKey(functionName)) {
             recordFoundFunctionHandle(function, cachedHandles.get(functionName));
             return cachedHandles.get(functionName);
         } else {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
@@ -46,6 +46,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI16Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
+import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToAddressNodeFactory.LLVMI64ToAddressNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMAbortFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMACosFactory;
@@ -168,7 +169,7 @@ public class LLVMFunctionRegistry {
         } else if (clazz.equals(LLVMDoubleNode.class)) {
             argNode = LLVMArgNodeFactory.LLVMDoubleArgNodeGen.create(i);
         } else if (clazz.equals(LLVMAddressNode.class)) {
-            argNode = LLVMArgNodeFactory.LLVMAddressArgNodeGen.create(i);
+            argNode = LLVMI64ToAddressNodeGen.create(LLVMArgNodeFactory.LLVMI64ArgNodeGen.create(i));
         } else if (clazz.equals(LLVMFunctionNode.class)) {
             argNode = LLVMArgNodeFactory.LLVMFunctionArgNodeGen.create(i);
         } else {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
@@ -49,7 +49,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVM80BitFloatNode;
-import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI64NodeFactory.LLVMAddressToI64NodeGen;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNodeFactory.LLVM80BitArgConvertNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNodeFactory.LLVMFunctionCallChainNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMNativeCallConvertNode.LLVMResolvedNative80BitFloatCallNode;
@@ -146,9 +146,8 @@ public abstract class LLVMCallNode {
             CompilerAsserts.neverPartOfCompilation();
             LLVMExpressionNode[] newNodes = new LLVMExpressionNode[originalArgs.length];
             for (int i = 0; i < newNodes.length; i++) {
-                if (originalArgs[i] instanceof LLVMAddressNode) {
-                    newNodes[i] = LLVMAddressToI64NodeGen.create((LLVMAddressNode) originalArgs[i]);
-                } else if (originalArgs[i] instanceof LLVM80BitFloatNode) {
+                assert !(originalArgs[i] instanceof LLVMAddressNode) : "should be passed as " + LLVMI64Node.class.getSimpleName();
+                if (originalArgs[i] instanceof LLVM80BitFloatNode) {
                     newNodes[i] = LLVM80BitArgConvertNodeGen.create((LLVM80BitFloatNode) originalArgs[i]);
                     throw new AssertionError("foreign function interface does not support 80 bit floats yet");
                 } else if (originalArgs[i] instanceof LLVMFunctionNode) {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
@@ -34,6 +34,7 @@ import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -242,6 +243,7 @@ public abstract class LLVMCallNode {
 
         public abstract Object executeDispatch(VirtualFrame frame, LLVMFunction function, Object[] arguments);
 
+        @TruffleBoundary
         public static CallTarget getIndirectCallTarget(LLVMContext context, LLVMFunction function, LLVMExpressionNode[] args) {
             CallTarget callTarget = context.getFunction(function);
             if (callTarget == null) {
@@ -272,7 +274,8 @@ public abstract class LLVMCallNode {
         @Specialization(contains = "doDirect")
         protected Object doIndirect(VirtualFrame frame, LLVMFunction function, Object[] arguments, //
                         @Cached("create()") IndirectCallNode callNode) {
-            return callNode.call(frame, context.getFunction(function), arguments);
+            CallTarget lookedUpFunction = getIndirectCallTarget(getContext(), function, getNodes());
+            return callNode.call(frame, lookedUpFunction, arguments);
         }
 
         public LLVMContext getContext() {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
@@ -57,12 +57,13 @@ public class LLVMGlobalRootNode extends RootNode {
         return new LLVMGlobalRootNode(context, staticInits, main, llvmAddresses, argsCount);
     }
 
-    public static LLVMGlobalRootNode createArgsMain(LLVMContext context, LLVMNode[] staticInits, CallTarget main, LLVMAddress[] llvmAddresses, int argsCount, LLVMAddress args) {
-        return new LLVMGlobalRootNode(context, staticInits, main, llvmAddresses, argsCount, args);
+    public static LLVMGlobalRootNode createArgsMain(LLVMContext context, LLVMNode[] staticInits, CallTarget main, LLVMAddress[] llvmAddresses, int argsCount, long allocatedArgsStartAddress) {
+        return new LLVMGlobalRootNode(context, staticInits, main, llvmAddresses, argsCount, allocatedArgsStartAddress);
     }
 
-    public static LLVMGlobalRootNode createArgsEnvMain(LLVMContext context, LLVMNode[] staticInits, CallTarget main, LLVMAddress[] llvmAddresses, int argsCount, LLVMAddress args, LLVMAddress envp) {
-        return new LLVMGlobalRootNode(context, staticInits, main, llvmAddresses, argsCount, args, envp);
+    public static LLVMGlobalRootNode createArgsEnvMain(LLVMContext context, LLVMNode[] staticInits, CallTarget main, LLVMAddress[] llvmAddresses, int argsCount, long allocatedArgsStartAddress,
+                    long posixEnvPointer) {
+        return new LLVMGlobalRootNode(context, staticInits, main, llvmAddresses, argsCount, allocatedArgsStartAddress, posixEnvPointer);
     }
 
     @Children private final LLVMNode[] staticInits;

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMNativeCallConvertNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMNativeCallConvertNode.java
@@ -34,7 +34,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode.LLVMResolvedDirectNativeCallNode;
-import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunction;
 import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
 
@@ -54,8 +53,7 @@ public abstract class LLVMNativeCallConvertNode {
 
         @Override
         public Object executeGeneric(VirtualFrame frame) {
-            long addr = (long) super.executeGeneric(frame);
-            return LLVMAddress.fromLong(addr);
+            return (long) super.executeGeneric(frame);
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/LLVMIntrinsicRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/LLVMIntrinsicRootNode.java
@@ -140,7 +140,7 @@ public abstract class LLVMIntrinsicRootNode extends RootNode {
 
         @Specialization
         public Object execute(LLVMAddress value) {
-            return value;
+            return value.getVal();
         }
 
     }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
@@ -48,8 +48,9 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMIVarBitNode;
 import com.oracle.truffle.llvm.nodes.impl.base.vector.LLVMVectorNode;
+import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToAddressNodeFactory.LLVMI64ToAddressNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI64NodeFactory.LLVMAddressToI64NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVM80BitFloatRetNodeGen;
-import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMAddressRetNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMDoubleRetNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMFloatRetNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMFunctionRetNodeGen;
@@ -63,7 +64,6 @@ import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMStructR
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMVectorRetNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMVoidReturnNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVM80BitFloatArgNodeGen;
-import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMAddressArgNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMDoubleArgNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMDoubleVectorArgNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMFloatArgNodeGen;
@@ -83,7 +83,6 @@ import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMIVarBitArg
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode.LLVMUnresolvedCallNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNode.LLVMVoidCallUnboxNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVM80BitFloatCallUnboxNodeGen;
-import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVMAddressCallUnboxNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVMDoubleCallUnboxNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVMFloatCallUnboxNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVMFunctionCallUnboxNodeGen;
@@ -137,7 +136,7 @@ public final class LLVMFunctionFactory {
                 case X86_FP80:
                     return LLVM80BitFloatRetNodeGen.create((LLVM80BitFloatNode) retValue, retSlot);
                 case ADDRESS:
-                    return LLVMAddressRetNodeGen.create((LLVMAddressNode) retValue, retSlot);
+                    return LLVMI64RetNodeGen.create(LLVMAddressToI64NodeGen.create((LLVMAddressNode) retValue), retSlot);
                 case FUNCTION_ADDRESS:
                     return LLVMFunctionRetNodeGen.create((LLVMFunctionNode) retValue, retSlot);
                 case STRUCT:
@@ -175,7 +174,7 @@ public final class LLVMFunctionFactory {
                 return LLVM80BitFloatArgNodeGen.create(argIndex);
             case ADDRESS:
             case STRUCT:
-                return LLVMAddressArgNodeGen.create(argIndex);
+                return LLVMI64ToAddressNodeGen.create(LLVMI64ArgNodeGen.create(argIndex));
             case FUNCTION_ADDRESS:
                 return LLVMFunctionArgNodeGen.create(argIndex);
             case I1_VECTOR:
@@ -225,7 +224,7 @@ public final class LLVMFunctionFactory {
                 case X86_FP80:
                     return LLVM80BitFloatCallUnboxNodeGen.create(unresolvedCallNode);
                 case ADDRESS:
-                    return LLVMAddressCallUnboxNodeGen.create(unresolvedCallNode);
+                    return LLVMI64ToAddressNodeGen.create(LLVMI64CallUnboxNodeGen.create(unresolvedCallNode));
                 case FUNCTION_ADDRESS:
                     return LLVMFunctionCallUnboxNodeGen.create(unresolvedCallNode);
                 case STRUCT:
@@ -235,6 +234,14 @@ public final class LLVMFunctionFactory {
             }
         }
 
+    }
+
+    public static LLVMExpressionNode createActualParameter(LLVMExpressionNode parameter) {
+        if (parameter instanceof LLVMAddressNode) {
+            return LLVMAddressToI64NodeGen.create((LLVMAddressNode) parameter);
+        } else {
+            return parameter;
+        }
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -302,4 +302,9 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
         return LLVMGetElementPtrFactory.createGetElementPtr((LLVMAddressNode) currentAddress, oneValueNode, currentOffset);
     }
 
+    @Override
+    public LLVMExpressionNode createActualParameter(LLVMExpressionNode parameter) {
+        return LLVMFunctionFactory.createActualParameter(parameter);
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -162,4 +162,13 @@ public interface NodeFactoryFacade {
 
     LLVMExpressionNode createGetElementPtr(LLVMExpressionNode currentAddress, LLVMExpressionNode oneValueNode, int currentOffset);
 
+    /**
+     * This method allows the wrapping of actual arguments to a normal (not intrinsified) function
+     * call.
+     *
+     * @param actualParameter the parameter for a function call
+     * @return a wrapped node or the original parameter
+     */
+    LLVMExpressionNode createActualParameter(LLVMExpressionNode actualParameter);
+
 }

--- a/projects/com.oracle.truffle.llvm.test/tests/c/mixed-function-pointer-calls.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/mixed-function-pointer-calls.c
@@ -1,0 +1,79 @@
+#include <stdio.h>
+#include <math.h>
+
+typedef double (*test_type)(double);
+
+double test1(double val) {
+	return val * 111.5234;
+}
+
+double test2(double val2) {
+	return val2 * 94.5023;
+}
+
+double test3(double val) {
+	return val * 111.5234;
+}
+
+double test4(double val2) {
+	return val2 * 94.5023;
+}
+
+double test5(double val) {
+	return val * 111.5234;
+}
+
+double test6(double val2) {
+	return val2 * 94.5023;
+}
+
+double test7(double val) {
+	return val * 111.5234;
+}
+
+double test8(double val2) {
+	return val2 * 94.5023;
+}
+
+double test9(double val2) {
+	return val2 * 94.5023;
+}
+
+#define SIZE 10
+
+test_type getFunction(int i) {
+	int val = i % SIZE;
+	switch (val) {
+		case 0: return &log2;
+		case 1: return &test1;
+		case 2: return &test2;
+		case 3: return &test3;
+		case 4: return &test4;
+		case 5: return &test5;
+		case 6: return &test6;
+		case 7: return &test7;
+		case 8: return &test8;
+		case 9: return &test9;
+	}
+	return 0;
+}
+
+int callFunction() {
+	double val;
+	int i;
+	test_type func;
+	double currentVal = 2342;
+	for (i = 0; i < 1000; i++) {
+		currentVal = getFunction(i)(currentVal);
+	}
+	return currentVal;	
+}
+
+int main() {
+	int i;
+	int sum = 0;
+	for (i = 0; i < 10000; i++) {
+		sum += callFunction();
+	}
+	return sum;
+}

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -170,17 +170,18 @@ public class LLVM {
             int argParamCount = mainSignature.getLlvmParamTypes().length;
             LLVMGlobalRootNode globalFunction;
             LLVMContext context = module.getContext();
+            // FIXME should create in parser
             if (argParamCount == 0) {
                 globalFunction = LLVMGlobalRootNode.createNoArgumentsMain(context, module.getStaticInits(), originalCallTarget, module.getAllocatedAddresses());
             } else if (argParamCount == 1) {
                 globalFunction = LLVMGlobalRootNode.createArgsCountMain(context, module.getStaticInits(), originalCallTarget, module.getAllocatedAddresses(), args.length + 1);
             } else {
-                LLVMAddress allocatedArgsStartAddress = getArgsAsStringArray(fileSource, args);
+                long allocatedArgsStartAddress = getArgsAsStringArray(fileSource, args).getVal();
                 if (argParamCount == 2) {
                     globalFunction = LLVMGlobalRootNode.createArgsMain(context, module.getStaticInits(), originalCallTarget, module.getAllocatedAddresses(), args.length + 1,
                                     allocatedArgsStartAddress);
                 } else if (argParamCount == THREE_ARGS) {
-                    LLVMAddress posixEnvPointer = LLVMAddress.NULL_POINTER;
+                    long posixEnvPointer = LLVMAddress.NULL_POINTER.getVal();
                     globalFunction = LLVMGlobalRootNode.createArgsEnvMain(context, module.getStaticInits(), originalCallTarget, module.getAllocatedAddresses(), args.length + 1,
                                     allocatedArgsStartAddress,
                                     posixEnvPointer);


### PR DESCRIPTION
Previously, mixed native and Sulong calls in indirect calls (for function pointer calls that exceeded the polymorphic inline cache limit) did not work. 

Previously, native functions in the indirect call node could not receive address arguments. With this change, addresses are passed as long values in function pointer calls, and the Sulong function prologue converts them again to addresses. The native functions can use the long values directly.

The indirect call node simply did not consider native functions and only performed a lookup for Sulong function. With this change, also native functions are considered. To prevent a bailout through too many lookups (of the same function) we now cache the looked up function handles.

I also added a regression test case that stresses mixed Sulong and native function pointer calls.