### PR TITLE
Increase the TruffleTimeThreshold for the benchmark runners

### DIFF
--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -495,7 +495,7 @@ def getRemoteClasspathOption():
     return "-Dsulong.TestRemoteBootPath=-Xbootclasspath/p:" + mx.distribution('truffle:TRUFFLE_API').path + " " + getLLVMRootOption() + " " + compilationSucceedsOption() + " -XX:-UseJVMCIClassLoader -Dsulong.Debug=false -Dsulong.IntrinsifyCFunctions=false -Djvmci.Compiler=graal"
 
 def getBenchmarkOptions():
-    return ['-Dgraal.TruffleBackgroundCompilation=false', '-Dsulong.IntrinsifyCFunctions=false', '-Dsulong.ExecutionCount=5', '-Dsulong.PerformanceWarningsAreFatal=true']
+    return ['-Dgraal.TruffleBackgroundCompilation=false', '-Dsulong.IntrinsifyCFunctions=false', '-Dsulong.ExecutionCount=5', '-Dsulong.PerformanceWarningsAreFatal=true', '-Dgraal.TruffleTimeThreshold=1000000']
 
 def getLLVMRootOption():
     return "-Dsulong.ProjectRoot=" + _root


### PR DESCRIPTION
This change increases the TruffleTimeThreshold to prevent that benchmark functions are not compiled when warmup takes too long.