### PR TITLE
refactor and simplify the passing of arguments to the entry point of a program

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
@@ -35,12 +35,11 @@ import com.oracle.nfi.api.NativeFunctionHandle;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.ExecutionContext;
 import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.llvm.nativeint.NativeLookup;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
-import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.parser.NodeFactoryFacade;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
-import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunction;
 import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
@@ -48,13 +47,13 @@ public class LLVMContext extends ExecutionContext {
 
     private final LLVMFunctionRegistry registry;
 
-    private LLVMNode[] staticInits;
-
-    private LLVMAddress[] deallocations;
-
     private final NativeLookup nativeLookup;
 
     private final LLVMStack stack = new LLVMStack();
+
+    private Object[] mainArguments;
+
+    private Source sourceFile;
 
     public LLVMContext(NodeFactoryFacade facade, LLVMOptimizationConfiguration optimizationConfig) {
         nativeLookup = new NativeLookup(facade);
@@ -66,22 +65,9 @@ public class LLVMContext extends ExecutionContext {
         return LLVMFunctionRegistry.lookup(function);
     }
 
-    public LLVMNode[] getStaticInits() {
-        return staticInits;
-    }
-
-    public LLVMAddress[] getAllocatedGlobalAddresses() {
-        return deallocations;
-    }
-
     public LLVMFunctionRegistry getFunctionRegistry() {
         CompilerAsserts.neverPartOfCompilation();
         return registry;
-    }
-
-    public void setStaticInits(LLVMNode[] staticInits, LLVMAddress[] deallocations) {
-        this.staticInits = staticInits;
-        this.deallocations = deallocations;
     }
 
     public NativeFunctionHandle getNativeHandle(LLVMFunction function, LLVMExpressionNode[] args) {
@@ -98,6 +84,22 @@ public class LLVMContext extends ExecutionContext {
 
     public LLVMStack getStack() {
         return stack;
+    }
+
+    public void setMainArguments(Object[] mainArguments) {
+        this.mainArguments = mainArguments;
+    }
+
+    public Object[] getMainArguments() {
+        return mainArguments;
+    }
+
+    public void setSourceFile(Source sourceFile) {
+        this.sourceFile = sourceFile;
+    }
+
+    public Source getSourceFile() {
+        return sourceFile;
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMLanguage.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMLanguage.java
@@ -56,6 +56,9 @@ public final class LLVMLanguage extends TruffleLanguage<LLVMContext> {
 
     public static LLVMLanguageProvider provider;
 
+    public static final String MAIN_ARGS_KEY = "Sulong Main Args";
+    public static final String LLVM_SOURCE_FILE_KEY = "Sulong Source File";
+
     @Override
     protected LLVMContext createContext(com.oracle.truffle.api.TruffleLanguage.Env env) {
         return provider.createContext(env);

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMMainFunctionReturnValueRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMMainFunctionReturnValueRootNode.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.base;
+
+import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.RootNode;
+import com.oracle.truffle.llvm.types.LLVMIVarBit;
+
+public abstract class LLVMMainFunctionReturnValueRootNode extends RootNode {
+
+    final RootCallTarget rootCallTarget;
+
+    protected LLVMMainFunctionReturnValueRootNode(RootCallTarget rootCallTarget) {
+        super(LLVMLanguage.class, null, new FrameDescriptor());
+        this.rootCallTarget = rootCallTarget;
+    }
+
+    public static class LLVMMainFunctionReturnI1RootNode extends LLVMMainFunctionReturnValueRootNode {
+
+        public LLVMMainFunctionReturnI1RootNode(RootCallTarget rootCallTarget) {
+            super(rootCallTarget);
+        }
+
+        @Override
+        public Object execute(VirtualFrame frame) {
+            return ((Boolean) rootCallTarget.call()).booleanValue() ? 1 : 0;
+        }
+
+    }
+
+    public static class LLVMMainFunctionReturnIVarBitRootNode extends LLVMMainFunctionReturnValueRootNode {
+
+        public LLVMMainFunctionReturnIVarBitRootNode(RootCallTarget rootCallTarget) {
+            super(rootCallTarget);
+        }
+
+        @Override
+        public Object execute(VirtualFrame frame) {
+            return ((LLVMIVarBit) rootCallTarget.call()).getIntValue();
+        }
+
+    }
+
+    public static class LLVMMainFunctionReturnNumberRootNode extends LLVMMainFunctionReturnValueRootNode {
+
+        public LLVMMainFunctionReturnNumberRootNode(RootCallTarget rootCallTarget) {
+            super(rootCallTarget);
+        }
+
+        @Override
+        public Object execute(VirtualFrame frame) {
+            return ((Number) rootCallTarget.call()).intValue();
+        }
+
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
@@ -31,13 +31,16 @@ package com.oracle.truffle.llvm.parser.factories;
 
 import com.intel.llvm.ireditor.types.ResolvedStructType;
 import com.intel.llvm.ireditor.types.ResolvedType;
+import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMStatementNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMMainFunctionReturnValueRootNode;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVM80BitFloatNode;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMDoubleNode;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMFloatNode;
@@ -98,6 +101,7 @@ import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVMVect
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
+import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
 
 public final class LLVMFunctionFactory {
 
@@ -235,6 +239,24 @@ public final class LLVMFunctionFactory {
             }
         }
 
+    }
+
+    public static RootNode createGlobalRootNodeWrapping(RootCallTarget mainCallTarget, LLVMRuntimeType returnType) {
+        switch (returnType) {
+            case I1:
+                return new LLVMMainFunctionReturnValueRootNode.LLVMMainFunctionReturnI1RootNode(mainCallTarget);
+            case I8:
+            case I16:
+            case I32:
+            case I64:
+            case FLOAT:
+            case DOUBLE:
+                return new LLVMMainFunctionReturnValueRootNode.LLVMMainFunctionReturnNumberRootNode(mainCallTarget);
+            case I_VAR_BITWIDTH:
+                return new LLVMMainFunctionReturnValueRootNode.LLVMMainFunctionReturnIVarBitRootNode(mainCallTarget);
+            default:
+                throw new AssertionError(returnType);
+        }
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -38,13 +38,16 @@ import com.intel.llvm.ireditor.lLVM_IR.FunctionDef;
 import com.intel.llvm.ireditor.lLVM_IR.Type;
 import com.intel.llvm.ireditor.types.ResolvedType;
 import com.intel.llvm.ireditor.types.ResolvedVectorType;
+import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMStatementNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMStructWriteNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI1Node;
@@ -52,6 +55,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.base.vector.LLVMI32VectorNode;
 import com.oracle.truffle.llvm.nodes.impl.base.vector.LLVMVectorNode;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMConditionalPhiWriteNode;
+import com.oracle.truffle.llvm.nodes.impl.func.LLVMGlobalRootNode;
 import com.oracle.truffle.llvm.nodes.impl.literals.LLVMAggregateLiteralNode.LLVMEmptyStructLiteralNode;
 import com.oracle.truffle.llvm.nodes.impl.memory.LLVMAddressZeroNode;
 import com.oracle.truffle.llvm.nodes.impl.memory.LLVMAllocInstruction.LLVMAllocaInstruction;
@@ -64,6 +68,8 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
+import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
 
 public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
 
@@ -300,6 +306,14 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     @Override
     public LLVMExpressionNode createGetElementPtr(LLVMExpressionNode currentAddress, LLVMExpressionNode oneValueNode, int currentOffset) {
         return LLVMGetElementPtrFactory.createGetElementPtr((LLVMAddressNode) currentAddress, oneValueNode, currentOffset);
+    }
+
+    public LLVMGlobalRootNode createGlobalRootNode(LLVMNode[] staticInits, RootCallTarget mainCallTarget, LLVMAddress[] allocatedGlobalAddresses, Object... args) {
+        return new LLVMGlobalRootNode(LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0()), staticInits, mainCallTarget, allocatedGlobalAddresses, args);
+    }
+
+    public RootNode createGlobalRootNodeWrapping(RootCallTarget mainCallTarget, LLVMRuntimeType returnType) {
+        return LLVMFunctionFactory.createGlobalRootNodeWrapping(mainCallTarget, returnType);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -126,12 +126,14 @@ import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeUtil;
+import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.llvm.nativeint.NativeLookup;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionRegistry;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMMetadataNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMStatementNode;
@@ -180,8 +182,10 @@ import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
 import com.oracle.truffle.llvm.types.LLVMMetadata;
 import com.oracle.truffle.llvm.types.memory.LLVMHeap;
+import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
 /**
@@ -218,11 +222,77 @@ public class LLVMVisitor implements LLVMParserRuntime {
         LLVMTypeHelper.setParserRuntime(this);
     }
 
+    public RootCallTarget getMain(Model model, NodeFactoryFacade facade) {
+        visit(model, facade);
+        currentContext.getFunctionRegistry();
+        LLVMFunction mainFunction = LLVMFunction.createFromName("@main");
+        RootCallTarget mainCallTarget = LLVMFunctionRegistry.lookup(mainFunction);
+        int argParamCount = mainFunction.getLlvmParamTypes().length;
+        RootNode globalFunction;
+        LLVMNode[] staticInits = globalNodes.toArray(new LLVMNode[globalNodes.size()]);
+        int argsCount = currentContext.getMainArguments().length + 1;
+        if (argParamCount == 0) {
+            globalFunction = factoryFacade.createGlobalRootNode(staticInits, mainCallTarget, deallocations);
+        } else {
+            if (argParamCount == 1) {
+                globalFunction = factoryFacade.createGlobalRootNode(staticInits, mainCallTarget, deallocations, argsCount);
+            } else {
+                Object[] args = new Object[argsCount];
+                args[0] = currentContext.getSourceFile();
+                System.arraycopy(currentContext.getMainArguments(), 0, args, 1, currentContext.getMainArguments().length);
+                LLVMAddress allocatedArgsStartAddress = getArgsAsStringArray(args);
+                // Checkstyle: stop magic number check
+                if (argParamCount == 2) {
+                    globalFunction = factoryFacade.createGlobalRootNode(staticInits, mainCallTarget, deallocations, argsCount, allocatedArgsStartAddress);
+                } else if (argParamCount == 3) {
+                    LLVMAddress posixEnvPointer = LLVMAddress.NULL_POINTER;
+                    globalFunction = factoryFacade.createGlobalRootNode(staticInits, mainCallTarget, deallocations, argsCount, allocatedArgsStartAddress, posixEnvPointer);
+                } else {
+                    throw new AssertionError(argParamCount);
+                }
+                // Checkstyle: resume magic number check
+            }
+        }
+        RootCallTarget wrappedCallTarget = Truffle.getRuntime().createCallTarget(wrapMainFunction(Truffle.getRuntime().createCallTarget(globalFunction)));
+        return wrappedCallTarget;
+    }
+
+    private RootNode wrapMainFunction(RootCallTarget mainCallTarget) {
+        LLVMFunction mainSignature = LLVMFunction.createFromName("@main");
+        LLVMRuntimeType returnType = mainSignature.getLlvmReturnType();
+        return factoryFacade.createGlobalRootNodeWrapping(mainCallTarget, returnType);
+    }
+
+    private static LLVMAddress getArgsAsStringArray(Object... args) {
+        String[] stringArgs = getStringArgs(args);
+        int argsMemory = stringArgs.length * LLVMAddress.WORD_LENGTH_BIT / Byte.SIZE;
+        LLVMAddress allocatedArgsStartAddress = LLVMHeap.allocateMemory(argsMemory);
+        LLVMAddress allocatedArgs = allocatedArgsStartAddress;
+        for (int i = 0; i < stringArgs.length; i++) {
+            String string = stringArgs[i];
+            LLVMAddress allocatedCString = LLVMHeap.allocateCString(string);
+            LLVMMemory.putAddress(allocatedArgs, allocatedCString);
+            allocatedArgs = allocatedArgs.increment(LLVMAddress.WORD_LENGTH_BIT / Byte.SIZE);
+        }
+        return allocatedArgsStartAddress;
+    }
+
+    private static String[] getStringArgs(Object... args) {
+        String[] stringArgs = new String[args.length];
+        for (int i = 0; i < args.length; i++) {
+            stringArgs[i] = args[i].toString();
+            if (stringArgs[i] == null) {
+                throw new AssertionError();
+            }
+        }
+        return stringArgs;
+    }
+
     public List<LLVMFunction> visit(Model model, NodeFactoryFacade facade) {
         this.factoryFacade = facade;
         List<EObject> objects = model.eContents();
         List<LLVMFunction> functions = new ArrayList<>();
-        List<LLVMNode> globalNodes = new ArrayList<>();
+        globalNodes = new ArrayList<>();
         List<GlobalVariable> staticVars = new ArrayList<>();
         functionToLabelMapping = new HashMap<>();
         setTargetInfo(objects);
@@ -264,8 +334,7 @@ public class LLVMVisitor implements LLVMParserRuntime {
         currentContext.getFunctionRegistry().register(functionCallTargets);
         List<LLVMNode> globalVarNodes = addGlobalVars(this, staticVars);
         globalNodes.addAll(globalVarNodes);
-        LLVMAddress[] deallocations = globalDeallocations.toArray(new LLVMAddress[globalDeallocations.size()]);
-        currentContext.setStaticInits(globalNodes.toArray(new LLVMNode[globalNodes.size()]), deallocations);
+        deallocations = globalDeallocations.toArray(new LLVMAddress[globalDeallocations.size()]);
         return functions;
     }
 
@@ -286,11 +355,11 @@ public class LLVMVisitor implements LLVMParserRuntime {
     }
 
     private List<LLVMNode> addGlobalVars(LLVMVisitor visitor, List<GlobalVariable> globalVariables) {
-        List<LLVMNode> globalNodes = new ArrayList<>();
+        List<LLVMNode> globalVarNodes = new ArrayList<>();
         for (GlobalVariable globalVar : globalVariables) {
             LLVMNode globalVarWrite = visitor.visitGlobalVariable(globalVar);
             if (globalVarWrite != null) {
-                globalNodes.add(globalVarWrite);
+                globalVarNodes.add(globalVarWrite);
             }
             if (globalVar.getName().equals("@llvm.global_ctors")) {
                 ResolvedArrayType type = (ResolvedArrayType) typeResolver.resolve(globalVar.getType());
@@ -309,13 +378,13 @@ public class LLVMVisitor implements LLVMParserRuntime {
                     LLVMAddressNode functionLoadTarget = (LLVMAddressNode) factoryFacade.createGetElementPtr(LLVMBaseType.I32, loadedStruct, oneLiteralNode, indexedTypeLength);
                     LLVMFunctionNode loadedFunction = (LLVMFunctionNode) factoryFacade.createLoad(functionType, functionLoadTarget);
                     LLVMNode functionCall = factoryFacade.createFunctionCall(loadedFunction, new LLVMExpressionNode[0], LLVMBaseType.VOID);
-                    globalNodes.add(functionCall);
+                    globalVarNodes.add(functionCall);
                 }
             } else if (globalVar.getName().equals("llvm.global_dtors")) {
                 throw new AssertionError("destructors not yet supported!");
             }
         }
-        return globalNodes;
+        return globalVarNodes;
     }
 
     private static void visitTargetInfo(TargetInfo object) {
@@ -552,6 +621,10 @@ public class LLVMVisitor implements LLVMParserRuntime {
     }
 
     public static DataSpecConverter layoutConverter;
+
+    private LLVMAddress[] deallocations;
+
+    private List<LLVMNode> globalNodes;
 
     private List<LLVMNode> visitBasicBlock(BasicBlock basicBlock) {
         List<LLVMNode> statements = new ArrayList<>(basicBlock.getInstructions().size());

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -38,9 +38,11 @@ import com.intel.llvm.ireditor.lLVM_IR.FunctionDef;
 import com.intel.llvm.ireditor.lLVM_IR.Type;
 import com.intel.llvm.ireditor.types.ResolvedType;
 import com.intel.llvm.ireditor.types.ResolvedVectorType;
+import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.parser.instructions.LLVMArithmeticInstructionType;
@@ -48,6 +50,8 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
+import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
 
 /**
  * This interface decouples the parser and the concrete implementation of the nodes by only making
@@ -161,5 +165,25 @@ public interface NodeFactoryFacade {
     LLVMExpressionNode createEmptyStructLiteralNode(LLVMExpressionNode alloca, int byteSize);
 
     LLVMExpressionNode createGetElementPtr(LLVMExpressionNode currentAddress, LLVMExpressionNode oneValueNode, int currentOffset);
+
+    /**
+     * Creates the global root (e.g., the main function in C).
+     *
+     * @param staticInits
+     * @param mainCallTarget
+     * @param allocatedGlobalAddresses
+     * @param args
+     * @return the global root
+     */
+    RootNode createGlobalRootNode(LLVMNode[] staticInits, RootCallTarget mainCallTarget, LLVMAddress[] allocatedGlobalAddresses, Object... args);
+
+    /**
+     * Wraps the global root (e.g., the main function in C) to convert its result.
+     *
+     * @param mainCallTarget
+     * @param returnType
+     * @return the wrapped global root
+     */
+    RootNode createGlobalRootNodeWrapping(RootCallTarget mainCallTarget, LLVMRuntimeType returnType);
 
 }


### PR DESCRIPTION
Previously, the logic for arguments passing and the construction of nodes was in the main LLVM class to work around the PolgylotEngine. Since https://github.com/graalvm/truffle/pull/10 it is possible to configure the PolyglotEngine directly with key and values for a MIME type. This change uses this mechanism and moved the node construction logic into the parser and facade.