### PR TITLE
Use boxed primitives in facade

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -333,7 +333,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public int getArgStartIndex() {
+    public Integer getArgStartIndex() {
         return LLVMCallNode.ARG_START_INDEX;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -30,6 +30,7 @@
 package com.oracle.truffle.llvm.parser.factories;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.emf.ecore.EObject;
 
@@ -333,8 +334,8 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public Integer getArgStartIndex() {
-        return LLVMCallNode.ARG_START_INDEX;
+    public Optional<Integer> getArgStartIndex() {
+        return Optional.of(LLVMCallNode.ARG_START_INDEX);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -371,7 +371,7 @@ public class LLVMVisitor implements LLVMParserRuntime {
                     LLVMExpressionNode functionLoadTarget = factoryFacade.createGetElementPtr(LLVMBaseType.I32, loadedStruct, oneLiteralNode, indexedTypeLength);
                     LLVMExpressionNode loadedFunction = factoryFacade.createLoad(functionType, functionLoadTarget);
                     LLVMExpressionNode[] argNodes = new LLVMExpressionNode[]{factoryFacade.createFrameRead(LLVMBaseType.ADDRESS, getStackPointerSlot())};
-                    assert argNodes.length == factoryFacade.getArgStartIndex();
+                    assert argNodes.length == factoryFacade.getArgStartIndex().get();
                     LLVMNode functionCall = factoryFacade.createFunctionCall(loadedFunction, argNodes, LLVMBaseType.VOID);
                     globalVarNodes.add(functionCall);
                 }
@@ -564,7 +564,7 @@ public class LLVMVisitor implements LLVMParserRuntime {
         EList<Parameter> pars = functionHeader.getParameters().getParameters();
         LLVMExpressionNode stackPointerNode = factoryFacade.createFunctionArgNode(0, LLVMBaseType.ADDRESS);
         formalParamInits.add(factoryFacade.createFrameWrite(LLVMBaseType.ADDRESS, stackPointerNode, getStackPointerSlot()));
-        int argIndex = factoryFacade.getArgStartIndex();
+        int argIndex = factoryFacade.getArgStartIndex().get();
         if (resolve(functionHeader.getRettype()).isStruct()) {
             LLVMExpressionNode functionRetParNode = factoryFacade.createFunctionArgNode(argIndex++, LLVMBaseType.STRUCT);
             LLVMNode retValue = createAssignment((String) retSlot.getIdentifier(), functionRetParNode, functionHeader.getRettype());

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -247,7 +247,7 @@ public interface NodeFactoryFacade {
      *
      * @return the index
      */
-    int getArgStartIndex();
+    Integer getArgStartIndex();
 
     /**
      * Creates an inline assembler instruction.

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -30,6 +30,7 @@
 package com.oracle.truffle.llvm.parser;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.emf.ecore.EObject;
 
@@ -247,7 +248,7 @@ public interface NodeFactoryFacade {
      *
      * @return the index
      */
-    Integer getArgStartIndex();
+    Optional<Integer> getArgStartIndex();
 
     /**
      * Creates an inline assembler instruction.

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -55,8 +55,8 @@ import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
 
 /**
- * This class implements an abstract adapter that returns a default value (mostly <code>null</code>)
- * for each implemented method.
+ * This class implements an abstract adapter that returns <code>null</code> for each implemented
+ * method.
  */
 public abstract class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
 
@@ -292,8 +292,8 @@ public abstract class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public int getArgStartIndex() {
-        return 0;
+    public Integer getArgStartIndex() {
+        return null;
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -30,6 +30,7 @@
 package com.oracle.truffle.llvm.parser;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.emf.ecore.EObject;
 
@@ -292,8 +293,8 @@ public abstract class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public Integer getArgStartIndex() {
-        return null;
+    public Optional<Integer> getArgStartIndex() {
+        return Optional.empty();
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeComposite.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeComposite.java
@@ -32,6 +32,8 @@ package com.oracle.truffle.llvm.parser;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.security.cert.PKIXRevocationChecker.Option;
+import java.util.Optional;
 
 /**
  * This class implements a chain of responsibility pattern by delegating node creation to another
@@ -85,12 +87,16 @@ public abstract class NodeFactoryFacadeComposite implements NodeFactoryFacade {
 
         @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-            Object firstNode = method.invoke(first, args);
-            if (firstNode == null) {
+            Object factoryResult = method.invoke(first, args);
+            if (factoryResult == null || isEmptyOptional(factoryResult)) {
                 return method.invoke(second, args);
             } else {
-                return firstNode;
+                return factoryResult;
             }
+        }
+
+        private static boolean isEmptyOptional(Object factoryResult) {
+            return factoryResult instanceof Optional<?> && !((Optional<?>) factoryResult).isPresent();
         }
     }
 


### PR DESCRIPTION
With this change, the node creation facade uses boxed primitives to use null as a default value. This allows composite facades to delegate the implementation of a method to another facade.