### PR TITLE
Simple logger implementation

### DIFF
--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -381,7 +381,7 @@ def getRemoteClasspathOption():
     return "-Dsulong.TestRemoteBootPath=-Xbootclasspath/p:" + mx.distribution('truffle:TRUFFLE_API').path + " " + getLLVMRootOption() + " " + compilationSucceedsOption() + " -XX:-UseJVMCIClassLoader -Dsulong.Debug=false -Dsulong.IntrinsifyCFunctions=false -Djvmci.Compiler=graal"
 
 def getBenchmarkOptions():
-    return ['-Dgraal.TruffleBackgroundCompilation=false', '-Dsulong.IntrinsifyCFunctions=false']
+    return ['-Dgraal.TruffleBackgroundCompilation=false', '-Dsulong.IntrinsifyCFunctions=false', '-Dsulong.PerformanceWarningsAreFatal=true']
 
 def getLLVMRootOption():
     return "-Dsulong.ProjectRoot=" + _root

--- a/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
+++ b/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
@@ -44,6 +44,7 @@ import com.oracle.nfi.api.NativeLibraryHandle;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.parser.NodeFactoryFacade;
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.LLVMOptions;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
@@ -127,9 +128,7 @@ public class NativeLookup {
                 return LOOKUP_FAILURE;
             }
         } catch (Exception e) {
-            if (LLVMOptions.debugEnabled()) {
-                System.err.println("external symbol " + name + " could not be resolved!");
-            }
+            LLVMLogger.info("external symbol " + name + " could not be resolved!");
             return LOOKUP_FAILURE;
         }
     }

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMAttributeVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMAttributeVisitor.java
@@ -36,7 +36,7 @@ import com.intel.llvm.ireditor.lLVM_IR.FunctionAttribute;
 import com.intel.llvm.ireditor.lLVM_IR.FunctionAttributes;
 import com.intel.llvm.ireditor.lLVM_IR.FunctionHeader;
 import com.intel.llvm.ireditor.lLVM_IR.TargetSpecificAttribute;
