### PR TITLE
Use the node facade for the function substitutions

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
@@ -57,7 +57,7 @@ public class LLVMContext extends ExecutionContext {
 
     public LLVMContext(NodeFactoryFacade facade, LLVMOptimizationConfiguration optimizationConfig) {
         nativeLookup = new NativeLookup(facade);
-        this.registry = new LLVMFunctionRegistry(optimizationConfig);
+        this.registry = new LLVMFunctionRegistry(optimizationConfig, facade);
 
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
@@ -29,7 +29,6 @@
  */
 package com.oracle.truffle.llvm.nodes.impl.base;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -48,22 +47,6 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMAbortFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMACosFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMASinFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMATanFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMCosFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMExpFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMLogFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMSinFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMSqrtFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMTanFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMTanhFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCallocFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMExitFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMFreeFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMMallocFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsic;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsic.LLVMVoidIntrinsic;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNode.LLVMIntrinsicVoidNode;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicAddressNodeGen;
@@ -73,6 +56,7 @@ import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeF
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI32NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI64NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI8NodeGen;
+import com.oracle.truffle.llvm.parser.NodeFactoryFacade;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.types.LLVMFunction;
 
@@ -81,38 +65,10 @@ import com.oracle.truffle.llvm.types.LLVMFunction;
  */
 public class LLVMFunctionRegistry {
 
-    private final Map<String, NodeFactory<? extends LLVMIntrinsic>> intrinsics = new HashMap<>();
+    private final Map<String, NodeFactory<? extends LLVMNode>> intrinsics;
 
-    public LLVMFunctionRegistry(LLVMOptimizationConfiguration optimizationConfig) {
-        initializeIntrinsics(optimizationConfig);
-    }
-
-    private void initializeIntrinsics(LLVMOptimizationConfiguration optimizationConfig) {
-        // Fortran
-        intrinsics.put("@_gfortran_abort", LLVMAbortFactory.getInstance());
-
-        // C
-        intrinsics.put("@abort", LLVMAbortFactory.getInstance());
-        intrinsics.put("@exit", LLVMExitFactory.getInstance());
-
-        if (optimizationConfig.intrinsifyCLibraryFunctions()) {
-            // math.h
-            intrinsics.put("@acos", LLVMACosFactory.getInstance());
-            intrinsics.put("@asin", LLVMASinFactory.getInstance());
-            intrinsics.put("@atan", LLVMATanFactory.getInstance());
-            intrinsics.put("@cos", LLVMCosFactory.getInstance());
-            intrinsics.put("@exp", LLVMExpFactory.getInstance());
-            intrinsics.put("@log", LLVMLogFactory.getInstance());
-            intrinsics.put("@sqrt", LLVMSqrtFactory.getInstance());
-            intrinsics.put("@sin", LLVMSinFactory.getInstance());
-            intrinsics.put("@tan", LLVMTanFactory.getInstance());
-            intrinsics.put("@tanh", LLVMTanhFactory.getInstance());
-
-            // other libraries
-            intrinsics.put("@malloc", LLVMMallocFactory.getInstance());
-            intrinsics.put("@free", LLVMFreeFactory.getInstance());
-            intrinsics.put("@calloc", LLVMCallocFactory.getInstance());
-        }
+    public LLVMFunctionRegistry(LLVMOptimizationConfiguration optimizationConfig, NodeFactoryFacade facade) {
+        this.intrinsics = facade.getFunctionSubstitutionFactories(optimizationConfig);
     }
 
     /**
@@ -148,14 +104,14 @@ public class LLVMFunctionRegistry {
     private void registerIntrinsics() {
         for (String intrinsicFunction : intrinsics.keySet()) {
             LLVMFunction function = LLVMFunction.createFromName(intrinsicFunction);
-            NodeFactory<? extends LLVMIntrinsic> nodeFactory = intrinsics.get(intrinsicFunction);
+            NodeFactory<? extends LLVMNode> nodeFactory = intrinsics.get(intrinsicFunction);
             List<Class<? extends Node>> executionSignature = nodeFactory.getExecutionSignature();
             int nrArguments = executionSignature.size();
             LLVMNode[] args = new LLVMNode[nrArguments];
             for (int i = 0; i < nrArguments; i++) {
                 args[i] = getArgReadNode(executionSignature, i);
             }
-            LLVMIntrinsic intrinsicNode = nodeFactory.createNode((Object[]) args);
+            LLVMNode intrinsicNode = nodeFactory.createNode((Object[]) args);
             RootNode functionRoot = getRootNode(intrinsicNode);
             RootCallTarget callTarget = Truffle.getRuntime().createCallTarget(functionRoot);
             addToFunctionMap(function, callTarget);
@@ -184,7 +140,7 @@ public class LLVMFunctionRegistry {
         return argNode;
     }
 
-    private static RootNode getRootNode(LLVMIntrinsic intrinsicNode) throws AssertionError {
+    private static RootNode getRootNode(LLVMNode intrinsicNode) throws AssertionError {
         RootNode functionRoot;
         if (intrinsicNode instanceof LLVMI8Node) {
             functionRoot = LLVMIntrinsicI8NodeGen.create((LLVMI8Node) intrinsicNode);
@@ -201,7 +157,7 @@ public class LLVMFunctionRegistry {
         } else if (intrinsicNode instanceof LLVMAddressNode) {
             functionRoot = LLVMIntrinsicAddressNodeGen.create((LLVMAddressNode) intrinsicNode);
         } else if (intrinsicNode instanceof LLVMVoidIntrinsic) {
-            functionRoot = new LLVMIntrinsicVoidNode(((LLVMNode) intrinsicNode));
+            functionRoot = new LLVMIntrinsicVoidNode(intrinsicNode);
         } else {
             throw new AssertionError(intrinsicNode.getClass());
         }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
@@ -39,21 +39,6 @@ import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
-import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMDoubleNode;
-import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMFloatNode;
-import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI16Node;
-import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
-import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
-import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsic.LLVMVoidIntrinsic;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNode.LLVMIntrinsicVoidNode;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicAddressNodeGen;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicDoubleNodeGen;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicFloatNodeGen;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI16NodeGen;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI32NodeGen;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI64NodeGen;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI8NodeGen;
 import com.oracle.truffle.llvm.parser.NodeFactoryFacade;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.types.LLVMFunction;
@@ -112,34 +97,10 @@ public class LLVMFunctionRegistry {
                 args[i] = facade.createFunctionArgNode(i, executionSignature.get(i));
             }
             LLVMNode intrinsicNode = nodeFactory.createNode((Object[]) args);
-            RootNode functionRoot = getRootNode(intrinsicNode);
+            RootNode functionRoot = facade.createFunctionSubstitutionRootNode(intrinsicNode);
             RootCallTarget callTarget = Truffle.getRuntime().createCallTarget(functionRoot);
             addToFunctionMap(function, callTarget);
         }
-    }
-
-    private static RootNode getRootNode(LLVMNode intrinsicNode) throws AssertionError {
-        RootNode functionRoot;
-        if (intrinsicNode instanceof LLVMI8Node) {
-            functionRoot = LLVMIntrinsicI8NodeGen.create((LLVMI8Node) intrinsicNode);
-        } else if (intrinsicNode instanceof LLVMI16Node) {
-            functionRoot = LLVMIntrinsicI16NodeGen.create((LLVMI16Node) intrinsicNode);
-        } else if (intrinsicNode instanceof LLVMI32Node) {
-            functionRoot = LLVMIntrinsicI32NodeGen.create((LLVMI32Node) intrinsicNode);
-        } else if (intrinsicNode instanceof LLVMI64Node) {
-            functionRoot = LLVMIntrinsicI64NodeGen.create((LLVMI64Node) intrinsicNode);
-        } else if (intrinsicNode instanceof LLVMFloatNode) {
-            functionRoot = LLVMIntrinsicFloatNodeGen.create((LLVMFloatNode) intrinsicNode);
-        } else if (intrinsicNode instanceof LLVMDoubleNode) {
-            functionRoot = LLVMIntrinsicDoubleNodeGen.create((LLVMDoubleNode) intrinsicNode);
-        } else if (intrinsicNode instanceof LLVMAddressNode) {
-            functionRoot = LLVMIntrinsicAddressNodeGen.create((LLVMAddressNode) intrinsicNode);
-        } else if (intrinsicNode instanceof LLVMVoidIntrinsic) {
-            functionRoot = new LLVMIntrinsicVoidNode(intrinsicNode);
-        } else {
-            throw new AssertionError(intrinsicNode.getClass());
-        }
-        return functionRoot;
     }
 
     private void addToFunctionMap(LLVMFunction function, RootCallTarget callTarget) {

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
@@ -101,6 +101,15 @@ import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVMI8Ca
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVMStructCallUnboxNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVMVarBitCallUnboxNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVMVectorCallUnboxNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsic.LLVMVoidIntrinsic;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNode.LLVMIntrinsicVoidNode;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicAddressNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicDoubleNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicFloatNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI16NodeGen;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI32NodeGen;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI64NodeGen;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI8NodeGen;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
@@ -291,6 +300,30 @@ public final class LLVMFunctionFactory {
             throw new AssertionError(clazz);
         }
         return argNode;
+    }
+
+    public static RootNode createFunctionSubstitutionRootNode(LLVMNode intrinsicNode) {
+        RootNode functionRoot;
+        if (intrinsicNode instanceof LLVMI8Node) {
+            functionRoot = LLVMIntrinsicI8NodeGen.create((LLVMI8Node) intrinsicNode);
+        } else if (intrinsicNode instanceof LLVMI16Node) {
+            functionRoot = LLVMIntrinsicI16NodeGen.create((LLVMI16Node) intrinsicNode);
+        } else if (intrinsicNode instanceof LLVMI32Node) {
+            functionRoot = LLVMIntrinsicI32NodeGen.create((LLVMI32Node) intrinsicNode);
+        } else if (intrinsicNode instanceof LLVMI64Node) {
+            functionRoot = LLVMIntrinsicI64NodeGen.create((LLVMI64Node) intrinsicNode);
+        } else if (intrinsicNode instanceof LLVMFloatNode) {
+            functionRoot = LLVMIntrinsicFloatNodeGen.create((LLVMFloatNode) intrinsicNode);
+        } else if (intrinsicNode instanceof LLVMDoubleNode) {
+            functionRoot = LLVMIntrinsicDoubleNodeGen.create((LLVMDoubleNode) intrinsicNode);
+        } else if (intrinsicNode instanceof LLVMAddressNode) {
+            functionRoot = LLVMIntrinsicAddressNodeGen.create((LLVMAddressNode) intrinsicNode);
+        } else if (intrinsicNode instanceof LLVMVoidIntrinsic) {
+            functionRoot = new LLVMIntrinsicVoidNode(intrinsicNode);
+        } else {
+            throw new AssertionError(intrinsicNode.getClass());
+        }
+        return functionRoot;
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
@@ -33,6 +33,7 @@ import com.intel.llvm.ireditor.types.ResolvedStructType;
 import com.intel.llvm.ireditor.types.ResolvedType;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
@@ -65,6 +66,8 @@ import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMIVarBit
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMStructRetNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMVectorRetNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMVoidReturnNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory;
+import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVM80BitFloatArgNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMAddressArgNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMDoubleArgNodeGen;
@@ -267,6 +270,27 @@ public final class LLVMFunctionFactory {
             default:
                 throw new AssertionError(returnType);
         }
+    }
+
+    public static LLVMNode createFunctionArgNode(int i, Class<? extends Node> clazz) {
+        int realIndex = LLVMCallNode.ARG_START_INDEX + i;
+        LLVMNode argNode;
+        if (clazz.equals(LLVMI32Node.class)) {
+            argNode = LLVMArgNodeFactory.LLVMI32ArgNodeGen.create(realIndex);
+        } else if (clazz.equals(LLVMI64Node.class)) {
+            argNode = LLVMArgNodeFactory.LLVMI64ArgNodeGen.create(realIndex);
+        } else if (clazz.equals(LLVMFloatNode.class)) {
+            argNode = LLVMArgNodeFactory.LLVMFloatArgNodeGen.create(realIndex);
+        } else if (clazz.equals(LLVMDoubleNode.class)) {
+            argNode = LLVMArgNodeFactory.LLVMDoubleArgNodeGen.create(realIndex);
+        } else if (clazz.equals(LLVMAddressNode.class)) {
+            argNode = LLVMArgNodeFactory.LLVMAddressArgNodeGen.create(realIndex);
+        } else if (clazz.equals(LLVMFunctionNode.class)) {
+            argNode = LLVMArgNodeFactory.LLVMFunctionArgNodeGen.create(realIndex);
+        } else {
+            throw new AssertionError(clazz);
+        }
+        return argNode;
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.parser.factories;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.oracle.truffle.api.dsl.NodeFactory;
+import com.oracle.truffle.llvm.nodes.base.LLVMNode;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMAbortFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMACosFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMASinFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMATanFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMCosFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMExpFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMLogFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMSinFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMSqrtFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMTanFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMTanhFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCallocFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMExitFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMFreeFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMMallocFactory;
+import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
+
+public class LLVMRuntimeIntrinsicFactory {
+
+    public static Map<String, NodeFactory<? extends LLVMNode>> getFunctionSubstitutionFactories(LLVMOptimizationConfiguration optConfig) {
+
+        Map<String, NodeFactory<? extends LLVMNode>> intrinsics = new HashMap<>();
+        // Fortran
+        intrinsics.put("@_gfortran_abort", LLVMAbortFactory.getInstance());
+
+        // C
+        intrinsics.put("@abort", LLVMAbortFactory.getInstance());
+        intrinsics.put("@exit", LLVMExitFactory.getInstance());
+
+        if (optConfig.intrinsifyCLibraryFunctions()) {
+            // math.h
+            intrinsics.put("@acos", LLVMACosFactory.getInstance());
+            intrinsics.put("@asin", LLVMASinFactory.getInstance());
+            intrinsics.put("@atan", LLVMATanFactory.getInstance());
+            intrinsics.put("@cos", LLVMCosFactory.getInstance());
+            intrinsics.put("@exp", LLVMExpFactory.getInstance());
+            intrinsics.put("@log", LLVMLogFactory.getInstance());
+            intrinsics.put("@sqrt", LLVMSqrtFactory.getInstance());
+            intrinsics.put("@sin", LLVMSinFactory.getInstance());
+            intrinsics.put("@tan", LLVMTanFactory.getInstance());
+            intrinsics.put("@tanh", LLVMTanhFactory.getInstance());
+
+            // other libraries
+            intrinsics.put("@malloc", LLVMMallocFactory.getInstance());
+            intrinsics.put("@free", LLVMFreeFactory.getInstance());
+            intrinsics.put("@calloc", LLVMCallocFactory.getInstance());
+        }
+        return intrinsics;
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -44,6 +44,7 @@ import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
@@ -348,6 +349,11 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     @Override
     public Map<String, NodeFactory<? extends LLVMNode>> getFunctionSubstitutionFactories(LLVMOptimizationConfiguration optConfig) {
         return LLVMRuntimeIntrinsicFactory.getFunctionSubstitutionFactories(optConfig);
+    }
+
+    @Override
+    public LLVMNode createFunctionArgNode(int i, Class<? extends Node> clazz) {
+        return LLVMFunctionFactory.createFunctionArgNode(i, clazz);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -356,4 +356,9 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
         return LLVMFunctionFactory.createFunctionArgNode(i, clazz);
     }
 
+    @Override
+    public RootNode createFunctionSubstitutionRootNode(LLVMNode intrinsicNode) {
+        return LLVMFunctionFactory.createFunctionSubstitutionRootNode(intrinsicNode);
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -30,6 +30,7 @@
 package com.oracle.truffle.llvm.parser.factories;
 
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
 
@@ -39,6 +40,7 @@ import com.intel.llvm.ireditor.lLVM_IR.Type;
 import com.intel.llvm.ireditor.types.ResolvedType;
 import com.intel.llvm.ireditor.types.ResolvedVectorType;
 import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
@@ -70,6 +72,7 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
+import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
 import com.oracle.truffle.llvm.types.LLVMAddress;
@@ -340,6 +343,11 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     @Override
     public LLVMNode createInlineAssemblerExpression(String asmExpression, String asmFlags, LLVMExpressionNode[] args, LLVMBaseType retType) {
         throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
+    }
+
+    @Override
+    public Map<String, NodeFactory<? extends LLVMNode>> getFunctionSubstitutionFactories(LLVMOptimizationConfiguration optConfig) {
+        return LLVMRuntimeIntrinsicFactory.getFunctionSubstitutionFactories(optConfig);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -44,6 +44,7 @@ import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
@@ -101,6 +102,22 @@ public interface NodeFactoryFacade {
     LLVMNode createNonVoidRet(LLVMExpressionNode retValue, ResolvedType resolvedType);
 
     LLVMExpressionNode createFunctionArgNode(int argIndex, LLVMBaseType paramType);
+
+    /**
+     * Creates a function argument read node.
+     *
+     * @param argIndex the index from where to read the argument
+     * @param clazz the expected class of the argument
+     * @return an argument node
+     */
+    LLVMNode createFunctionArgNode(int argIndex, Class<? extends Node> clazz);
+
+    /**
+     * Returns the index of the first argument of the formal parameter list.
+     *
+     * @return the index
+     */
+    int getArgStartIndex();
 
     LLVMNode createFunctionCall(LLVMExpressionNode functionNode, LLVMExpressionNode[] argNodes, LLVMBaseType llvmType);
 
@@ -244,13 +261,6 @@ public interface NodeFactoryFacade {
      * @return a function root node
      */
     RootNode createFunctionStartNode(LLVMExpressionNode functionBodyNode, LLVMNode[] beforeFunction, LLVMNode[] afterFunction, FrameDescriptor frameDescriptor, String functionName);
-
-    /**
-     * Returns the index of the first argument of the formal parameter list.
-     *
-     * @return the index
-     */
-    int getArgStartIndex();
 
     /**
      * Creates an inline assembler instruction.

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -30,6 +30,7 @@
 package com.oracle.truffle.llvm.parser;
 
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
 
@@ -39,6 +40,7 @@ import com.intel.llvm.ireditor.lLVM_IR.Type;
 import com.intel.llvm.ireditor.types.ResolvedType;
 import com.intel.llvm.ireditor.types.ResolvedVectorType;
 import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
@@ -51,6 +53,7 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
+import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
 
@@ -259,5 +262,14 @@ public interface NodeFactoryFacade {
      * @return an inline assembler node
      */
     LLVMNode createInlineAssemblerExpression(String asmExpression, String asmFlags, LLVMExpressionNode[] args, LLVMBaseType retType);
+
+    /**
+     * Gets factories that provide substitutions for (standard library) functions. The substitutions
+     * are installed when a function is called the first time.
+     *
+     * @param optimizationConfig
+     * @return a map of function names that map to node factories
+     */
+    Map<String, NodeFactory<? extends LLVMNode>> getFunctionSubstitutionFactories(LLVMOptimizationConfiguration optimizationConfig);
 
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -282,4 +282,14 @@ public interface NodeFactoryFacade {
      */
     Map<String, NodeFactory<? extends LLVMNode>> getFunctionSubstitutionFactories(LLVMOptimizationConfiguration optimizationConfig);
 
+    /**
+     * Creates a function substitution root node from an already existing function substitution
+     * node.
+     *
+     * @param intrinsicNode the existing function substitution node, created from
+     *            {@link #getFunctionSubstitutionFactories(LLVMOptimizationConfiguration)}
+     * @return the root node for the intrinsic
+     */
+    RootNode createFunctionSubstitutionRootNode(LLVMNode intrinsicNode);
+
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -315,4 +315,9 @@ public abstract class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
         return null;
     }
 
+    @Override
+    public RootNode createFunctionSubstitutionRootNode(LLVMNode intrinsicNode) {
+        return null;
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -44,6 +44,7 @@ import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
@@ -306,6 +307,11 @@ public abstract class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
 
     @Override
     public Map<String, NodeFactory<? extends LLVMNode>> getFunctionSubstitutionFactories(LLVMOptimizationConfiguration optimizationConfig) {
+        return null;
+    }
+
+    @Override
+    public LLVMNode createFunctionArgNode(int argIndex, Class<? extends Node> clazz) {
         return null;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -30,6 +30,7 @@
 package com.oracle.truffle.llvm.parser;
 
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
 
@@ -39,6 +40,7 @@ import com.intel.llvm.ireditor.lLVM_IR.Type;
 import com.intel.llvm.ireditor.types.ResolvedType;
 import com.intel.llvm.ireditor.types.ResolvedVectorType;
 import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
@@ -51,6 +53,7 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
+import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
 
@@ -298,6 +301,11 @@ public abstract class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
 
     @Override
     public LLVMNode createInlineAssemblerExpression(String asmExpression, String asmFlags, LLVMExpressionNode[] finalArgs, LLVMBaseType retType) {
+        return null;
+    }
+
+    @Override
+    public Map<String, NodeFactory<? extends LLVMNode>> getFunctionSubstitutionFactories(LLVMOptimizationConfiguration optimizationConfig) {
         return null;
     }
 


### PR DESCRIPTION
With this change, the function registry creates the intrinsic nodes over the node facade.