### PR TITLE
move phi write nodes into terminator instruction nodes

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/control/LLVMBrUnconditionalNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/control/LLVMBrUnconditionalNode.java
@@ -29,17 +29,29 @@
  */
 package com.oracle.truffle.llvm.nodes.impl.control;
 
-import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMStatementNode;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI1Node;
 
-public abstract class LLVMBrUnconditionalNode extends LLVMStatementNode {
+@NodeChild(type = LLVMI1Node.class)
+public class LLVMBrUnconditionalNode extends LLVMStatementNode {
 
-    public LLVMBrUnconditionalNode(int trueSuccessor) {
+    @Children private final LLVMNode[] phiWrites;
+
+    public LLVMBrUnconditionalNode(int trueSuccessor, LLVMNode[] phiWrites) {
         super(trueSuccessor);
+        this.phiWrites = phiWrites;
     }
 
-    @Specialization
-    public int executeGetSuccessorIndex() {
+    @ExplodeLoop
+    @Override
+    public int executeGetSuccessorIndex(VirtualFrame frame) {
+        for (LLVMNode node : phiWrites) {
+            node.executeVoid(frame);
+        }
         return DEFAULT_SUCCESSOR;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMBranchFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMBranchFactory.java
@@ -34,7 +34,7 @@ import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMStatementNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI1Node;
-import com.oracle.truffle.llvm.nodes.impl.control.LLVMBrUnconditionalNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.control.LLVMBrUnconditionalNode;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMConditionalBranchNodeFactory;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMConditionalBranchNodeFactory.LLVMBrConditionalInjectionNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMIndirectBranchNode;
@@ -42,20 +42,21 @@ import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 
 public class LLVMBranchFactory {
 
-    public static LLVMNode createIndirectBranch(LLVMExpressionNode value, int[] labelTargets) {
-        return new LLVMIndirectBranchNode((LLVMAddressNode) value, labelTargets);
+    public static LLVMNode createIndirectBranch(LLVMExpressionNode value, int[] labelTargets, LLVMNode[] phiWrites) {
+        return new LLVMIndirectBranchNode((LLVMAddressNode) value, labelTargets, phiWrites);
     }
 
-    public static LLVMStatementNode createConditionalBranch(LLVMParserRuntime runtime, int trueIndex, int falseIndex, LLVMExpressionNode conditionNode) {
+    public static LLVMStatementNode createConditionalBranch(LLVMParserRuntime runtime, int trueIndex, int falseIndex, LLVMExpressionNode conditionNode, LLVMNode[] truePhiWriteNodes,
+                    LLVMNode[] falsePhiWriteNodes) {
         if (runtime.getOptimizationConfiguration().injectBranchProbabilitiesForConditionalBranch()) {
-            return LLVMBrConditionalInjectionNodeGen.create(trueIndex, falseIndex, (LLVMI1Node) conditionNode);
+            return LLVMBrConditionalInjectionNodeGen.create(trueIndex, falseIndex, truePhiWriteNodes, falsePhiWriteNodes, (LLVMI1Node) conditionNode);
         } else {
-            return LLVMConditionalBranchNodeFactory.LLVMBrConditionalNodeGen.create(trueIndex, falseIndex, (LLVMI1Node) conditionNode);
+            return LLVMConditionalBranchNodeFactory.LLVMBrConditionalNodeGen.create(trueIndex, falseIndex, truePhiWriteNodes, falsePhiWriteNodes, (LLVMI1Node) conditionNode);
         }
     }
 
-    public static LLVMStatementNode createUnconditionalBranch(int unconditionalIndex) {
-        return LLVMBrUnconditionalNodeGen.create(unconditionalIndex);
+    public static LLVMStatementNode createUnconditionalBranch(int unconditionalIndex, LLVMNode[] phiWrites) {
+        return new LLVMBrUnconditionalNode(unconditionalIndex, phiWrites);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMSwitchFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMSwitchFactory.java
@@ -32,6 +32,7 @@ package com.oracle.truffle.llvm.parser.factories;
 import java.util.Arrays;
 
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
+import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMStatementNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
@@ -43,17 +44,18 @@ import com.oracle.truffle.llvm.parser.LLVMBaseType;
 
 public class LLVMSwitchFactory {
 
-    public static LLVMStatementNode createSwitch(LLVMExpressionNode cond, int defaultLabel, int[] otherLabels, LLVMExpressionNode[] cases, LLVMBaseType llvmType) {
+    public static LLVMStatementNode createSwitch(LLVMExpressionNode cond, int defaultLabel, int[] otherLabels, LLVMExpressionNode[] cases,
+                    LLVMBaseType llvmType, LLVMNode[] phiWriteNodes) {
         switch (llvmType) {
             case I8:
                 LLVMI8Node[] i8Cases = Arrays.copyOf(cases, cases.length, LLVMI8Node[].class);
-                return new LLVMI8SwitchNode((LLVMI8Node) cond, i8Cases, otherLabels, defaultLabel);
+                return new LLVMI8SwitchNode((LLVMI8Node) cond, i8Cases, otherLabels, defaultLabel, phiWriteNodes);
             case I32:
                 LLVMI32Node[] i32Cases = Arrays.copyOf(cases, cases.length, LLVMI32Node[].class);
-                return new LLVMI32SwitchNode((LLVMI32Node) cond, i32Cases, otherLabels, defaultLabel);
+                return new LLVMI32SwitchNode((LLVMI32Node) cond, i32Cases, otherLabels, defaultLabel, phiWriteNodes);
             case I64:
                 LLVMI64Node[] i64Cases = Arrays.copyOf(cases, cases.length, LLVMI64Node[].class);
-                return new LLVMI64SwitchNode((LLVMI64Node) cond, i64Cases, otherLabels, defaultLabel);
+                return new LLVMI64SwitchNode((LLVMI64Node) cond, i64Cases, otherLabels, defaultLabel, phiWriteNodes);
             default:
                 throw new AssertionError(llvmType);
         }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -249,23 +249,24 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMNode createIndirectBranch(LLVMExpressionNode value, int[] labelTargets) {
-        return LLVMBranchFactory.createIndirectBranch(value, labelTargets);
+    public LLVMNode createIndirectBranch(LLVMExpressionNode value, int[] labelTargets, LLVMNode[] phiWrites) {
+        return LLVMBranchFactory.createIndirectBranch(value, labelTargets, phiWrites);
     }
 
     @Override
-    public LLVMStatementNode createSwitch(LLVMExpressionNode cond, int defaultLabel, int[] otherLabels, LLVMExpressionNode[] cases, LLVMBaseType llvmType) {
-        return LLVMSwitchFactory.createSwitch(cond, defaultLabel, otherLabels, cases, llvmType);
+    public LLVMStatementNode createSwitch(LLVMExpressionNode cond, int defaultLabel, int[] otherLabels, LLVMExpressionNode[] cases,
+                    LLVMBaseType llvmType, LLVMNode[] phiWriteNodes) {
+        return LLVMSwitchFactory.createSwitch(cond, defaultLabel, otherLabels, cases, llvmType, phiWriteNodes);
     }
 
     @Override
-    public LLVMStatementNode createConditionalBranch(int trueIndex, int falseIndex, LLVMExpressionNode conditionNode) {
-        return LLVMBranchFactory.createConditionalBranch(runtime, trueIndex, falseIndex, conditionNode);
+    public LLVMStatementNode createConditionalBranch(int trueIndex, int falseIndex, LLVMExpressionNode conditionNode, LLVMNode[] truePhiWriteNodes, LLVMNode[] falsePhiWriteNodes) {
+        return LLVMBranchFactory.createConditionalBranch(runtime, trueIndex, falseIndex, conditionNode, truePhiWriteNodes, falsePhiWriteNodes);
     }
 
     @Override
-    public LLVMStatementNode createUnconditionalBranch(int unconditionalIndex) {
-        return LLVMBranchFactory.createUnconditionalBranch(unconditionalIndex);
+    public LLVMStatementNode createUnconditionalBranch(int unconditionalIndex, LLVMNode[] phiWrites) {
+        return LLVMBranchFactory.createUnconditionalBranch(unconditionalIndex, phiWrites);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -142,13 +142,14 @@ public interface NodeFactoryFacade {
 
     LLVMNode createUnreachableNode();
 
-    LLVMNode createIndirectBranch(LLVMExpressionNode value, int[] labelTargets);
+    LLVMNode createIndirectBranch(LLVMExpressionNode value, int[] labelTargets, LLVMNode[] phiWrites);
 
-    LLVMNode createSwitch(LLVMExpressionNode cond, int defaultLabel, int[] otherLabels, LLVMExpressionNode[] cases, LLVMBaseType llvmType);
+    LLVMNode createSwitch(LLVMExpressionNode cond, int defaultLabel, int[] otherLabels, LLVMExpressionNode[] cases,
+                    LLVMBaseType llvmType, LLVMNode[] phiWriteNodes);
 
-    LLVMNode createConditionalBranch(int trueIndex, int falseIndex, LLVMExpressionNode conditionNode);
+    LLVMNode createConditionalBranch(int trueIndex, int falseIndex, LLVMExpressionNode conditionNode, LLVMNode[] truePhiWriteNodes, LLVMNode[] falsePhiWriteNodes);
 
-    LLVMNode createUnconditionalBranch(int unconditionalIndex);
+    LLVMNode createUnconditionalBranch(int unconditionalIndex, LLVMNode[] phiWrites);
 
     LLVMExpressionNode createArrayLiteral(List<LLVMExpressionNode> arrayValues, ResolvedType arrayType);
 


### PR DESCRIPTION
Conditional phi writes occur in conditional branches of a basic blick, when a successor of the basic block refers to it in a phi function. Previously, the check on the condition of the conditional branch was executed twice, namely once for the conditional phi write nodes and once for the conditional branch. @rschatz found that the redundant checks remain in the compiled code. This change moves the conditional phi write nodes together with the conditional branches, so that the condition is only checked once.