### PR TITLE
link with gmp and include pidigits test

### DIFF
--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -332,15 +332,15 @@ def runTypeTestCases(args=None):
     return unittest(getCommonUnitTestOptions() + vmArgs + ['com.oracle.truffle.llvm.types.floating.test'])
 
 def getCommonOptions():
-    return ['-Dgraal.TruffleCompilationExceptionsArePrinted=true', '-Dgraal.ExitVMOnException=true']
+    return ['-Dgraal.TruffleCompilationExceptionsArePrinted=true', '-Dgraal.ExitVMOnException=true', getSearchPathOption()]
 
 # other OSs?
 def getSearchPathOption():
-    return '-Dsulong.DynamicNativeLibraryPath=libgfortran.so.3:libstdc++.so.6:libc.so.6'
+    return '-Dsulong.DynamicNativeLibraryPath=libgfortran.so.3:libstdc++.so.6:libc.so.6:libgmp.so.10'
 
 
 def getCommonUnitTestOptions():
-    return getCommonOptions() + ['-Xss56m', getSearchPathOption(), getLLVMRootOption()]
+    return getCommonOptions() + ['-Xss56m', getLLVMRootOption()]
 
 # PE does not work yet for all test cases
 def compilationSucceedsOption():
@@ -466,7 +466,7 @@ def gccBench(args=None):
     return mx.run(['./a.out'])
 
 def standardLinkerCommands(args=None):
-    return ['-lm']
+    return ['-lm', '-lgmp']
 
 mx.update_commands(_suite, {
     'suoptbench' : [suOptBench, ''],

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/BenchmarkGameSuite.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/BenchmarkGameSuite.java
@@ -78,7 +78,9 @@ public class BenchmarkGameSuite extends TestSuiteBase {
         C_MANDELBROT4("mandelbrot/mandelbrot.gcc-9.gcc.c", 500),
         C_NBODY1("nbody/nbody.cint.c", 10),
         C_SPECTRALNORM1("spectralnorm/spectralnorm.cint.c", 150),
-        C_SPECTRALNORM2("spectralnorm/spectralnorm.gcc-2.gcc.c", 150);
+        C_SPECTRALNORM2("spectralnorm/spectralnorm.gcc-2.gcc.c", 150),
+        C_PIDIGTS("pidigits/pidigits.cint-4.cint.c", 10000),
+        C_PIDIGITS2("pidigits/pidigits.gcc.c", 10000);
 
         private File file;
         private String arg;

--- a/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/GCC.java
+++ b/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/GCC.java
@@ -39,7 +39,7 @@ public final class GCC extends CompilerBase {
     }
 
     public static void compileObjectToMachineCode(File objectFile, File executable) {
-        String linkCommand = "gcc " + objectFile.getAbsolutePath() + " -o " + executable.getAbsolutePath() + " -lm -lgfortran";
+        String linkCommand = "gcc " + objectFile.getAbsolutePath() + " -o " + executable.getAbsolutePath() + " -lm -lgfortran -lgmp";
         ProcessUtil.executeNativeCommandZeroReturn(linkCommand);
         executable.setExecutable(true);
     }


### PR DESCRIPTION
This changes adds pidigits to the test suite and includes libgmp.so.10 as a shared library used by the benchmark.