### PR TITLE
implement some missing casts produced by the GVN pass

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToDoubleNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToDoubleNode.java
@@ -130,6 +130,15 @@ public abstract class LLVMToDoubleNode extends LLVMDoubleNode {
         }
     }
 
+    @NodeChild(value = "fromNode", type = LLVMI64Node.class)
+    public abstract static class LLVMI64ToDoubleBitNode extends LLVMToDoubleNode {
+
+        @Specialization
+        public double executeDouble(long from) {
+            return Double.longBitsToDouble(from);
+        }
+    }
+
     @NodeChild(value = "fromNode", type = LLVMFloatNode.class)
     public abstract static class LLVMFloatToDoubleNode extends LLVMToDoubleNode {
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI32Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI32Node.java
@@ -148,6 +148,15 @@ public abstract class LLVMToI32Node extends LLVMI32Node {
         }
     }
 
+    @NodeChild(value = "fromNode", type = LLVMFloatNode.class)
+    public abstract static class LLVMFloatToI32BitNode extends LLVMToI32Node {
+
+        @Specialization
+        public int executeI32(float from) {
+            return Float.floatToIntBits(from);
+        }
+    }
+
     @NodeChild(value = "fromNode", type = LLVMDoubleNode.class)
     public abstract static class LLVMDoubleToI32Node extends LLVMToI32Node {
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI8Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI8Node.java
@@ -31,6 +31,7 @@ package com.oracle.truffle.llvm.nodes.impl.cast;
 
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVM80BitFloatNode;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMDoubleNode;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMFloatNode;
@@ -40,6 +41,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMIVarBitNode;
+import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 
@@ -123,6 +125,15 @@ public abstract class LLVMToI8Node extends LLVMI8Node {
         @Specialization
         public byte executeI8(LLVM80BitFloat from) {
             return from.getByteValue();
+        }
+    }
+
+    @NodeChild(value = "fromNode", type = LLVMAddressNode.class)
+    public abstract static class LLVMAddressToI8Node extends LLVMToI8Node {
+
+        @Specialization
+        public byte executeI8(LLVMAddress from) {
+            return (byte) from.getVal();
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMCastsFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMCastsFactory.java
@@ -58,6 +58,7 @@ import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI16To
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI16ToDoubleZeroExtNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI32ToDoubleNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI32ToDoubleUnsignedNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI64ToDoubleBitNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI64ToDoubleNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI64ToDoubleUnsignedNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToDoubleNodeFactory.LLVMI8ToDoubleNodeGen;
@@ -114,6 +115,7 @@ import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI64NodeFactory.LLVMI8ToI64Z
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI64NodeFactory.LLVMIVarToI64NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI64NodeFactory.LLVMIVarToI64ZeroExtNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVM80BitFloatToI8NodeGen;
+import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVMAddressToI8NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVMDoubleToI8NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVMFloatToI8NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI8NodeFactory.LLVMI16ToI8NodeGen;
@@ -298,6 +300,13 @@ public final class LLVMCastsFactory {
                 default:
                     throw new AssertionError(targetType + " " + conv);
             }
+        } else if (conv == LLVMConversionType.BITCAST) {
+            switch (targetType) {
+                case I32:
+                    return LLVMFloatToI32NodeGen.create(fromNode);
+                default:
+                    throw new AssertionError(targetType);
+            }
         } else {
             throw new AssertionError(targetType + " " + conv);
         }
@@ -355,6 +364,8 @@ public final class LLVMCastsFactory {
         }
         if (hasJavaCastSemantics() || conv == LLVMConversionType.BITCAST) {
             switch (targetType) {
+                case I8:
+                    return LLVMAddressToI8NodeGen.create(fromNode);
                 case I32:
                     return LLVMAddressToI32NodeGen.create(fromNode);
                 case I64:
@@ -409,6 +420,11 @@ public final class LLVMCastsFactory {
                     return LLVMI64ToAddressNodeGen.create(fromNode);
                 default:
                     throw new AssertionError(targetType + " " + conv);
+            }
+        } else if (conv == LLVMConversionType.BITCAST) {
+            switch (targetType) {
+                case DOUBLE:
+                    return LLVMI64ToDoubleBitNodeGen.create(fromNode);
             }
         }
         throw new AssertionError(targetType + " " + conv);

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMCastsFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMCastsFactory.java
@@ -425,6 +425,8 @@ public final class LLVMCastsFactory {
             switch (targetType) {
                 case DOUBLE:
                     return LLVMI64ToDoubleBitNodeGen.create(fromNode);
+                default:
+                    throw new AssertionError(targetType);
             }
         }
         throw new AssertionError(targetType + " " + conv);


### PR DESCRIPTION
This change implements some casts produced by opt's GVN pass. The pass also produces some vector comparisons that Sulong does not implement yet, so I do not have test cases yet.