-import com.oracle.truffle.llvm.runtime.LLVMOptions;
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
 
 public class LLVMAttributeVisitor {
 
@@ -74,18 +74,14 @@ public class LLVMAttributeVisitor {
                 // ignore for the moment, investigate later
                 break;
             default:
-                if (LLVMOptions.debugEnabled()) {
-                    System.err.println(attribute + " not supported!");
-                }
+                LLVMLogger.info(attribute + " not supported!");
         }
     }
 
     private static void visitAttributeGroup(AttributeGroup attributeGroup) {
         EList<TargetSpecificAttribute> targetSpecificAttributes = attributeGroup.getTargetSpecificAttributes();
         if (targetSpecificAttributes.size() != 0) {
-            if (LLVMOptions.debugEnabled()) {
-                System.err.println("target specific attributes not yet supported");
-            }
+            LLVMLogger.info("target specific attributes not yet supported");
         }
         EList<FunctionAttribute> attributes = attributeGroup.getAttributes();
         if (attributes.size() != 0) {

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -171,6 +171,7 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
 import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.runtime.LLVMOptions;
 import com.oracle.truffle.llvm.runtime.LLVMParserException;
@@ -308,9 +309,7 @@ public class LLVMVisitor implements LLVMParserRuntime {
             } else if (object instanceof TargetInfo) {
                 // already parsed
             } else if (object instanceof NamedMetadata) {
-                if (LLVMOptions.debugEnabled()) {
-                    System.err.println(object + " not supported!");
-                }
+                LLVMLogger.info(object + " not supported!");
             } else if (object instanceof FunctionDecl) {
                 // not needed for the moment
             } else if (object instanceof AttributeGroup) {
@@ -324,9 +323,7 @@ public class LLVMVisitor implements LLVMParserRuntime {
             } else if (object instanceof Alias) {
                 // do nothing, visit later when alias is referenced
             } else if (object instanceof InlineAsm) {
-                if (LLVMOptions.debugEnabled()) {
-                    System.err.println("ignoring module level inline assembler!");
-                }
+                LLVMLogger.info("ignoring module level inline assembler!");
             } else {
                 throw new AssertionError(object);
             }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMLogger.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMLogger.java
@@ -40,6 +40,9 @@ public class LLVMLogger {
             System.err.println(warning);
             // Checkstyle: resume
         }
+        if (LLVMOptions.performanceWarningsAreFatal()) {
+            throw new AssertionError(warning);
+        }
     }
 
     public static void error(String error) {

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMLogger.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMLogger.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.runtime;
+
+import com.oracle.truffle.api.CompilerAsserts;
+
+public class LLVMLogger {
+
+    public static void performanceWarning(String warning) {
+        CompilerAsserts.neverPartOfCompilation();
+        if (LLVMOptions.printPerformanceWarnings()) {
+            // Checkstyle: stop
+            System.err.println(warning);
+            // Checkstyle: resume
+        }
+    }
+
+    public static void error(String error) {
+        CompilerAsserts.neverPartOfCompilation();
+        // Checkstyle: stop
+        System.err.println(error);
+        // Checkstyle: resume
+    }
+
+    public static void unconditionalInfo(String string) {
+        CompilerAsserts.neverPartOfCompilation();
+        System.err.println(string);
+    }
+
+    public static void info(String string) {
+        CompilerAsserts.neverPartOfCompilation();
+        if (LLVMOptions.debugEnabled()) {
+            System.err.println(string);
+        }
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMLogger.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMLogger.java
@@ -54,13 +54,17 @@ public class LLVMLogger {
 
     public static void unconditionalInfo(String string) {
         CompilerAsserts.neverPartOfCompilation();
+        // Checkstyle: stop
         System.err.println(string);
+        // Checkstyle: resume
     }
 
     public static void info(String string) {
         CompilerAsserts.neverPartOfCompilation();
         if (LLVMOptions.debugEnabled()) {
+            // Checkstyle: stop
             System.err.println(string);
+            // Checkstyle: resume
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -103,6 +103,7 @@ public class LLVMOptions {
 
         DEBUG("Debug", "Turns debugging on/off", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
         PRINT_PERFORMANCE_WARNINGS("PrintPerformanceWarnings", "Prints performance warnings", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
+        PERFORMANCE_WARNING_ARE_FATAL("PerformanceWarningsAreFatal", "Terminates the program after a performance issue is encountered", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
         PRINT_FUNCTION_ASTS("PrintASTs", "Prints the Truffle ASTs for the parsed functions", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
         EXECUTION_COUNT("ExecutionCount", "Execute each program for as many times as specified by this option", "1", LLVMOptions::parseInteger, PropertyCategory.DEBUG),
         /*
@@ -344,6 +345,10 @@ public class LLVMOptions {
 
     public static boolean valueProfileFunctionArgs() {
         return getParsedProperty(Property.OPTIMIZATION_VALUE_PROFILE_FUNCTION_ARGS);
+    }
+
+    public static boolean performanceWarningsAreFatal() {
+        return getParsedProperty(Property.PERFORMANCE_WARNING_ARE_FATAL);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -41,13 +41,11 @@ public class LLVMOptions {
         for (PropertyCategory category : PropertyCategory.values()) {
             List<Property> properties = category.getProperties();
             if (!properties.isEmpty()) {
-                // Checkstyle: stop
-                System.out.println(category + ":");
+                LLVMLogger.unconditionalInfo(category + ":");
                 for (Property prop : properties) {
-                    System.out.println(prop);
+                    LLVMLogger.unconditionalInfo(prop.toString());
                 }
-                System.out.println();
-                // Checkstyle: resume
+                LLVMLogger.unconditionalInfo("");
             }
 
         }
@@ -222,16 +220,12 @@ public class LLVMOptions {
             if (key.startsWith(OPTION_PREFIX)) {
                 if (Property.fromKey(key) == null) {
                     wrongOptionName = true;
-                    // Checkstyle: stop
-                    System.err.println(key + " is an invalid option!");
-                    // Checkstyle: resume
+                    LLVMLogger.error(key + " is an invalid option!");
                 }
             }
         }
         if (wrongOptionName) {
-            // Checkstyle: stop
-            System.err.println("\nvalid options:");
-            // Checkstyle: resume
+            LLVMLogger.error("\nvalid options:");
             printOptions();
             System.exit(-1);
         }
@@ -245,9 +239,8 @@ public class LLVMOptions {
         Properties allProperties = System.getProperties();
         for (String key : allProperties.stringPropertyNames()) {
             if (key.startsWith(OBSOLETE_OPTION_PREFIX)) {
-                // Checkstyle: stop
-                System.err.println("The prefix '" + OBSOLETE_OPTION_PREFIX + "' in option '" + key + "' is an obsolete option prefix and has been replaced by the prefix '" + OPTION_PREFIX + "':");
-                // Checkstyle: resume
+                LLVMLogger.error(
+                                "The prefix '" + OBSOLETE_OPTION_PREFIX + "' in option '" + key + "' is an obsolete option prefix and has been replaced by the prefix '" + OPTION_PREFIX + "':");
                 printOptions();
                 System.exit(-1);
             }

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/LLVMTestSuite.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/LLVMTestSuite.java
@@ -44,7 +44,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import com.oracle.truffle.llvm.runtime.LLVMOptions;
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.tools.Clang;
 import com.oracle.truffle.llvm.tools.ProgrammingLanguage;
 import com.oracle.truffle.llvm.tools.util.PathUtil;
@@ -108,9 +108,7 @@ public class LLVMTestSuite extends RemoteTestSuiteBase {
 
     @Test(timeout = TEST_TIMEOUT_TIME)
     public void test() throws IOException {
-        if (LLVMOptions.debugEnabled()) {
-            System.out.println("current file: " + originalFile);
-        }
+        LLVMLogger.info("current file: " + originalFile);
         List<String> expectedLines;
         int expectedReturnValue;
         try {

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/NWCCTestSuite.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/NWCCTestSuite.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import com.oracle.truffle.llvm.runtime.LLVMOptions;
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.tools.util.ProcessUtil.ProcessResult;
 
 @RunWith(Parameterized.class)
@@ -63,9 +63,7 @@ public class NWCCTestSuite extends RemoteTestSuiteBase {
 
     @Test
     public void test() throws Throwable {
-        if (LLVMOptions.debugEnabled()) {
-            System.out.println("original file: " + tuple.getOriginalFile());
-        }
+        LLVMLogger.info("original file: " + tuple.getOriginalFile());
         try {
             List<String> launchRemote = launchRemote(tuple);
             int sulongRetValue = parseAndRemoveReturnValue(launchRemote);

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/RemoteTestSuiteBase.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/RemoteTestSuiteBase.java
@@ -45,6 +45,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 
 import com.oracle.truffle.llvm.LLVM;
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.LLVMOptions;
 import com.oracle.truffle.llvm.tools.util.ProcessUtil;
 
@@ -59,9 +60,7 @@ public class RemoteTestSuiteBase extends TestSuiteBase {
 
     public List<String> launchLocal(TestCaseFiles tuple) {
         List<String> result = new ArrayList<>();
-        if (LLVMOptions.debugEnabled()) {
-            System.out.println("current file: " + tuple.getOriginalFile().getAbsolutePath());
-        }
+        LLVMLogger.info("current file: " + tuple.getOriginalFile().getAbsolutePath());
         try {
             int retValue = LLVM.executeMain(tuple.getBitCodeFile());
             result.add("exit " + retValue);

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestGCCSuite.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestGCCSuite.java
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import com.oracle.truffle.llvm.LLVM;
-import com.oracle.truffle.llvm.runtime.LLVMOptions;
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
 
@@ -58,22 +58,16 @@ public class TestGCCSuite extends TestSuiteBase {
     public static List<TestCaseFiles[]> getTestFiles() throws IOException {
         File configFile = LLVMPaths.GCC_TEST_SUITE_CONFIG;
         File testSuite = LLVMPaths.GCC_TEST_SUITE;
-        if (LLVMOptions.debugEnabled()) {
-            System.out.println("...start to read and compile files");
-        }
+        LLVMLogger.info("...start to read and compile files");
         List<TestCaseFiles[]> files = getTestCasesFromConfigFile(configFile, testSuite, new TestCaseGeneratorImpl());
-        if (LLVMOptions.debugEnabled()) {
-            System.out.println("...finished reading and compiling files!");
-        }
+        LLVMLogger.info("...finished reading and compiling files!");
         return files;
     }
 
     @Test
     public void test() {
         try {
-            if (LLVMOptions.debugEnabled()) {
-                System.out.println("original file: " + tuple.getOriginalFile());
-            }
+            LLVMLogger.info("original file: " + tuple.getOriginalFile());
             int expectedResult;
             try {
                 expectedResult = TestHelper.executeLLVMBinary(byteCodeFile).getReturnValue();

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestSuiteBase.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestSuiteBase.java
@@ -43,6 +43,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.LLVMOptions;
 import com.oracle.truffle.llvm.runtime.LLVMParserException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
@@ -113,8 +114,8 @@ public abstract class TestSuiteBase {
 
     static void printList(String header, List<File> files) {
         if (files.size() != 0) {
-            System.out.println(header + " (" + files.size() + "):");
-            files.stream().forEach(t -> System.out.println(t));
+            LLVMLogger.info(header + " (" + files.size() + "):");
+            files.stream().forEach(t -> LLVMLogger.info(t.toString()));
         }
     }
 
@@ -203,9 +204,7 @@ public abstract class TestSuiteBase {
             List<File> excludedFiles = testSpecification.getExcludedFiles();
             File absoluteDiscoveryPath = new File(testSuite.getAbsolutePath(), LLVMOptions.getTestDiscoveryPath());
             assert absoluteDiscoveryPath.exists() : absoluteDiscoveryPath.toString();
-            if (LLVMOptions.debugEnabled()) {
-                System.out.println("\tcollect files");
-            }
+            LLVMLogger.info("\tcollect files");
             List<File> filesToRun = getFilesRecursively(absoluteDiscoveryPath, gen);
             for (File alreadyCanExecute : includedFiles) {
                 filesToRun.remove(alreadyCanExecute);
@@ -225,9 +224,7 @@ public abstract class TestSuiteBase {
                     }
                 }
             }
-            if (LLVMOptions.debugEnabled()) {
-                System.out.println("\tfinished collecting files");
-            }
+            LLVMLogger.info("\tfinished collecting files");
             return discoveryTestCases;
         } else {
             List<TestCaseFiles[]> includedFileTestCases = collectIncludedFiles(includedFiles, gen);

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/spec/SpecificationFileReader.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/spec/SpecificationFileReader.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.oracle.truffle.llvm.runtime.LLVMOptions;
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.test.TestHelper;
 
 public class SpecificationFileReader {
@@ -64,9 +64,7 @@ public class SpecificationFileReader {
     };
 
     public static TestSpecification readSpecificationFolder(File directory, File testRoot) throws IOException {
-        if (LLVMOptions.debugEnabled()) {
-            System.out.println("\tread specification files in " + directory);
-        }
+        LLVMLogger.info("\tread specification files in " + directory);
         List<File> includeFiles = getSpecificationFiles(directory, testRoot, FILE_NAME_INCLUDE_FILTER);
         List<File> excludeFiles = getSpecificationFiles(directory, testRoot, FILE_NAME_EXCLUDE_FILTER);
         return new TestSpecification(includeFiles, excludeFiles);

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMIVarBit.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMIVarBit.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
 import java.util.BitSet;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.llvm.runtime.LLVMOptions;
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.types.floating.BinaryHelper;
 
 // see https://bugs.chromium.org/p/nativeclient/issues/detail?id=3360 for use cases where variable ints arise
@@ -140,10 +140,8 @@ public abstract class LLVMIVarBit {
 
         LLVMVarBitByteArray(int bits, byte[] arr) {
             super(bits);
-            if (CompilerDirectives.inInterpreter() && LLVMOptions.printPerformanceWarnings()) {
-                // Checkstyle: stop
-                System.err.println("constructing a variable bit number!");
-                // Checkstyle: resume
+            if (CompilerDirectives.inInterpreter()) {
+                LLVMLogger.performanceWarning("constructing a variable bit number!");
             }
             // TODO: what about sign extension?
             this.arr = new byte[getByteSize()];

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/floating/LLVM80BitFloat.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/floating/LLVM80BitFloat.java
@@ -37,7 +37,7 @@ import javax.xml.bind.DatatypeConverter;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
-import com.oracle.truffle.llvm.runtime.LLVMOptions;
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
 
 public abstract class LLVM80BitFloat {
 
@@ -170,10 +170,8 @@ public abstract class LLVM80BitFloat {
         }
 
         private static RealLLVM80BitFloat fromLong(long val, boolean sign) {
-            if (CompilerDirectives.inInterpreter() && LLVMOptions.printPerformanceWarnings()) {
-                // Checkstyle: stop
-                System.err.println("constructing a 80 bit float!");
-                // Checkstyle: resume
+            if (CompilerDirectives.inInterpreter()) {
+                LLVMLogger.performanceWarning("constructing a 80 bit float!");
             }
             int leadingOnePosition = Long.SIZE - Long.numberOfLeadingZeros(val);
             int exponent = EXPONENT_BIAS + (leadingOnePosition - 1);

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -52,7 +52,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 import com.oracle.truffle.llvm.parser.factories.NodeFactoryFacadeImpl;
 import com.oracle.truffle.llvm.parser.impl.LLVMVisitor;
-import com.oracle.truffle.llvm.runtime.LLVMOptions;
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.LLVMPropertyOptimizationConfiguration;
 import com.oracle.truffle.llvm.types.LLVMFunction;
 
@@ -116,9 +116,7 @@ public class LLVM {
     }
 
     public static int executeMain(File file, Object... args) {
-        if (LLVMOptions.debugEnabled()) {
-            System.out.println("current file: " + file.getAbsolutePath());
-        }
+        LLVMLogger.info("current file: " + file.getAbsolutePath());
         Source fileSource;
         try {
             fileSource = Source.fromFileName(file.getAbsolutePath());
@@ -130,9 +128,7 @@ public class LLVM {
 
     public static int executeMain(String codeString, Object... args) {
         Source fromText = Source.fromText(codeString, "code string").withMimeType(LLVMLanguage.LLVM_MIME_TYPE);
-        if (LLVMOptions.debugEnabled()) {
-            System.out.println("current code string: " + codeString);
-        }
+        LLVMLogger.info("current code string: " + codeString);
         return evaluateFromSource(fromText, args);
     }
 


### PR DESCRIPTION
This change moves all output to `System.out` and `System.err` to a simple logger class to prevent turning off Checkstyle for code segments in other classes.