### PR TITLE
call memcpy over native handle as PE fail workaround

### DIFF
--- a/mx.sulong/suite.py
+++ b/mx.sulong/suite.py
@@ -219,6 +219,7 @@ suite = {
       "subDir" : "projects",
       "sourceDirs" : ["src"],
       "dependencies" : [
+        "graal-core:GRAAL_TRUFFLE_HOTSPOT",
         "truffle:TRUFFLE_API",
       ],
       "checkstyle" : "com.oracle.truffle.llvm.nodes",

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
@@ -37,7 +37,7 @@ import com.oracle.truffle.llvm.types.LLVMFunction;
 
 public class LLVMHeap extends LLVMMemory {
 
-    private static NativeFunctionHandle memCopyHandle;
+    private static final NativeFunctionHandle memCopyHandle;
 
     public static LLVMAddress allocateCString(String string) {
         LLVMAddress baseAddress = LLVMHeap.allocateMemory(string.length() + 1);

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
@@ -29,10 +29,15 @@
  */
 package com.oracle.truffle.llvm.types.memory;
 
+import com.oracle.nfi.NativeFunctionInterfaceRuntime;
+import com.oracle.nfi.api.NativeFunctionHandle;
+import com.oracle.nfi.api.NativeFunctionInterface;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunction;
 
 public class LLVMHeap extends LLVMMemory {
+
+    private static NativeFunctionHandle memCopyHandle;
 
     public static LLVMAddress allocateCString(String string) {
         LLVMAddress baseAddress = LLVMHeap.allocateMemory(string.length() + 1);
@@ -66,7 +71,17 @@ public class LLVMHeap extends LLVMMemory {
     public static void memCopy(LLVMAddress target, LLVMAddress source, long length) {
         long targetAddress = extractAddrNullPointerAllowed(target);
         long sourceAddress = extractAddrNullPointerAllowed(source);
-        UNSAFE.copyMemory(sourceAddress, targetAddress, length);
+        unsafeMemoryCopy(length, targetAddress, sourceAddress);
+    }
+
+    static {
+        final NativeFunctionInterface nfi = NativeFunctionInterfaceRuntime.getNativeFunctionInterface();
+        memCopyHandle = nfi.getFunctionHandle("memcpy", void.class, long.class, long.class, long.class);
+    }
+
+    // FIXME PE still fails for unintrinsified native methods
+    private static void unsafeMemoryCopy(long length, long targetAddress, long sourceAddress) {
+        memCopyHandle.call(targetAddress, sourceAddress, length);
     }
 
     public static void memCopy(LLVMAddress target, LLVMAddress source, long length, @SuppressWarnings("unused") int align, @SuppressWarnings("unused") boolean isVolatile) {


### PR DESCRIPTION
As analyzed by @christianwimmer, the PE currently fails for calls such as Unsafe.copyMemory used to implement memcpy due to missing LoopExits that should be inserted by the graph decoder on exception edges. This change calls the native memcpy until the issue is fixed in the partial evaluator. 