### PR TITLE
fix env variables to build DragonEgg for Arch Linux

### DIFF
--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -143,7 +143,7 @@ def hasDragoneggGCCInstalled():
 
 # platform independent
 def pullInstallDragonEgg(args=None):
-    """downloads and installs dragonegg (assumes that GCC 4.6 is on the path)"""
+    """downloads and installs dragonegg (assumes that gcc-4.6 and g++-4.6 are installed)"""
     if hasDragoneggGCCInstalled():
         toolDir = join(_toolDir, "tools/dragonegg")
         mx.ensure_dir_exists(toolDir)
@@ -152,6 +152,8 @@ def pullInstallDragonEgg(args=None):
         tar(localPath, toolDir)
         os.remove(localPath)
         os.environ['GCC'] = 'gcc-4.6'
+        os.environ['CXX'] = 'g++-4.6'
+        os.environ['CC'] = 'gcc-4.6'
         os.environ['LLVM_CONFIG'] = _toolDir + 'tools/llvm/bin/llvm-config'
         compileCommand = ['make']
         return mx.run(compileCommand, cwd=_toolDir + 'tools/dragonegg/dragonegg-3.2.src')


### PR DESCRIPTION
One of our students reported that mx failed installing DragonEgg. To fix the problem, he executed `GCC=gcc-4.6 CXX=g++-4.6 CC=gcc-4.6 mx su-tests` where `su-tests` downloads and builds DragonEgg on its first execution.

Previously, we already set the GCC environment variable. This change additionally sets CXX and CC. I could not verify the changes since I use Ubuntu.

This change is also related to https://github.com/graalvm/sulong/issues/21.