### PR TITLE
Enforce @Override annotations on interface method overrides

### DIFF
--- a/mx.sulong/eclipse-settings/org.eclipse.jdt.core.prefs
+++ b/mx.sulong/eclipse-settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,1 @@
+org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotationForInterfaceMethodImplementation=enabled

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
@@ -203,6 +203,7 @@ public abstract class LLVMCallNode {
             functionHandle = nativeFunctionHandle;
         }
 
+        @Override
         public Object call(Object... arguments) {
             return functionHandle.call(arguments);
         }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -309,28 +309,34 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
         return LLVMFunctionFactory.createGlobalRootNodeWrapping(mainCallTarget, returnType);
     }
 
+    @Override
     public LLVMExpressionNode createStructureConstantNode(boolean packed, int structureSize, ResolvedType[] types, LLVMExpressionNode[] constants) {
         return LLVMAggregateFactory.createStructConstantNode(runtime, packed, structureSize, types, constants);
     }
 
+    @Override
     public LLVMNode createMemCopyNode(LLVMExpressionNode globalVarAddress, LLVMExpressionNode constant, LLVMExpressionNode lengthNode, LLVMExpressionNode alignNode,
                     LLVMExpressionNode isVolatileNode) {
         return LLVMMemI32CopyFactory.create((LLVMAddressNode) globalVarAddress, (LLVMAddressNode) constant, (LLVMI32Node) lengthNode, (LLVMI32Node) alignNode,
                         (LLVMI1Node) isVolatileNode);
     }
 
+    @Override
     public LLVMNode createPhiNode() {
         return new LLVMPhiNode();
     }
 
+    @Override
     public LLVMNode createBasicBlockNode(LLVMNode[] statementNodes, LLVMNode terminatorNode) {
         return LLVMBlockFactory.createBasicBlock(statementNodes, (LLVMTerminatorNode) terminatorNode);
     }
 
+    @Override
     public LLVMExpressionNode createFunctionBlockNode(FrameSlot retSlot, List<LLVMNode> allFunctionNodes, LLVMStackFrameNuller[][] indexToSlotNuller) {
         return LLVMBlockFactory.createFunctionBlock(retSlot, allFunctionNodes.toArray(new LLVMBasicBlockNode[allFunctionNodes.size()]), indexToSlotNuller);
     }
 
+    @Override
     public RootNode createFunctionStartNode(LLVMExpressionNode functionBodyNode, LLVMNode[] beforeFunction, LLVMNode[] afterFunction, FrameDescriptor frameDescriptor, String functionName) {
         return new LLVMFunctionStartNode(functionBodyNode, beforeFunction, afterFunction, frameDescriptor, functionName);
     }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -342,6 +342,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
         return new LLVMFunctionStartNode(functionBodyNode, beforeFunction, afterFunction, frameDescriptor, functionName);
     }
 
+    @Override
     public int getArgStartIndex() {
         return LLVMCallNode.ARG_START_INDEX;
     }

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -1448,18 +1448,22 @@ public class LLVMVisitor implements LLVMParserRuntime {
         return globalVars.get(var);
     }
 
+    @Override
     public FrameSlot getStackPointerSlot() {
         return stackPointerSlot;
     }
 
+    @Override
     public LLVMOptimizationConfiguration getOptimizationConfiguration() {
         return optimizationConfiguration;
     }
 
+    @Override
     public int getBitAlignment(LLVMBaseType type) {
         return layoutConverter.getBitAlignment(type);
     }
 
+    @Override
     public FrameDescriptor getGlobalFrameDescriptor() {
         return globalFrameDescriptor;
     }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMPropertyOptimizationConfiguration.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMPropertyOptimizationConfiguration.java
@@ -34,22 +34,27 @@ package com.oracle.truffle.llvm.runtime;
  */
 public class LLVMPropertyOptimizationConfiguration implements LLVMOptimizationConfiguration {
 
+    @Override
     public boolean specializeForExpectIntrinsic() {
         return LLVMOptions.specializeForExpectIntrinsic();
     }
 
+    @Override
     public boolean valueProfileMemoryReads() {
         return LLVMOptions.valueProfileMemoryReads();
     }
 
+    @Override
     public boolean injectBranchProbabilitiesForSelect() {
         return LLVMOptions.injectBranchProbabilitiesForSelect();
     }
 
+    @Override
     public boolean intrinsifyCLibraryFunctions() {
         return LLVMOptions.intrinsifyCLibraryFunctions();
     }
 
+    @Override
     public boolean injectBranchProbabilitiesForConditionalBranch() {
         return LLVMOptions.injectBranchProbabilitiesForConditionalBranch();
     }

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/LLVMTestSuite.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/LLVMTestSuite.java
@@ -75,6 +75,7 @@ public class LLVMTestSuite extends RemoteTestSuiteBase {
         File testSuite = LLVMPaths.LLVM_TEST_SUITE;
         return getTestCasesFromConfigFile(configFile, testSuite, new TestCaseGenerator() {
 
+            @Override
             public List<TestCaseFiles> getCompiledTestCaseFiles(File toBeCompiled) {
                 String expectedOutputName = PathUtil.replaceExtension(toBeCompiled.getAbsolutePath(), LLVM_REFERENCE_OUTPUT_EXTENSION);
                 File expectedOutputFile = new File(expectedOutputName);
@@ -88,6 +89,7 @@ public class LLVMTestSuite extends RemoteTestSuiteBase {
 
             }
 
+            @Override
             public TestCaseFiles getBitCodeTestCaseFiles(File bitCodeFile) {
                 String expectedOutputName = PathUtil.replaceExtension(bitCodeFile.getAbsolutePath(), LLVM_REFERENCE_OUTPUT_EXTENSION);
                 File expectedOutputFile = new File(expectedOutputName);
@@ -100,6 +102,7 @@ public class LLVMTestSuite extends RemoteTestSuiteBase {
                 return testCaseFiles;
             }
 
+            @Override
             public ProgrammingLanguage[] getSupportedLanguages() {
                 return Clang.getSupportedLanguages();
             }

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/RemoteLLVMTester.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/RemoteLLVMTester.java
@@ -69,6 +69,7 @@ public class RemoteLLVMTester {
                 File file = new File(command);
                 Runnable executeTruffleTask = new Runnable() {
 
+                    @Override
                     public void run() {
                         try {
                             result = LLVM.executeMain(file);

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestHelper.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestHelper.java
@@ -65,6 +65,7 @@ public class TestHelper {
         }
         File[] files = folder.listFiles(new FilenameFilter() {
 
+            @Override
             public boolean accept(File dir, String name) {
                 File fileWithDir = new File(dir, name);
                 for (ProgrammingLanguage lang : languages) {
@@ -78,6 +79,7 @@ public class TestHelper {
 
         File[] subDirectories = folder.listFiles(new FileFilter() {
 
+            @Override
             public boolean accept(File pathname) {
                 return pathname.isDirectory() && !pathname.getName().endsWith(LLVMPaths.IGNORE_FOLDER_NAME);
             }

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestSuiteBase.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestSuiteBase.java
@@ -152,10 +152,12 @@ public abstract class TestSuiteBase {
 
     static class TestCaseGeneratorImpl implements TestCaseGenerator {
 
+        @Override
         public TestCaseFiles getBitCodeTestCaseFiles(File bitCodeFile) {
             return TestCaseFiles.createFromBitCodeFile(bitCodeFile);
         }
 
+        @Override
         public List<TestCaseFiles> getCompiledTestCaseFiles(File toBeCompiled) {
             List<TestCaseFiles> files = new ArrayList<>();
             File dest = TestHelper.getTempLLFile(toBeCompiled, "_main");
@@ -191,6 +193,7 @@ public abstract class TestSuiteBase {
             return optimize;
         }
 
+        @Override
         public ProgrammingLanguage[] getSupportedLanguages() {
             return GCC.getSupportedLanguages();
         }

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/spec/SpecificationFileReader.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/spec/SpecificationFileReader.java
@@ -51,6 +51,7 @@ public class SpecificationFileReader {
 
     private static final FilenameFilter FILE_NAME_INCLUDE_FILTER = new FilenameFilter() {
 
+        @Override
         public boolean accept(File dir, String name) {
             return name.endsWith(INCLUDE);
         }
@@ -58,6 +59,7 @@ public class SpecificationFileReader {
 
     private static final FilenameFilter FILE_NAME_EXCLUDE_FILTER = new FilenameFilter() {
 
+        @Override
         public boolean accept(File dir, String name) {
             return name.endsWith(EXCLUDE);
         }

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunction.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunction.java
@@ -174,6 +174,7 @@ public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunctio
         return getName() + " " + getFunctionAddress();
     }
 
+    @Override
     public ForeignAccess getForeignAccess() {
         throw new AssertionError();
     }
@@ -182,6 +183,7 @@ public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunctio
         return functionCounter;
     }
 
+    @Override
     public int compareTo(LLVMFunction o) {
         return getName().compareTo(o.getName());
     }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -70,6 +70,7 @@ public class LLVM {
     private static LLVMLanguage.LLVMLanguageProvider getProvider() {
         return new LLVMLanguage.LLVMLanguageProvider() {
 
+            @Override
             public CallTarget parse(Source code, Node context, String... argumentNames) {
                 Node findContext = LLVMLanguage.INSTANCE.createFindContextNode0();
                 LLVMContext llvmContext = LLVMLanguage.INSTANCE.findContext0(findContext);
@@ -77,6 +78,7 @@ public class LLVM {
                 return parseFile;
             }
 
+            @Override
             public LLVMContext createContext(Env env) {
                 NodeFactoryFacadeImpl facade = new NodeFactoryFacadeImpl();
                 LLVMContext context = new LLVMContext(facade, OPTIMIZATION_CONFIGURATION);


### PR DESCRIPTION
Previously, interface method overrides sometimes contained `@Override` annotations, and sometimes not. Graal-core switched with https://github.com/graalvm/graal-core/commit/35155dabdcf8d664190e2eb931eaad1405a75d03 to enforce these overrides. For consistency and readability in Sulong, these changes fix and force the  `@Override` annotation. 