### PR TITLE
Pe workaround fix

### DIFF
--- a/mx.sulong/suite.py
+++ b/mx.sulong/suite.py
@@ -219,7 +219,6 @@ suite = {
       "subDir" : "projects",
       "sourceDirs" : ["src"],
       "dependencies" : [
-        "graal-core:GRAAL_TRUFFLE_HOTSPOT",
         "com.oracle.truffle.llvm.runtime",
         "truffle:TRUFFLE_API",
       ],

--- a/mx.sulong/suite.py
+++ b/mx.sulong/suite.py
@@ -6,7 +6,7 @@ suite = {
     "suites" : [
         {
            "name" : "graal-core",
-           "version" : "466c7dd66e9d6700a2963ff1f5bd5599928376b2",
+           "version" : "95ff8c420850dc4f02bc11599505244bbea771ec",
            "urls" : [
                 {"url" : "https://github.com/graalvm/graal-core", "kind" : "git"},
             ]

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
@@ -29,15 +29,10 @@
  */
 package com.oracle.truffle.llvm.types.memory;
 
-import com.oracle.nfi.NativeFunctionInterfaceRuntime;
-import com.oracle.nfi.api.NativeFunctionHandle;
-import com.oracle.nfi.api.NativeFunctionInterface;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunction;
 
 public class LLVMHeap extends LLVMMemory {
-
-    private static final NativeFunctionHandle memCopyHandle;
 
     public static LLVMAddress allocateCString(String string) {
         LLVMAddress baseAddress = LLVMHeap.allocateMemory(string.length() + 1);
@@ -66,22 +61,10 @@ public class LLVMHeap extends LLVMMemory {
         UNSAFE.freeMemory(extractAddrNullPointerAllowed(addr));
     }
 
-    // setters
-
     public static void memCopy(LLVMAddress target, LLVMAddress source, long length) {
         long targetAddress = extractAddrNullPointerAllowed(target);
         long sourceAddress = extractAddrNullPointerAllowed(source);
-        unsafeMemoryCopy(length, targetAddress, sourceAddress);
-    }
-
-    static {
-        final NativeFunctionInterface nfi = NativeFunctionInterfaceRuntime.getNativeFunctionInterface();
-        memCopyHandle = nfi.getFunctionHandle("memcpy", void.class, long.class, long.class, long.class);
-    }
-
-    // FIXME PE still fails for unintrinsified native methods
-    private static void unsafeMemoryCopy(long length, long targetAddress, long sourceAddress) {
-        memCopyHandle.call(targetAddress, sourceAddress, length);
+        UNSAFE.copyMemory(sourceAddress, targetAddress, length);
     }
 
     public static void memCopy(LLVMAddress target, LLVMAddress source, long length, @SuppressWarnings("unused") int align, @SuppressWarnings("unused") boolean isVolatile) {

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
@@ -64,6 +64,7 @@ public class LLVMHeap extends LLVMMemory {
     public static void memCopy(LLVMAddress target, LLVMAddress source, long length) {
         long targetAddress = extractAddrNullPointerAllowed(target);
         long sourceAddress = extractAddrNullPointerAllowed(source);
+        assert length == 0 || targetAddress != 0 && sourceAddress != 0;
         UNSAFE.copyMemory(sourceAddress, targetAddress, length);
     }
 


### PR DESCRIPTION
#78 introduced a workaround for PE fails for memcpy. Since the PE fails were fixed in https://github.com/graalvm/graal-core/pull/160 this change removes the workaround again.