### PR TITLE
Commit message checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ branches:
   only:
     - master
 env:
+  - TEST_COMMAND='mx/mx su-gitlogcheck'
   - TEST_COMMAND='mx/mx pylint'
   - TEST_COMMAND='mx/mx checkstyle'
   - TEST_COMMAND='mx/mx checkoverlap'

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -620,7 +620,7 @@ def standardLinkerCommands(args=None):
 import subprocess
 import re
 
-titleWithEndingPunct = re.compile('^(.*)[\.!?]$')
+titleWithEndingPunct = re.compile(r'^(.*)[\.!?]$')
 pastTenseWords = ['installed', 'implemented', 'fixed', 'merged', 'improved', 'simplified', 'enhanced', 'changed', 'removed', 'replaced', 'substituted', 'corrected', 'used', 'moved', 'refactored']
 
 def logCheck(args=None):

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -625,7 +625,7 @@ pastTenseWords = ['installed', 'implemented', 'fixed', 'merged', 'improved', 'si
 
 def logCheck(args=None):
     error = False
-    output = subprocess.check_output(['git', 'log', '--pretty=format:"%s"'])
+    output = subprocess.check_output(['git', 'log', '--pretty=format:"%s"', '-10'])
     for s in output.splitlines():
         withoutQuotes = s[1:-1]
         if withoutQuotes[0].islower():

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -617,6 +617,31 @@ def gccBench(args=None):
 def standardLinkerCommands(args=None):
     return ['-lm', '-lgmp']
 
+import subprocess
+import re
+
+titleWithEndingPunct = re.compile('^(.*)[\.!?]$')
+pastTenseWords = ['installed', 'implemented', 'fixed', 'merged', 'improved', 'simplified', 'enhanced', 'changed', 'removed', 'replaced', 'substituted', 'corrected', 'used', 'moved', 'refactored']
+
+def logCheck(args=None):
+    error = False
+    output = subprocess.check_output(['git', 'log', '--pretty=format:"%s"'])
+    for s in output.splitlines():
+        withoutQuotes = s[1:-1]
+        if withoutQuotes[0].islower():
+            error = True
+            print s, 'starts with a lower case character'
+        if titleWithEndingPunct.match(withoutQuotes):
+            error = True
+            print s, 'ends with period, question mark, or exclamation mark'
+        for pastTenseWord in pastTenseWords:
+            if pastTenseWord in withoutQuotes.lower().split():
+                error = True
+                print s, 'contains past tense word', pastTenseWord
+    if error:
+        print "\nFound illegal git log messages! Please check CONTRIBUTING.md for commit message guidelines."
+        exit(-1)
+
 mx.update_commands(_suite, {
     'suoptbench' : [suOptBench, ''],
     'subench' : [suBench, ''],
@@ -648,5 +673,6 @@ mx.update_commands(_suite, {
     'su-gfortran' : [dragonEggGFortran, ''],
     'su-g++' : [dragonEggGPP, ''],
     'su-travis1' : [travis1, ''],
-    'su-travis2' : [travis2, '']
+    'su-travis2' : [travis2, ''],
+    'su-gitlogcheck' : [logCheck, '']
 })

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -625,7 +625,7 @@ pastTenseWords = ['installed', 'implemented', 'fixed', 'merged', 'improved', 'si
 
 def logCheck(args=None):
     error = False
-    output = subprocess.check_output(['git', 'log', '--pretty=format:"%s"', '-10'])
+    output = subprocess.check_output(['git', 'log', '--pretty=format:"%s"', '--since="2016-04-07"'])
     for s in output.splitlines():
         withoutQuotes = s[1:-1]
         if withoutQuotes[0].islower():


### PR DESCRIPTION
We decided to use stricter commit message and PR description rules in #114. To help enforcing this, this change introduces the following checks on Git commit message:

1. A message cannot start with a lower case character.
2. A message cannot end with a period, exclamation mark, or question mark.
3. A commit message should not contain past tense words such as "implemented", "fixed", "merged", and others.

Currently, many old commit messages do not comply do these rules. Thus, currently only the latest ten commit messages are checked.

Here is an example output caused by some recent violations:

```
"update Graal version" starts with a lower case character
"Update Mac building instructions." ends with period, question mark, or exclamation mark
"execute program five times in the benchmark runner" starts with a lower case character
"unreachable node documentation" starts with a lower case character
"fix assertion in insert value node construction" starts with a lower case character
"move phi node creation into the node facade" starts with a lower case character
"use constant evaluator for insert value constant evaluation" starts with a lower case character
"move memcpy node to the facade" starts with a lower case character
"remove unused conditional phi write node" starts with a lower case character
"remove untested metadata and debug nodes" starts with a lower case character
"remove untested invoke and landingpad prototypes" starts with a lower case character
"remove unused imports" starts with a lower case character
 
```