### PR TITLE
Add mdl markdown file checks to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     - gobjc++-4.6
     - gcc-4.6-plugin-dev
 install:
+  - gem install mdl
   - sudo pip install astroid==1.1.0
   - sudo pip install pylint==1.1.0
   - git clone https://github.com/graalvm/mx
@@ -33,6 +34,7 @@ branches:
   only:
     - master
 env:
+  - TEST_COMMAND='mdl .'
   - TEST_COMMAND='mx/mx su-gitlogcheck'
   - TEST_COMMAND='mx/mx pylint'
   - TEST_COMMAND='mx/mx checkstyle'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ branches:
   only:
     - master
 env:
-  - TEST_COMMAND='mdl .'
+  - TEST_COMMAND='mdl -r~MD026,~MD002,~MD029,~MD032 .'
   - TEST_COMMAND='mx/mx su-gitlogcheck'
   - TEST_COMMAND='mx/mx pylint'
   - TEST_COMMAND='mx/mx checkstyle'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ branches:
   only:
     - master
 env:
-  - TEST_COMMAND='mdl -r~MD026,~MD002,~MD029,~MD032 .'
+  - TEST_COMMAND='mx/mx su-mdlcheck'
   - TEST_COMMAND='mx/mx su-gitlogcheck'
   - TEST_COMMAND='mx/mx pylint'
   - TEST_COMMAND='mx/mx checkstyle'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,12 @@ requests:
 
 Commit messages
 ================
+
 - Each commit (message) should contain (and describe) one logical change.
 
 PR request:
 ===========
+
 - You should only address one feature or change per PR request.
 - You do not need to explain self-explanatory changes such as updates of
 the Graal version.
@@ -32,6 +34,7 @@ request description field or the commit message.
 
 Both PR request titles and commit messages:
 ===========================================
+
 - Write the summary line and description of what you have done in the
 imperative mode, that is as if you were commanding someone. Start the
 line with "Fix", "Add", "Change" instead of "Fixed", "Added", "Changed".
@@ -41,6 +44,7 @@ don't end with a period.
 
 Links:
 ======
