### PR TITLE
Exclude testcases failing on Ubuntu 16.04

### DIFF
--- a/projects/com.oracle.truffle.llvm.test/suites-configs/gcc/gcc.c-torture/execute/working.include
+++ b/projects/com.oracle.truffle.llvm.test/suites-configs/gcc/gcc.c-torture/execute/working.include
@@ -1195,7 +1195,6 @@ gcc.c-torture/execute/va-arg-26.c
 gcc.c-torture/execute/va-arg-9.c
 gcc.c-torture/execute/920726-1.c
 gcc.c-torture/execute/20041214-1.c
-gcc.c-torture/execute/920501-8.c
 gcc.c-torture/execute/va-arg-2.c
 gcc.c-torture/execute/va-arg-20.c
 gcc.c-torture/execute/pr38051.c

--- a/projects/com.oracle.truffle.llvm.test/suites-configs/gcc/gfortran.dg/gomp/working.include
+++ b/projects/com.oracle.truffle.llvm.test/suites-configs/gcc/gfortran.dg/gomp/working.include
@@ -6,7 +6,6 @@ gfortran.dg/gomp/pr29759.f90
 gfortran.dg/gomp/proc_ptr_1.f90
 gfortran.dg/gomp/pr59488-1.f90
 gfortran.dg/gomp/pr48794.f90
-gfortran.dg/gomp/workshare3.f90
 gfortran.dg/gomp/sharing-2.f90
 gfortran.dg/gomp/block-1.f90
 gfortran.dg/gomp/associate1.f90


### PR DESCRIPTION
Base system:
Ubuntu 16.04 LTS Xenial Xerus (Beta)

Packages from Ubuntu 14.04 LTS Trusty Tahr:
- g++-4.6
- gcc-4.6
- gcc-4.6-plugin-dev
- gfortran-4.6
- gobjc++-4.6
- llvm-3.3
- pylint
- python-astroid

Dependencies also pulled from 14.04:
- cpp-4.6
- gcc-4.6-base
- gobjc-4.6
- libisl10
- libllvm3.3
- libobjc3
- libstdc++6-4.6-dev
- llvm-3.3-dev
- llvm-3.3-runtime