### PR TITLE
Add an inline assembler node construction method in the facade

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -70,6 +70,8 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
+import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
+import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
 
@@ -333,6 +335,11 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     @Override
     public int getArgStartIndex() {
         return LLVMCallNode.ARG_START_INDEX;
+    }
+
+    @Override
+    public LLVMNode createInlineAssemblerExpression(String asmExpression, String asmFlags, LLVMExpressionNode[] args, LLVMBaseType retType) {
+        throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -249,4 +249,15 @@ public interface NodeFactoryFacade {
      */
     int getArgStartIndex();
 
+    /**
+     * Creates an inline assembler instruction.
+     *
+     * @param asmExpression
+     * @param asmFlags
+     * @param args
+     * @param retType the type the inline assembler instruction produces
+     * @return an inline assembler node
+     */
+    LLVMNode createInlineAssemblerExpression(String asmExpression, String asmFlags, LLVMExpressionNode[] args, LLVMBaseType retType);
+
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -296,4 +296,9 @@ public abstract class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
         return 0;
     }
 
+    @Override
+    public LLVMNode createInlineAssemblerExpression(String asmExpression, String asmFlags, LLVMExpressionNode[] finalArgs, LLVMBaseType retType) {
+        return null;
+    }
+
 }


### PR DESCRIPTION
This change adds an interface method for constructing inline assembler since one of our students is currently working on implementing inline assembler.