### PR TITLE
split travis test case execution into two parts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
   - TEST_COMMAND='mx/mx checkstyle'
   - TEST_COMMAND='mx/mx checkoverlap'
   - TEST_COMMAND='mx/mx canonicalizeprojects'
-  - TEST_COMMAND='mx/mx travis1'
-  - TEST_COMMAND='mx/mx travis2'
+  - TEST_COMMAND='mx/mx su-travis1'
+  - TEST_COMMAND='mx/mx su-travis2'
 after_failure:
   - find . -iname "*.log" -print0 | xargs -0 cat

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ env:
   - TEST_COMMAND='mx/mx checkstyle'
   - TEST_COMMAND='mx/mx checkoverlap'
   - TEST_COMMAND='mx/mx canonicalizeprojects'
-  - TEST_COMMAND='mx/mx su-local-gate'
+  - TEST_COMMAND='mx/mx travis1'
+  - TEST_COMMAND='mx/mx travis2'
 after_failure:
   - find . -iname "*.log" -print0 | xargs -0 cat

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -62,6 +62,37 @@ def executeGate():
         with Task('TestNWCC', tasks) as t:
             if t: runNWCCTestCases()
 
+def travis1(args=None):
+    tasks = []
+    with Task('BuildHotSpotGraalServer: product', tasks) as t:
+        if t: buildvms(['-c', '--vms', 'server', '--builds', 'product'])
+    with VM('server', 'product'):
+        with Task('Findbugs', tasks) as t:
+            if t: mx_findbugs.findbugs([])
+    with VM('server', 'product'):
+        with Task('TestBenchmarks', tasks) as t:
+            if t: runBenchmarkTestCases()
+    with VM('server', 'product'):
+        with Task('TestTypes', tasks) as t:
+            if t: runTypeTestCases()
+    with VM('server', 'product'):
+        with Task('TestSulong', tasks) as t:
+            if t: runTruffleTestCases()
+    with VM('server', 'product'):
+        with Task('TestLLVM', tasks) as t:
+            if t: runLLVMTestCases()
+    with VM('server', 'product'):
+        with Task('TestNWCC', tasks) as t:
+            if t: runNWCCTestCases()
+
+def travis2(args=None):
+    tasks = []
+    with Task('BuildHotSpotGraalServer: product', tasks) as t:
+        if t: buildvms(['-c', '--vms', 'server', '--builds', 'product'])
+    with VM('server', 'product'):
+        with Task('TestGCC', tasks) as t:
+            if t: runGCCTestCases()
+
 def localGate(args=None):
     """executes the gate without downloading the dependencies and without building"""
     executeGate()
@@ -497,5 +528,7 @@ mx.update_commands(_suite, {
     'su-clang++' : [compileWithClangPP, ''],
     'su-opt' : [opt, ''],
     'su-gcc' : [dragonEgg, ''],
-    'su-g++' : [dragonEggGPP, '']
+    'su-g++' : [dragonEggGPP, ''],
+    'su-travis1' : [travis1, ''],
+    'su-travis2' : [travis2, '']
 })


### PR DESCRIPTION
Previously, the Travis build step for executing the test cases for Sulong needed over 40 minutes and approached the maximum limit of 50 minutes that is allowed for a Travis build step. This change splits the execution of the test cases into two separate build steps. Currently, there is one for the GCC test cases (test step 2), and one for the remaining test cases (test step 1). Since the steps can run in parallel, the wall time for the Travis gate for the PR improved from about 41 minutes to 31 minutes. Since the native and Java code has to be compiled twice, the total time increased from 51 minutes to 1 hour and 8 minutes.