### PR TITLE
Options benchmark

### DIFF
--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -380,6 +380,9 @@ def compilationSucceedsOption():
 def getRemoteClasspathOption():
     return "-Dsulong.TestRemoteBootPath=-Xbootclasspath/p:" + mx.distribution('truffle:TRUFFLE_API').path + " " + getLLVMRootOption() + " " + compilationSucceedsOption() + " -XX:-UseJVMCIClassLoader -Dsulong.Debug=false -Dsulong.IntrinsifyCFunctions=false -Djvmci.Compiler=graal"
 
+def getBenchmarkOptions():
+    return ['-Dgraal.TruffleBackgroundCompilation=false', '-Dsulong.IntrinsifyCFunctions=false']
+
 def getLLVMRootOption():
     return "-Dsulong.ProjectRoot=" + _root
 
@@ -453,7 +456,7 @@ def suBench(args=None):
     ensureLLVMBinariesExist()
     vmArgs, sulongArgs = truffle_extract_VM_args(args)
     compileWithClang(['-S', '-emit-llvm', '-o', 'test.ll', sulongArgs[0]])
-    return runLLVM(['test.ll'] + vmArgs)
+    return runLLVM(getBenchmarkOptions() + ['test.ll'] + vmArgs)
 
 def suOptBench(args=None):
     """runs a given benchmark with Sulong after optimizing it with opt"""
@@ -471,7 +474,7 @@ def suOptBench(args=None):
     else:
         exit(ext + " is not supported!")
     opt(['-S', '-o', outputFile, outputFile, '-globalopt', '-simplifycfg', '-constprop', '-instcombine', '-dse', '-loop-simplify', '-reassociate', '-licm', '-gvn'])
-    return runLLVM([getSearchPathOption(), '-Dsulong.IntrinsifyCFunctions=false', 'test.ll'] + vmArgs)
+    return runLLVM(getBenchmarkOptions() + [getSearchPathOption(), 'test.ll'] + vmArgs)
 
 def clangBench(args=None):
     """ Executes a benchmark with the system default Clang"""

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
@@ -89,7 +89,11 @@ public class LLVMGlobalRootNode extends RootNode {
         realArgs[0] = LLVMFrameUtil.getAddress(frame, stackPointerSlot);
         System.arraycopy(arguments, 0, realArgs, LLVMCallNode.ARG_START_INDEX, arguments.length);
         try {
-            return main.call(frame, realArgs);
+            Object result = null;
+            for (int i = 0; i < LLVMOptions.getExecutionCount(); i++) {
+                result = main.call(frame, realArgs);
+            }
+            return result;
         } catch (LLVMExitException e) {
             return e.getReturnCode();
         } finally {

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -70,6 +70,10 @@ public class LLVMOptions {
         return System.getProperty(prop.getKey(), prop.getDefaultValue());
     }
 
+    static int parseInteger(Property prop) {
+        return Integer.parseInt(System.getProperty(prop.getKey(), prop.getDefaultValue()));
+    }
+
     static String[] parseDynamicLibraryPath(Property prop) {
         String property = System.getProperty(prop.getKey(), prop.getDefaultValue());
         if (property == null) {
@@ -101,6 +105,7 @@ public class LLVMOptions {
 
         DEBUG("Debug", "Turns debugging on/off", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
         PRINT_FUNCTION_ASTS("PrintASTs", "Prints the Truffle ASTs for the parsed functions", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
+        EXECUTION_COUNT("ExecutionCount", "Execute each program for as many times as specified by this option", "1", LLVMOptions::parseInteger, PropertyCategory.DEBUG),
         /*
          * The boot classpath that should be used to execute the remote JVM when executing the LLVM
          * test suite (and other tests). These rely on comparing output sent to stdout that cannot
@@ -327,6 +332,10 @@ public class LLVMOptions {
 
     public static boolean launchRemoteTestCasesAsLocal() {
         return getParsedProperty(Property.REMOTE_TEST_CASES_AS_LOCAL);
+    }
+
+    public static int getExecutionCount() {
+        return getParsedProperty(Property.EXECUTION_COUNT);
     }
 
 }


### PR DESCRIPTION
This change turns off background compilation in the benchmark runners and provides an option to execute program more than one time.