### PR TITLE
Indirect native calls

### DIFF
--- a/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
+++ b/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
@@ -61,7 +61,7 @@ public class NativeLookup {
 
     private final Map<LLVMFunction, Integer> nativeFunctionLookupStats;
 
-    private static final Map<LLVMFunction, NativeFunctionHandle> cachedNativeFunctions = new WeakHashMap<>();
+    private final Map<LLVMFunction, NativeFunctionHandle> cachedNativeFunctions = new WeakHashMap<>();
 
     private final NodeFactoryFacade facade;
 

--- a/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
+++ b/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
@@ -32,6 +32,7 @@ package com.oracle.truffle.llvm.nativeint;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.WeakHashMap;
 
 import com.oracle.graal.truffle.hotspot.nfi.HotSpotNativeFunctionInterface;
 import com.oracle.graal.truffle.hotspot.nfi.HotSpotNativeFunctionPointer;
@@ -51,12 +52,16 @@ import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
 
 public class NativeLookup {
 
+    static final int LOOKUP_FAILURE = 0;
+
     // TODO lazy loading
     private static final NativeFunctionInterface nfi = NativeFunctionInterfaceRuntime.getNativeFunctionInterface();
 
-    static final int LOOKUP_FAILURE = 0;
+    private static final NativeLibraryHandle[] libraryHandles = getNativeFunctionHandles();
 
     private final Map<LLVMFunction, Integer> nativeFunctionLookupStats;
+
+    private final static Map<LLVMFunction, NativeFunctionHandle> cachedNativeFunctions = new WeakHashMap<>();
 
     private final NodeFactoryFacade facade;
 
@@ -76,12 +81,11 @@ public class NativeLookup {
             HotSpotNativeFunctionInterface face = (HotSpotNativeFunctionInterface) nfi;
             method.setAccessible(true);
             HotSpotNativeLibraryHandle handle;
-            NativeLibraryHandle[] nativeFunctionHandles = getNativeFunctionHandles();
-            if (nativeFunctionHandles.length == 0) {
+            if (libraryHandles.length == 0) {
                 handle = new HotSpotNativeLibraryHandle("", 0);
                 return ((HotSpotNativeFunctionPointer) method.invoke(face, name, handle, false)).getRawValue();
             } else {
-                for (NativeLibraryHandle libraryHandle : nativeFunctionHandles) {
+                for (NativeLibraryHandle libraryHandle : libraryHandles) {
                     try {
                         HotSpotNativeFunctionPointer hotSpotPointer = (HotSpotNativeFunctionPointer) method.invoke(face, name, libraryHandle, false);
                         if (hotSpotPointer != null) {
@@ -113,9 +117,19 @@ public class NativeLookup {
 
     public NativeFunctionHandle getNativeHandle(LLVMFunction function, LLVMExpressionNode[] args) {
         CompilerAsserts.neverPartOfCompilation();
-        if (nfi == null) {
-            throw new IllegalStateException("want to call native function but VM does not support the native function interface!");
+        if (cachedNativeFunctions.containsKey(function)) {
+            return cachedNativeFunctions.get(function);
+        } else {
+            NativeFunctionHandle handle = uncachedGetNativeFunctionHandle(function, args);
+            // FIXME we should also cash var args!
+            if (!function.isVarArgs()) {
+                cachedNativeFunctions.put(function, handle);
+            }
+            return handle;
         }
+    }
+
+    private NativeFunctionHandle uncachedGetNativeFunctionHandle(LLVMFunction function, LLVMExpressionNode[] args) {
         Class<?> retType = getJavaClass(function.getLlvmReturnType());
         Class<?>[] paramTypes = getJavaClassses(args, function.getLlvmParamTypes());
         String functionName = function.getName().substring(1);
@@ -126,8 +140,7 @@ public class NativeLookup {
         if (LLVMOptions.getDynamicLibraryPaths() == null) {
             functionHandle = nfi.getFunctionHandle(functionName, retType, paramTypes);
         } else {
-            NativeLibraryHandle[] handles = getNativeFunctionHandles();
-            functionHandle = nfi.getFunctionHandle(handles, functionName, retType, paramTypes);
+            functionHandle = nfi.getFunctionHandle(libraryHandles, functionName, retType, paramTypes);
         }
         if (LLVMOptions.printNativeCallStats() && functionHandle != null) {
             recordNativeFunctionCallSite(function);

--- a/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
+++ b/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
@@ -61,7 +61,7 @@ public class NativeLookup {
 
     private final Map<LLVMFunction, Integer> nativeFunctionLookupStats;
 
-    private final static Map<LLVMFunction, NativeFunctionHandle> cachedNativeFunctions = new WeakHashMap<>();
+    private static final Map<LLVMFunction, NativeFunctionHandle> cachedNativeFunctions = new WeakHashMap<>();
 
     private final NodeFactoryFacade facade;
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
@@ -62,7 +62,7 @@ public class LLVMContext extends ExecutionContext {
     }
 
     public RootCallTarget getFunction(LLVMFunction function) {
-        return LLVMFunctionRegistry.lookup(function);
+        return registry.lookup(function);
     }
 
     public LLVMFunctionRegistry getFunctionRegistry() {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
@@ -117,7 +117,7 @@ public class LLVMFunctionRegistry {
     /**
      * Maps a function index (see {@link LLVMFunction#getFunctionIndex()} to a call target.
      */
-    @CompilationFinal private static RootCallTarget[] functionPtrCallTargetMap;
+    @CompilationFinal private RootCallTarget[] functionPtrCallTargetMap;
 
     /**
      * Looks up the call target for a specific function. The lookup may return <code>null</code> if
@@ -126,9 +126,14 @@ public class LLVMFunctionRegistry {
      * @param function the function
      * @return the call target, <code>null</code> if not found.
      */
-    public static RootCallTarget lookup(LLVMFunction function) {
-        RootCallTarget result = functionPtrCallTargetMap[function.getFunctionIndex()];
-        return result;
+    public RootCallTarget lookup(LLVMFunction function) {
+        int functionIndex = function.getFunctionIndex();
+        if (functionIndex >= 0 && functionIndex < functionPtrCallTargetMap.length) {
+            RootCallTarget result = functionPtrCallTargetMap[functionIndex];
+            return result;
+        } else {
+            return null;
+        }
     }
 
     public void register(Map<LLVMFunction, RootCallTarget> functionCallTargets) {
@@ -201,7 +206,7 @@ public class LLVMFunctionRegistry {
         return functionRoot;
     }
 
-    private static void addToFunctionMap(LLVMFunction function, RootCallTarget callTarget) {
+    private void addToFunctionMap(LLVMFunction function, RootCallTarget callTarget) {
         assert functionPtrCallTargetMap[function.getFunctionIndex()] == null;
         functionPtrCallTargetMap[function.getFunctionIndex()] = callTarget;
     }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMCastsFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMCastsFactory.java
@@ -58,6 +58,7 @@ import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI16To
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI16ToDoubleZeroExtNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI32ToDoubleNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI32ToDoubleUnsignedNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI64ToDoubleBitNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI64ToDoubleNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI64ToDoubleUnsignedNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI8ToDoubleNodeGen;
@@ -114,6 +115,7 @@ import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI64NodeFactory.LLVMI8ToI64Z
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI64NodeFactory.LLVMIVarToI64NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI64NodeFactory.LLVMIVarToI64ZeroExtNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVM80BitFloatToI8NodeGen;
+import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVMAddressToI8NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVMDoubleToI8NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVMFloatToI8NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVMI16ToI8NodeGen;
@@ -298,6 +300,13 @@ public final class LLVMCastsFactory {
                 default:
                     throw new AssertionError(targetType + " " + conv);
             }
+        } else if (conv == LLVMConversionType.BITCAST) {
+            switch (targetType) {
+                case I32:
+                    return LLVMFloatToI32NodeGen.create(fromNode);
+                default:
+                    throw new AssertionError(targetType);
+            }
         } else {
             throw new AssertionError(targetType + " " + conv);
         }
@@ -355,6 +364,8 @@ public final class LLVMCastsFactory {
         }
         if (hasJavaCastSemantics() || conv == LLVMConversionType.BITCAST) {
             switch (targetType) {
+                case I8:
+                    return LLVMAddressToI8NodeGen.create(fromNode);
                 case I32:
                     return LLVMAddressToI32NodeGen.create(fromNode);
                 case I64:
@@ -409,6 +420,11 @@ public final class LLVMCastsFactory {
                     return LLVMI64ToAddressNodeGen.create(fromNode);
                 default:
                     throw new AssertionError(targetType + " " + conv);
+            }
+        } else if (conv == LLVMConversionType.BITCAST) {
+            switch (targetType) {
+                case DOUBLE:
+                    return LLVMI64ToDoubleBitNodeGen.create(fromNode);
             }
         }
         throw new AssertionError(targetType + " " + conv);

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMCastsFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMCastsFactory.java
@@ -58,7 +58,6 @@ import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI16To
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI16ToDoubleZeroExtNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI32ToDoubleNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI32ToDoubleUnsignedNodeGen;
-import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI64ToDoubleBitNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI64ToDoubleNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI64ToDoubleUnsignedNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI8ToDoubleNodeGen;
@@ -115,7 +114,6 @@ import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI64NodeFactory.LLVMI8ToI64Z
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI64NodeFactory.LLVMIVarToI64NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI64NodeFactory.LLVMIVarToI64ZeroExtNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVM80BitFloatToI8NodeGen;
-import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVMAddressToI8NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVMDoubleToI8NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVMFloatToI8NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVMI16ToI8NodeGen;
@@ -300,13 +298,6 @@ public final class LLVMCastsFactory {
                 default:
                     throw new AssertionError(targetType + " " + conv);
             }
-        } else if (conv == LLVMConversionType.BITCAST) {
-            switch (targetType) {
-                case I32:
-                    return LLVMFloatToI32NodeGen.create(fromNode);
-                default:
-                    throw new AssertionError(targetType);
-            }
         } else {
             throw new AssertionError(targetType + " " + conv);
         }
@@ -364,8 +355,6 @@ public final class LLVMCastsFactory {
         }
         if (hasJavaCastSemantics() || conv == LLVMConversionType.BITCAST) {
             switch (targetType) {
-                case I8:
-                    return LLVMAddressToI8NodeGen.create(fromNode);
                 case I32:
                     return LLVMAddressToI32NodeGen.create(fromNode);
                 case I64:
@@ -420,11 +409,6 @@ public final class LLVMCastsFactory {
                     return LLVMI64ToAddressNodeGen.create(fromNode);
                 default:
                     throw new AssertionError(targetType + " " + conv);
-            }
-        } else if (conv == LLVMConversionType.BITCAST) {
-            switch (targetType) {
-                case DOUBLE:
-                    return LLVMI64ToDoubleBitNodeGen.create(fromNode);
             }
         }
         throw new AssertionError(targetType + " " + conv);

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -133,7 +133,6 @@ import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
-import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionRegistry;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMMetadataNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMStatementNode;
@@ -226,7 +225,7 @@ public class LLVMVisitor implements LLVMParserRuntime {
         visit(model, facade);
         currentContext.getFunctionRegistry();
         LLVMFunction mainFunction = LLVMFunction.createFromName("@main");
-        RootCallTarget mainCallTarget = LLVMFunctionRegistry.lookup(mainFunction);
+        RootCallTarget mainCallTarget = currentContext.getFunctionRegistry().lookup(mainFunction);
         int argParamCount = mainFunction.getLlvmParamTypes().length;
         RootNode globalFunction;
         LLVMNode[] staticInits = globalNodes.toArray(new LLVMNode[globalNodes.size()]);

--- a/projects/com.oracle.truffle.llvm.test/tests/c/polymorphic-native-function-pointers1.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/polymorphic-native-function-pointers1.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <math.h>
+
+typedef double (*test_type)(double);
+
+#define SIZE 4
+
+test_type getFunction(int i) {
+	int val = i % SIZE;
+	switch (val) {
+		case 0: return &log2;
+		case 1: return &floor;
+		case 2: return &fabs;
+		case 3: return &ceil;
+	}
+	return 0;
+}
+
+int callFunction() {
+	double val;
+	int i;
+	test_type func;
+	double currentVal = 2342;
+	for (i = 0; i < 1000; i++) {
+		currentVal = getFunction(i)(currentVal);
+	}
+	return currentVal;	
+}
+
+int main() {
+	int i;
+	int sum = 0;
+	for (i = 0; i < 1000; i++) {
+		sum += callFunction();
+	}
+	return sum;
+}

--- a/projects/com.oracle.truffle.llvm.test/tests/c/polymorphic-native-function-pointers1.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/polymorphic-native-function-pointers1.c
@@ -22,7 +22,7 @@ int callFunction() {
 	test_type func;
 	double currentVal = 2342;
 	for (i = 0; i < 1000; i++) {
-		currentVal = getFunction(i)(currentVal);
+		currentVal = getFunction(i)(currentVal) > 4353423;
 	}
 	return currentVal;	
 }
@@ -33,5 +33,5 @@ int main() {
 	for (i = 0; i < 1000; i++) {
 		sum += callFunction();
 	}
-	return sum;
+	return sum == 0;
 }

--- a/projects/com.oracle.truffle.llvm.test/tests/c/polymorphic-native-function-pointers2.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/polymorphic-native-function-pointers2.c
@@ -40,5 +40,5 @@ int main() {
 	for (i = 0; i < 1000; i++) {
 		sum += callFunction();
 	}
-	return sum;
+	return sum == 2000000;
 }

--- a/projects/com.oracle.truffle.llvm.test/tests/c/polymorphic-native-function-pointers2.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/polymorphic-native-function-pointers2.c
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include <ctype.h>
+
+typedef int (*test_type)(int c);
+
+#define SIZE 4
+
+test_type getFunction(int i) {
+	int val = i % SIZE;
+	switch (val) {
+		case 0: return &isalnum;
+		case 1: return &isalpha;
+		case 2: return &iscntrl;
+		case 3: return &isdigit;
+		case 4: return &isgraph;
+		case 5: return &islower;
+		case 6: return &isprint;
+		case 7: return &ispunct;
+		case 8: return &isspace;
+		case 9: return &isupper;
+		case 10: return &isxdigit;
+	}
+	return 0;
+}
+
+int callFunction() {
+	double val;
+	int i;
+	test_type func;
+	double currentVal = 0;
+	for (i = 0; i < 1000; i++) {
+		currentVal += getFunction(i)(i % 2 == 0 ? 'a' : ' ');
+	}
+	return currentVal;	
+}
+
+int main() {
+	int i;
+	int sum = 0;
+	for (i = 0; i < 1000; i++) {
+		sum += callFunction();
+	}
+	return sum;
+}

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunction.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunction.java
@@ -166,7 +166,6 @@ public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunctio
 
     private static int getFunctionIndex(LLVMAddress addr) {
         long functionAddr = addr.getVal() - FUNCTION_START_ADDR;
-        assert functionAddr >= 0 && functionAddr < getNumberRegisteredFunctions();
         return (int) functionAddr;
     }
 

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunction.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunction.java
@@ -187,4 +187,32 @@ public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunctio
         return getName().compareTo(o.getName());
     }
 
+    @Override
+    public int hashCode() {
+        return getName().hashCode() + 11 * getLlvmParamTypes().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof LLVMFunction)) {
+            return false;
+        } else {
+            LLVMFunction other = (LLVMFunction) obj;
+            if (!getName().equals(other.getName())) {
+                return false;
+            } else if (!getLlvmReturnType().equals(other.getLlvmReturnType())) {
+                return false;
+            } else if (getLlvmParamTypes().length != other.getLlvmParamTypes().length) {
+                return false;
+            } else {
+                for (int i = 0; i < getLlvmParamTypes().length; i++) {
+                    if (!getLlvmParamTypes()[i].equals(other.getLlvmParamTypes()[i])) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
The indirect call node previously did not consider native functions and only performed a lookup for Sulong functions. With this change, also native functions are considered. To prevent a bailout through too many lookups (of the same function) we now cache the looked up function handles.

I added two different regression tests to lower the probability that we intrinsify all the used native functions with Java equivalents.