### PR TITLE
Reduce the two alloca node facade methods to one

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAggregateFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAggregateFactory.java
@@ -69,7 +69,6 @@ import com.oracle.truffle.llvm.nodes.impl.vector.LLVMExtractValueNodeFactory.LLV
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
-import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
 public final class LLVMAggregateFactory {
 
@@ -114,13 +113,13 @@ public final class LLVMAggregateFactory {
         }
     }
 
-    public static LLVMExpressionNode createStructConstantNode(LLVMParserRuntime runtime, boolean packed, int structSize, ResolvedType[] types, LLVMExpressionNode[] constants) {
+    public static LLVMExpressionNode createStructConstantNode(LLVMParserRuntime runtime, ResolvedType structType, boolean packed, ResolvedType[] types, LLVMExpressionNode[] constants) {
         int[] offsets = new int[types.length];
         LLVMStructWriteNode[] nodes = new LLVMStructWriteNode[types.length];
         int currentOffset = 0;
-        // FIXME we need to find a test case where alignment of structure constants matters and then
-        // supply the right alignment
-        LLVMExpressionNode alloc = runtime.allocateFunctionLifetime(structSize, LLVMStack.NO_ALIGNMENT_REQUIREMENTS);
+        int structSize = LLVMTypeHelper.getByteSize(structType);
+        int structAlignment = LLVMTypeHelper.getAlignmentByte(structType);
+        LLVMExpressionNode alloc = runtime.allocateFunctionLifetime(structType, structSize, structAlignment);
         for (int i = 0; i < types.length; i++) {
             ResolvedType resolvedType = types[i];
             if (!packed) {

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAllocFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAllocFactory.java
@@ -55,9 +55,9 @@ public class LLVMAllocFactory {
         }
     }
 
-    public static LLVMAllocaInstruction createAlloc(LLVMParserRuntime runtime, int size, int alignment) {
+    public static LLVMAllocaInstruction createAlloc(LLVMParserRuntime runtime, int byteSize, int alignment) {
         LLVMContext context = LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0());
-        return LLVMAllocaInstructionNodeGen.create(size, alignment, context, runtime.getStackPointerSlot());
+        return LLVMAllocaInstructionNodeGen.create(byteSize, alignment, context, runtime.getStackPointerSlot());
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
@@ -365,7 +365,7 @@ public final class LLVMLiteralFactory {
         LLVMBaseType llvmElementType = LLVMTypeHelper.getLLVMType(elementType);
         int baseTypeSize = LLVMTypeHelper.getByteSize(elementType);
         int size = nrElements * baseTypeSize;
-        LLVMAddressNode arrayAlloc = (LLVMAddressNode) runtime.allocateFunctionLifetime(size, LLVMTypeHelper.getAlignmentByte(arrayType));
+        LLVMAddressNode arrayAlloc = (LLVMAddressNode) runtime.allocateFunctionLifetime(arrayType, size, LLVMTypeHelper.getAlignmentByte(arrayType));
         int byteLength = LLVMTypeHelper.getByteSize(elementType);
         if (size == 0) {
             throw new AssertionError(llvmElementType + " has size of 0!");

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -61,7 +61,6 @@ import com.oracle.truffle.llvm.nodes.impl.func.LLVMGlobalRootNode;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMMemCopyFactory.LLVMMemI32CopyFactory;
 import com.oracle.truffle.llvm.nodes.impl.literals.LLVMAggregateLiteralNode.LLVMEmptyStructLiteralNode;
 import com.oracle.truffle.llvm.nodes.impl.memory.LLVMAddressZeroNode;
-import com.oracle.truffle.llvm.nodes.impl.memory.LLVMAllocInstruction.LLVMAllocaInstruction;
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnreachableNode;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
@@ -261,13 +260,13 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMExpressionNode createAlloc(LLVMBaseType llvmType, LLVMExpressionNode numElements, int byteSize, int alignment) {
-        return LLVMAllocFactory.createAlloc(runtime, llvmType, numElements, byteSize, alignment);
-    }
-
-    @Override
-    public LLVMAllocaInstruction createAlloc(int size, int alignment) {
-        return LLVMAllocFactory.createAlloc(runtime, size, alignment);
+    public LLVMExpressionNode createAlloc(ResolvedType type, int byteSize, int alignment, LLVMBaseType llvmType, LLVMExpressionNode numElements) {
+        if (numElements == null) {
+            assert llvmType == null;
+            return LLVMAllocFactory.createAlloc(runtime, byteSize, alignment);
+        } else {
+            return LLVMAllocFactory.createAlloc(runtime, llvmType, numElements, byteSize, alignment);
+        }
     }
 
     @Override
@@ -305,8 +304,8 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMExpressionNode createStructureConstantNode(boolean packed, int structureSize, ResolvedType[] types, LLVMExpressionNode[] constants) {
-        return LLVMAggregateFactory.createStructConstantNode(runtime, packed, structureSize, types, constants);
+    public LLVMExpressionNode createStructureConstantNode(ResolvedType structType, boolean packed, ResolvedType[] types, LLVMExpressionNode[] constants) {
+        return LLVMAggregateFactory.createStructConstantNode(runtime, structType, packed, types, constants);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParserRuntime.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParserRuntime.java
@@ -54,7 +54,7 @@ public interface LLVMParserRuntime {
      * @param size the bytes to be allocated
      * @return a node that allocates the requested memory.
      */
-    LLVMExpressionNode allocateFunctionLifetime(int size, int alignment);
+    LLVMExpressionNode allocateFunctionLifetime(ResolvedType type, int size, int alignment);
 
     /**
      * Gets the return slot where the function return value is stored.

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -154,9 +154,19 @@ public interface NodeFactoryFacade {
 
     LLVMExpressionNode createArrayLiteral(List<LLVMExpressionNode> arrayValues, ResolvedType arrayType);
 
-    LLVMExpressionNode createAlloc(LLVMBaseType llvmType, LLVMExpressionNode numElements, int byteSize, int alignment);
-
-    LLVMExpressionNode createAlloc(int size, int alignment);
+    /**
+     * Creates an <code>alloca</code> node with a certain number of elements.
+     *
+     * @param numElementsType the type of <code>numElements</code>
+     * @param byteSize the size of an element
+     * @param alignment the alignment requirement
+     * @param numElements how many elements to allocate, may be <code>null</code> if only one
+     *            element should be allocated
+     * @param type the type of an element, may be <code>null</code> if only one element should be
+     *            allocated
+     * @return a node that allocates the specified number of elements
+     */
+    LLVMExpressionNode createAlloc(ResolvedType type, int byteSize, int alignment, LLVMBaseType numElementsType, LLVMExpressionNode numElements);
 
     LLVMExpressionNode createInsertValue(LLVMExpressionNode resultAggregate, LLVMExpressionNode sourceAggregate, int size, int offset, LLVMExpressionNode valueToInsert, LLVMBaseType llvmType);
 
@@ -189,14 +199,14 @@ public interface NodeFactoryFacade {
     /**
      * Creates a structure literal node.
      *
+     * @param structureType type of the structure
      * @param packed whether the struct is packed (alignment of the struct is one byte and there is
      *            no padding between the elements)
-     * @param structSize the size of the structure
      * @param types the types of the structure members
      * @param constants the structure members
      * @return the constructed structure literal
      */
-    LLVMExpressionNode createStructureConstantNode(boolean packed, int structSize, ResolvedType[] types, LLVMExpressionNode[] constants);
+    LLVMExpressionNode createStructureConstantNode(ResolvedType structureType, boolean packed, ResolvedType[] types, LLVMExpressionNode[] constants);
 
     LLVMNode createMemCopyNode(LLVMExpressionNode globalVarAddress, LLVMExpressionNode constant, LLVMExpressionNode lengthNode, LLVMExpressionNode alignNode, LLVMExpressionNode isVolatileNode);
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -231,12 +231,7 @@ public abstract class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMExpressionNode createAlloc(LLVMBaseType llvmType, LLVMExpressionNode numElements, int byteSize, int alignment) {
-        return null;
-    }
-
-    @Override
-    public LLVMExpressionNode createAlloc(int size, int alignment) {
+    public LLVMExpressionNode createAlloc(ResolvedType type, int byteSize, int alignment, LLVMBaseType llvmType, LLVMExpressionNode numElements) {
         return null;
     }
 
@@ -271,7 +266,7 @@ public abstract class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMExpressionNode createStructureConstantNode(boolean packed, int structSize, ResolvedType[] types, LLVMExpressionNode[] constants) {
+    public LLVMExpressionNode createStructureConstantNode(ResolvedType structType, boolean packed, ResolvedType[] types, LLVMExpressionNode[] constants) {
         return null;
     }
 


### PR DESCRIPTION
With this change the facade only provides one method for the alloca instruction node generation instead of two.