### PR TITLE
print an error for invalid options with the old llvm. option prefix

### DIFF
--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -237,7 +237,9 @@ public class LLVMOptions {
         Properties allProperties = System.getProperties();
         for (String key : allProperties.stringPropertyNames()) {
             if (key.startsWith(OBSOLETE_OPTION_PREFIX)) {
+                // Checkstyle: stop
                 System.err.println("The prefix '" + OBSOLETE_OPTION_PREFIX + "' in option '" + key + "' is an obsolete option prefix and has been replaced by the prefix '" + OPTION_PREFIX + "':");
+                // Checkstyle: resume
                 printOptions();
                 System.exit(-1);
             }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -55,6 +55,7 @@ public class LLVMOptions {
 
     private static final String PATH_DELIMITER = ":";
     private static final String OPTION_PREFIX = "sulong.";
+    private static final String OBSOLETE_OPTION_PREFIX = "llvm.";
 
     @FunctionalInterface
     interface OptionParser {
@@ -203,6 +204,7 @@ public class LLVMOptions {
     static {
         parseOptions();
         checkForInvalidOptionNames();
+        checkForObsoleteOptionPrefix();
     }
 
     private static void checkForInvalidOptionNames() {
@@ -222,8 +224,23 @@ public class LLVMOptions {
             // Checkstyle: stop
             System.err.println("\nvalid options:");
             // Checkstyle: resume
-            LLVMOptions.main(new String[0]);
+            printOptions();
             System.exit(-1);
+        }
+    }
+
+    private static void printOptions() {
+        LLVMOptions.main(new String[0]);
+    }
+
+    private static void checkForObsoleteOptionPrefix() {
+        Properties allProperties = System.getProperties();
+        for (String key : allProperties.stringPropertyNames()) {
+            if (key.startsWith(OBSOLETE_OPTION_PREFIX)) {
+                System.err.println("The prefix '" + OBSOLETE_OPTION_PREFIX + "' in option '" + key + "' is an obsolete option prefix and has been replaced by the prefix '" + OPTION_PREFIX + "':");
+                printOptions();
+                System.exit(-1);
+            }
         }
     }
 


### PR DESCRIPTION
With this change, an error is printed for options that start with `llvm.` which we previously used as a prefix:

```
mx su-run test.ll -Dllvm.Debug=true
The prefix 'llvm.' in option 'llvm.Debug' is an obsolete option prefix and has been replaced by the prefix 'sulong.':
GENERAL:
         sulong.DynamicNativeLibraryPath (default =  null) The native library search paths delimited by :

DEBUG:
                            sulong.Debug (default = false) Turns debugging on/off
                        sulong.PrintASTs (default = false) Prints the Truffle ASTs for the parsed functions
             sulong.PrintNativeCallStats (default = false) Outputs stats about native call site frequencies
         sulong.PrintNativeAnalysisStats (default = false) Outputs the results of the lifetime analysis (if enabled)

PERFORMANCE:
  sulong.DisableSpeculativeOptimizations (default = false) Disables all speculative optimizations regardless if they would be enabled otherwise
        sulong.SpecializeExpectIntrinsic (default =  true) Specialize the llvm.expect intrinsic
          sulong.ValueProfileMemoryReads (default =  true) Enable value profiling for memory reads
          sulong.InjectProbabilitySelect (default =  true) Inject branch probabilities for select
             sulong.IntrinsifyCFunctions (default =  true) Substitute C functions by Java equivalents where possible
              sulong.InjectProbabilityBr (default =  true) Inject branch probabilities for conditional branches
           sulong.EnableLifetimeAnalysis (default =  true) Performs a lifetime analysis to set dead frame slots to null to assist the PE

TESTS:
               sulong.TestRemoteBootPath (default =  null) The boot classpath for the remote JVM used to capture native printf and other output.
     sulong.LaunchRemoteTestCasesLocally (default = false) Launches the test cases which are usually launched in a separate JVM in the currently running one.
                sulong.TestDiscoveryPath (default =  null) Looks for newly supported test cases in the specified path. E.g., when executing the GCC test cases you can use /gcc.c-torture/execute to discover newly working torture test cases.

MX:
                      sulong.ProjectRoot (default =     .) Overrides the root of the project. This option exists to set the project root from mx
```
