### PR TITLE
Performance warnings

### DIFF
--- a/mx.sulong/suite.py
+++ b/mx.sulong/suite.py
@@ -297,7 +297,6 @@ suite = {
       "dependencies" : [
         "com.oracle.truffle.llvm.nodes",
         "com.oracle.truffle.llvm.types",
-        "com.oracle.truffle.llvm.runtime",
         "LLVM_IR_PARSER",
         "EMF_COMMON", "ECORE", "INJECT", "XTEXT", "EMF_ECORE_XMI", "XTEXT_TYPES", "XTEXT_JAVAX_INJECT", "XTEXT_LOG4J", "XTEXT_GOOGLE_GUAVA", "XTEXT_ANTLR_RUNTIME", "XTEXT_UTIL", "ECLIPSE_EQUINOX"
        ],

--- a/mx.sulong/suite.py
+++ b/mx.sulong/suite.py
@@ -220,6 +220,7 @@ suite = {
       "sourceDirs" : ["src"],
       "dependencies" : [
         "graal-core:GRAAL_TRUFFLE_HOTSPOT",
+        "com.oracle.truffle.llvm.runtime",
         "truffle:TRUFFLE_API",
       ],
       "checkstyle" : "com.oracle.truffle.llvm.nodes",

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
@@ -33,6 +33,7 @@ import com.oracle.nfi.api.NativeFunctionHandle;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.Cached;
@@ -238,32 +239,34 @@ public abstract class LLVMCallNode {
 
         @Children private final LLVMExpressionNode[] nodes;
 
+        private final boolean printPerformanceWarnings = LLVMOptions.printPerformanceWarnings();
+        @CompilationFinal private boolean printedNativePerformanceWarning;
+        @CompilationFinal private boolean printedExceedInlineCacheWarning;
+
+        protected static final int INLINE_CACHE_SIZE = 2;
+
         public LLVMFunctionCallChain(LLVMContext context, LLVMExpressionNode[] nodes) {
             this.context = context;
             this.nodes = nodes;
         }
 
-        protected static final int INLINE_CACHE_SIZE = 2;
-
         public abstract Object executeDispatch(VirtualFrame frame, LLVMFunction function, Object[] arguments);
 
-        public static CallTarget getIndirectCallTarget(LLVMContext context, LLVMFunction function, LLVMExpressionNode[] args) {
-            CallTarget callTarget = context.getFunction(function);
+        public CallTarget getIndirectCallTarget(LLVMContext currentContext, LLVMFunction function, LLVMExpressionNode[] args) {
+            CallTarget callTarget = currentContext.getFunction(function);
             if (callTarget == null) {
-                return getNativeCallTarget(context, function, args);
+                return getNativeCallTarget(currentContext, function, args);
             } else {
                 return callTarget;
             }
         }
 
         @TruffleBoundary
-        private static CallTarget getNativeCallTarget(LLVMContext context, LLVMFunction function, LLVMExpressionNode[] args) {
-            if (LLVMOptions.debugEnabled()) {
-                // Checkstyle: stop
-                System.err.println("indirectly calling a native function is expensive at the moment!");
-                // Checkstyle: resume
+        private CallTarget getNativeCallTarget(LLVMContext currentContext, LLVMFunction function, LLVMExpressionNode[] args) {
+            if (printPerformanceWarnings && !printedNativePerformanceWarning) {
+                printIndirectNativeCallWarning(function);
             }
-            final NativeFunctionHandle nativeHandle = context.getNativeHandle(function, prepareForNative(args, context));
+            final NativeFunctionHandle nativeHandle = currentContext.getNativeHandle(function, prepareForNative(args, currentContext));
             if (nativeHandle == null) {
                 throw new IllegalStateException("could not find function " + function.getName());
             } else {
@@ -290,7 +293,26 @@ public abstract class LLVMCallNode {
         @Specialization(contains = "doDirect")
         protected Object doIndirect(VirtualFrame frame, LLVMFunction function, Object[] arguments, //
                         @Cached("create()") IndirectCallNode callNode) {
+            if (printPerformanceWarnings && !printedExceedInlineCacheWarning) {
+                printExceededInlineCacheWarning(function);
+            }
             return callNode.call(frame, getIndirectCallTarget(getContext(), function, getNodes()), arguments);
+        }
+
+        private void printIndirectNativeCallWarning(LLVMFunction function) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            printedNativePerformanceWarning = true;
+            // Checkstyle: stop
+            System.err.println("indirectly calling a native function " + function.getName() + " + is expensive at the moment!");
+            // Checkstyle: resume
+        }
+
+        private void printExceededInlineCacheWarning(LLVMFunction function) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            // Checkstyle: stop
+            System.err.println("exceeded inline cache limit for function " + function);
+            // Checkstyle: resume
+            printedExceedInlineCacheWarning = true;
         }
 
         public LLVMContext getContext() {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
@@ -243,7 +243,7 @@ public abstract class LLVMCallNode {
         @CompilationFinal private boolean printedNativePerformanceWarning;
         @CompilationFinal private boolean printedExceedInlineCacheWarning;
 
-        protected static final int INLINE_CACHE_SIZE = 2;
+        protected static final int INLINE_CACHE_SIZE = LLVMOptions.getInlineCacheSize();
 
         public LLVMFunctionCallChain(LLVMContext context, LLVMExpressionNode[] nodes) {
             this.context = context;

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -70,6 +70,10 @@ public class LLVMOptions {
         return System.getProperty(prop.getKey(), prop.getDefaultValue());
     }
 
+    static int parseInteger(Property prop) {
+        return Integer.parseInt(System.getProperty(prop.getKey(), prop.getDefaultValue()));
+    }
+
     static String[] parseDynamicLibraryPath(Property prop) {
         String property = System.getProperty(prop.getKey(), prop.getDefaultValue());
         if (property == null) {
@@ -139,6 +143,7 @@ public class LLVMOptions {
         OPTIMIZATION_INJECT_PROBS_SELECT("InjectProbabilitySelect", "Inject branch probabilities for select", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_INTRINSIFY_C_FUNCTIONS("IntrinsifyCFunctions", "Substitute C functions by Java equivalents where possible", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_INJECT_PROBS_COND_BRANCH("InjectProbabilityBr", "Inject branch probabilities for conditional branches", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
+        OPTIMIZATION_INLINE_CACHE_SIZE("InlineCacheSize", "Specifies the size of the polymorphic inline cache", "5", LLVMOptions::parseInteger, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_LIFE_TIME_ANALYSIS(
                         "EnableLifetimeAnalysis",
                         "Performs a lifetime analysis to set dead frame slots to null to assist the PE",
@@ -332,6 +337,10 @@ public class LLVMOptions {
 
     public static boolean printPerformanceWarnings() {
         return getParsedProperty(Property.PRINT_PERFORMANCE_WARNINGS);
+    }
+
+    public static int getInlineCacheSize() {
+        return getParsedProperty(Property.OPTIMIZATION_INLINE_CACHE_SIZE);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -100,6 +100,7 @@ public class LLVMOptions {
     public enum Property {
 
         DEBUG("Debug", "Turns debugging on/off", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
+        PRINT_PERFORMANCE_WARNINGS("PrintPerformanceWarnings", "Prints performance warnings", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
         PRINT_FUNCTION_ASTS("PrintASTs", "Prints the Truffle ASTs for the parsed functions", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
         /*
          * The boot classpath that should be used to execute the remote JVM when executing the LLVM
@@ -327,6 +328,10 @@ public class LLVMOptions {
 
     public static boolean launchRemoteTestCasesAsLocal() {
         return getParsedProperty(Property.REMOTE_TEST_CASES_AS_LOCAL);
+    }
+
+    public static boolean printPerformanceWarnings() {
+        return getParsedProperty(Property.PRINT_PERFORMANCE_WARNINGS);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMIVarBit.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMIVarBit.java
@@ -35,6 +35,8 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.BitSet;
 
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.llvm.runtime.LLVMOptions;
 import com.oracle.truffle.llvm.types.floating.BinaryHelper;
 
 // see https://bugs.chromium.org/p/nativeclient/issues/detail?id=3360 for use cases where variable ints arise
@@ -138,6 +140,11 @@ public abstract class LLVMIVarBit {
 
         LLVMVarBitByteArray(int bits, byte[] arr) {
             super(bits);
+            if (CompilerDirectives.inInterpreter() && LLVMOptions.printPerformanceWarnings()) {
+                // Checkstyle: stop
+                System.err.println("constructing a variable bit number!");
+                // Checkstyle: resume
+            }
             // TODO: what about sign extension?
             this.arr = new byte[getByteSize()];
             if (getByteSize() >= arr.length) {

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/floating/LLVM80BitFloat.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/floating/LLVM80BitFloat.java
@@ -35,7 +35,9 @@ import java.util.Arrays;
 import javax.xml.bind.DatatypeConverter;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.llvm.runtime.LLVMOptions;
 
 public abstract class LLVM80BitFloat {
 
@@ -168,6 +170,11 @@ public abstract class LLVM80BitFloat {
         }
 
         private static RealLLVM80BitFloat fromLong(long val, boolean sign) {
+            if (CompilerDirectives.inInterpreter() && LLVMOptions.printPerformanceWarnings()) {
+                // Checkstyle: stop
+                System.err.println("constructing a 80 bit float!");
+                // Checkstyle: resume
+            }
             int leadingOnePosition = Long.SIZE - Long.numberOfLeadingZeros(val);
             int exponent = EXPONENT_BIAS + (leadingOnePosition - 1);
             long fractionMask;


### PR DESCRIPTION
This change separates the performance warnings from the debug warnings and adds performance warnings for 80 bit floats and variable bit integers. It also adds an option for the size of the polymorphic inline cache.