### PR TITLE
perform some opt optimizations in the benchmarks and disable the C intrinsifications

### DIFF
--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -439,7 +439,8 @@ def suOptBench(args=None):
         mx.run(['opt', '-S', '-o', outputFile, '-mem2reg', '-lowerinvoke', '-prune-eh', '-simplifycfg', outputFile])
     else:
         exit(ext + " is not supported!")
-    return runLLVM([getSearchPathOption(), 'test.ll'] + vmArgs)
+    mx.run(['opt', '-S', '-o', outputFile, outputFile, '-globalopt', '-simplifycfg', '-constprop', '-instcombine', '-dse', '-loop-simplify', '-reassociate', '-licm', '-gvn'])
+    return runLLVM([getSearchPathOption(), '-Dsulong.IntrinsifyCFunctions=false', 'test.ll'] + vmArgs)
 
 def clangBench(args=None):
     """ Executes a benchmark with the system default Clang"""


### PR DESCRIPTION
I'm still trying to figure out which LLVM passes improve the performance for Sulong. So far, it seems that only the loop invariant code modition pass (`-licm`) shows improvements for the benchmarks I'm testing. I still added some other passes that could help, and did not regress performance at least.

I also disable the intrinsifications of C functions, since it seems that substituting them with Java equivalents makes Sulong slower.