-- https://github.com/erlang/otp/wiki/writing-good-commit-messages
-- http://who-t.blogspot.co.at/2009/12/on-commit-messages.html
-- http://chris.beams.io/posts/git-commit/
+
+- [https://github.com/erlang/otp/wiki/writing-good-commit-messages](https://github.com/erlang/otp/wiki/writing-good-commit-messages)
+- [http://who-t.blogspot.co.at/2009/12/on-commit-messages.html](http://who-t.blogspot.co.at/2009/12/on-commit-messages.html)
+- [http://chris.beams.io/posts/git-commit/](http://chris.beams.io/posts/git-commit/)

--- a/ECLIPSE.md
+++ b/ECLIPSE.md
@@ -2,23 +2,26 @@
 
 In order to work with Eclipse, use `mx eclipseinit` to generate the
 Eclipse project files. Import not only the Sulong project, but also the
-Graal, Truffle, and JVMCI projects. You have the choice to either use 
+Graal, Truffle, and JVMCI projects. You have the choice to either use
 remote debugging and launch Sulong in mx, or launch Sulong within
 Eclipse.
 
 If you use Eclipse to launch Sulong, you have to ensure that all needed
 packages are on the classpath and all necessary options set. You can
-determine them by using `-v` in the mx Sulong command to make mx 
+determine them by using `-v` in the mx Sulong command to make mx
 output information on how it executed the command.
 
 ## Useful Plugins:
-* Use checkstyle (http://checkstyle.sourceforge.net/) to highlight 
-style errors during development. Alternatively you can also use 
+
+* Use [checkstyle](http://checkstyle.sourceforge.net/) to highlight
+style errors during development. Alternatively you can also use
 mx checkstyle to run checkstyle from mx.
 
 ## Useful Configs:
-* See 
-http://stackoverflow.com/questions/2604424/how-can-i-add-a-
-	default-header-to-my-source-files-automatically-in-eclipse 
-for alternatives regarding adding the copyright header automatically 
+
+* See
+[http://stackoverflow.com/questions/2604424/how-can-i-add-a-
+    default-header-to-my-source-files-automatically-in-eclipse](http://stackoverflow.com/questions/2604424/how-can-i-add-a-
+    default-header-to-my-source-files-automatically-in-eclipse)
+for alternatives regarding adding the copyright header automatically
 for new filse.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,23 +2,23 @@ Copyright (c) 2016, Oracle and/or its affiliates.
 
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions are 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
 met:
 
-1. Redistributions of source code must retain the above copyright 
+1. Redistributions of source code must retain the above copyright
 notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright 
-notice, this list of conditions and the following disclaimer in the 
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
 documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its 
-contributors may be used to endorse or promote products derived from 
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
 PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 Sulong (Graal LLVM) is an interpreter for LLVM IR written in
 Java using the Truffle language implementation framework and Graal as a
-just-in-time (JIT) compiler. 
+just-in-time (JIT) compiler.
 
-With Sulong you can execute C/C++, Fortran, and other programs written 
+With Sulong you can execute C/C++, Fortran, and other programs written
 in a LLVM language on the JVM. To execute a program by Sulong, you have
 to compile the program to LLVM IR by a LLVM front end such as Clang. By
-using Truffle and Java the interpreter implementation is simple and is 
+using Truffle and Java the interpreter implementation is simple and is
 thus a great platform for experimentation. On the other hand, dynamic
 optimizations and JIT compilation with Graal still provides native
-execution speed (improving performance is work in progress). Through 
+execution speed (improving performance is work in progress). Through
 Truffle's language interoperability capabilities, you will soon be able
 to call functions from/to other languages on Truffle such as Ruby,
 JavaScript, or R.
@@ -21,6 +21,7 @@ by Alon Mishne.
 
 External Dependencies
 ---------------------
+
 Make sure you have GCC-4.6, G++-4.6, and GFortran-4.6 installed. For
 a full list of external dependencies on Ubuntu you can look at our
 [Travis configuration](https://github.com/graalvm/sulong/blob/master/.travis.yml).
@@ -31,10 +32,10 @@ On the Mac you can use Homebrew:
     brew install gcc46 --with-fortran
     brew link --force gmp4
 
-On some versions of Mac OS X, `gcc46` may fail to install with a segmentation
-fault (https://github.com/Homebrew/homebrew-versions/issues/515). A fix for this
+On some versions of Mac OS X, `gcc46` [may fail to install with a segmentation
+fault](https://github.com/Homebrew/homebrew-versions/issues/515). A fix for this
 is to `brew edit gcc46` and replace the patch `p0` with
-https://gist.githubusercontent.com/chrisseaton/7008085997269e3478e1/raw/46bff773d37914d6e66d0d8e1cab0d50d77e7280/patch-10.10.diff,
+[patch-10.10.diff](https://gist.githubusercontent.com/chrisseaton/7008085997269e3478e1/raw/46bff773d37914d6e66d0d8e1cab0d50d77e7280/patch-10.10.diff),
 shasum `51814a0d79a9f21344c76f2d4235b59d9a4bc1601117e8ca5bfabdb82305aad0`.
 
 However you install GCC on the Mac, you may then need to manually link the
@@ -45,6 +46,7 @@ gcc libraries we use into a location where they can be found, as
 
 How to get started?
 -------------------
+
 First create a new directory, which will contain the needed GraalVM
 projects:
 
@@ -68,7 +70,7 @@ Next, build the project:
 The mx tool will ask you to choose between its server and jvmci
 configuration. For now, just select server. You can read the differences
 between the configurations on
-https://wiki.openjdk.java.net/display/Graal/Instructions. The first
+[the Graal wiki](https://wiki.openjdk.java.net/display/Graal/Instructions). The first
 build will take some time because mx has not only to build Sulong,
 but also its dependencies and the Graal VM.
 
@@ -87,9 +89,9 @@ for other IDEs):
 If you want to inspect the command line that mx generates for a mx
 command you can use the -v flag.
 
-
 From where does the project name originate?
 -------------------------------------------
+
 Sulong is the romanization of the Chinese term "速龙" (Velocisaurus).
 The first character translates as fast, rapid or quick, while the second
 character means dragon. A literal translation of the name giving Chinese
@@ -100,6 +102,7 @@ project.
 
 What is LLVM?
 -------------
+
 LLVM is an umbrella project for a modular and reusable compiler
 infrastructure written in C++. It includes a compiler frontend `clang`
 for compiling C, C++, Objective C and Objective C++ to LLVM bitcode IR.
@@ -110,11 +113,13 @@ applied during compile-time, link-time, runtime, and offline.
 
 What is LLVM IR?
 ----------------
+
 LLVM IR is a language that resembles assembler, but which provides
 type-safety and has virtual registers that are in Static Single
 Assignment (SSA) form.
 
 Consider the following C program:
+
 ```C
 #include <stdio.h>
 
@@ -130,22 +135,23 @@ file, one can see a LLVM IR program that looks similar to the following:
 ```
 ; ModuleID = 'test.c'
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-
-	i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-
-	s0:64:64-f80:128:128-n8:16:32:64-S128"
+    i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-
+    s0:64:64-f80:128:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 
 @.str = private unnamed_addr constant [14 x i8]
-	c"Hello World \0A\00", align 1
+    c"Hello World \0A\00", align 1
 @str = internal constant [13 x i8] c"Hello World \00"
 
 define i32 @main() nounwind uwtable {
   %puts = tail call i32 @puts(i8* getelementptr inbounds
-	([13 x i8]* @str, i64 0, i64 0))
+    ([13 x i8]* @str, i64 0, i64 0))
   ret i32 0
 }
 
 declare i32 @puts(i8* nocapture) nounwind
 ```
+
 The file contains a `datalayout` and `triple` that specifies how data
 should be laid out in memory, and which architecture should be targeted
 in the backend. One can also see global the global variables `@.str` and
@@ -153,24 +159,25 @@ in the backend. One can also see global the global variables `@.str` and
 `@puts` function declaration that refers to the C standard library
 `puts` function.
 
-
 What is Truffle?
 ----------------
-[Truffle](https://github.com/graalvm/truffle) is a language 
+
+[Truffle](https://github.com/graalvm/truffle) is a language
 implementation framework written in Java. It allows language designers
 to implement a (guest) language as an Abstract Syntax Tree (AST)
 interpreter. Additionally, Truffle provides many language independent
-facilities to the host language such as profiling, debugging, and 
+facilities to the host language such as profiling, debugging, and
 language interoperability. When a Truffle AST is executed often and then
 JIT-compiled with Graal, Graal can exploit its knowledge about the
 Truffle framework and produce efficient machine code. Normally, the
-Truffle implementation can also run on any other JVM. 
+Truffle implementation can also run on any other JVM.
 However, Truffle LLVM relies on the Foreign Function Interface (FFI) of
 Graal to provide native interoperability (e.g., to call the native
 malloc) and thus has a direct dependency on Graal.
 
 What is Graal?
 -------------
+
 Graal is a JIT compiler written in Java that receives Java bytecode as
 an input and produces machine code. Currently, Graal is an alternative
 to the C1 and C2 compilers of the HotSpot VM. The term GraalVM refers to
@@ -180,34 +187,39 @@ escape analysis.
 
 How can I trace compilation?
 ----------------------------
+
 You can enable textual notifications about compilations:
+
 ```
 mx su-run <file> -Dgraal.TraceTruffleCompilation=true
 ```
 
 To visualize Graal's graphs you can use the Ideal Graph Visualizer:
+
 ```
 mx igv
 mx su-run <file> -Dgraal.Dump=Truffle
 ```
 
-
 Build Status
 ------------
+
 Thanks to Travis CI, all commits of this repository are tested:
 [![Build Status](https://travis-ci.org/graalvm/sulong.svg?branch=master)](https://travis-ci.org/graalvm/sulong)
 
 Further Information
 -------------------
+
 The parser of the project bases on the LLVM IR editor plugin for Eclipse
 by [Alon Mishne](https://github.com/amishne/llvm-ir-editor).
 
-The logo was designed by 
+The logo was designed by
 [Valentina Caruso](https://www.behance.net/volantina).
 
 Links:
-* LLVM IR: http://llvm.org/docs/LangRef.html
+
+* LLVM IR: [http://llvm.org/docs/LangRef.html](http://llvm.org/docs/LangRef.html)
 * Instructions to build Graal:
-	https://wiki.openjdk.java.net/display/Graal/Instructions
+    [https://wiki.openjdk.java.net/display/Graal/Instructions](https://wiki.openjdk.java.net/display/Graal/Instructions)
 * Truffle and Graal publications, presentations, and videos:
-	https://wiki.openjdk.java.net/display/Graal/Publications+and+Presentations
+    [https://wiki.openjdk.java.net/display/Graal/Publications+and+Presentations](https://wiki.openjdk.java.net/display/Graal/Publications+and+Presentations)

--- a/mx.sulong/CHECKSTYLE.md
+++ b/mx.sulong/CHECKSTYLE.md
@@ -3,5 +3,5 @@ Currently there are three different checkstyle files:
  numbers and System.out.println/System.err.println
 * com.oracle.truffle.llvm: allows System.out.println/System.err.println
  but no magic numbers
-* com.oracle.truffle.llvm.nodes: the most restrictive which does not 
+* com.oracle.truffle.llvm.nodes: the most restrictive which does not
  magic numbers, nor System.out.println/System.err.println

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -642,6 +642,14 @@ def logCheck(args=None):
         print "\nFound illegal git log messages! Please check CONTRIBUTING.md for commit message guidelines."
         exit(-1)
 
+def mdlCheck(args=None):
+    """runs mdl on all .md files in the projects and root directory"""
+    for path, _, files in os.walk('.'):
+        for f in files:
+            if f.endswith('.md') and (path.startswith('./projects') or path is '.'):
+                absPath = path + '/' + f
+                subprocess.check_output(['mdl', '-r~MD026,~MD002,~MD029,~MD032', absPath])
+
 mx.update_commands(_suite, {
     'suoptbench' : [suOptBench, ''],
     'subench' : [suBench, ''],
@@ -674,5 +682,6 @@ mx.update_commands(_suite, {
     'su-g++' : [dragonEggGPP, ''],
     'su-travis1' : [travis1, ''],
     'su-travis2' : [travis2, ''],
-    'su-gitlogcheck' : [logCheck, '']
+    'su-gitlogcheck' : [logCheck, ''],
+    'su-mdlcheck' : [mdlCheck, '']
 })

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -625,7 +625,7 @@ pastTenseWords = ['installed', 'implemented', 'fixed', 'merged', 'improved', 'si
 
 def logCheck(args=None):
     error = False
-    output = subprocess.check_output(['git', 'log', '--pretty=format:"%s"', '--since="2016-04-07"'])
+    output = subprocess.check_output(['git', 'log', '--pretty=format:"%s"', '--after="2016-04-08"'])
     for s in output.splitlines():
         withoutQuotes = s[1:-1]
         if withoutQuotes[0].islower():

--- a/projects/com.intel.llvm.ireditor/README.md
+++ b/projects/com.intel.llvm.ireditor/README.md
@@ -1,16 +1,16 @@
-Including this project into the mx workflow is a rather tedious task. 
-A previous attempt to use the xtext infrastructure in a standalone way 
+Including this project into the mx workflow is a rather tedious task.
+A previous attempt to use the xtext infrastructure in a standalone way
 failed, because some code fragments did not work with absolute paths.
 
-At the moment, the project is thus included in the suite with only a 
-dummy source directory. Since findbug fails on the gate if no bin 
-directory exists, we still have to have some Java file to compile, 
-which is in the mentioned dummy source directory. However, mx does not 
-compile projects with a plugin.xml file. To circumvent this issue, the 
+At the moment, the project is thus included in the suite with only a
+dummy source directory. Since findbug fails on the gate if no bin
+directory exists, we still have to have some Java file to compile,
+which is in the mentioned dummy source directory. However, mx does not
+compile projects with a plugin.xml file. To circumvent this issue, the
 plugin.xml is not checked into the repository.
 
-In order to still be able to work on the project, it is recommended to 
+In order to still be able to work on the project, it is recommended to
 use Eclipse. After import of the project, the folders with Java sources
-have to be added as source folders. Then, the project has to be 
-converted to a plugin project and xtext nature added to it. Afterwards 
-it is possible to generate the parser. 
+have to be added as source folders. Then, the project has to be
+converted to a plugin project and xtext nature added to it. Afterwards
+it is possible to generate the parser.


### PR DESCRIPTION
This change adds [markdownlint](https://github.com/mivok/markdownlint) to the Travis configuration in order to have consistency between the different markdown files and to prevent other minor issues such as trailing whitespaces.

This is a squashed PR of #139.