### PR TITLE
Remove unnecessary specializations for the intrinsic nodes

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/LLVMIntrinsicRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/LLVMIntrinsicRootNode.java
@@ -34,16 +34,9 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.RootNode;
+import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
-import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
-import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMDoubleNode;
-import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMFloatNode;
-import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI16Node;
-import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
-import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
-import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
-import com.oracle.truffle.llvm.types.LLVMAddress;
 
 /**
  * This class is the entry point for every intrinsified (substituted) function.
@@ -81,68 +74,13 @@ public abstract class LLVMIntrinsicRootNode extends RootNode {
         }
     }
 
-    @NodeChild(type = LLVMI8Node.class, value = "node")
-    public abstract static class LLVMIntrinsicI8Node extends LLVMIntrinsicRootNode {
+    @NodeChild(type = LLVMExpressionNode.class, value = "node")
+    public abstract static class LLVMIntrinsicExpressionNode extends LLVMIntrinsicRootNode {
 
         @Specialization
-        public Object execute(byte val) {
+        public Object execute(Object val) {
             return val;
         }
-    }
-
-    @NodeChild(type = LLVMI16Node.class, value = "node")
-    public abstract static class LLVMIntrinsicI16Node extends LLVMIntrinsicRootNode {
-
-        @Specialization
-        public Object execute(short val) {
-            return val;
-        }
-    }
-
-    @NodeChild(type = LLVMI32Node.class, value = "node")
-    public abstract static class LLVMIntrinsicI32Node extends LLVMIntrinsicRootNode {
-
-        @Specialization
-        public Object execute(int val) {
-            return val;
-        }
-    }
-
-    @NodeChild(type = LLVMI64Node.class, value = "node")
-    public abstract static class LLVMIntrinsicI64Node extends LLVMIntrinsicRootNode {
-
-        @Specialization
-        public Object execute(long value) {
-            return value;
-        }
-    }
-
-    @NodeChild(type = LLVMFloatNode.class, value = "node")
-    public abstract static class LLVMIntrinsicFloatNode extends LLVMIntrinsicRootNode {
-
-        @Specialization
-        public Object execute(float val) {
-            return val;
-        }
-    }
-
-    @NodeChild(type = LLVMDoubleNode.class, value = "node")
-    public abstract static class LLVMIntrinsicDoubleNode extends LLVMIntrinsicRootNode {
-
-        @Specialization
-        public Object execute(double val) {
-            return val;
-        }
-    }
-
-    @NodeChild(type = LLVMAddressNode.class, value = "node")
-    public abstract static class LLVMIntrinsicAddressNode extends LLVMIntrinsicRootNode {
-
-        @Specialization
-        public Object execute(LLVMAddress value) {
-            return value;
-        }
-
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
@@ -67,7 +67,6 @@ import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMStructR
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMVectorRetNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMRetNodeFactory.LLVMVoidReturnNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory;
-import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVM80BitFloatArgNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMAddressArgNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMDoubleArgNodeGen;
@@ -86,6 +85,7 @@ import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMI64VectorA
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMI8ArgNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMI8VectorArgNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMIVarBitArgNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode.LLVMUnresolvedCallNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNode.LLVMVoidCallUnboxNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVM80BitFloatCallUnboxNodeGen;
@@ -103,13 +103,7 @@ import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVMVarB
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVMVectorCallUnboxNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsic.LLVMVoidIntrinsic;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNode.LLVMIntrinsicVoidNode;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicAddressNodeGen;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicDoubleNodeGen;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicFloatNodeGen;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI16NodeGen;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI32NodeGen;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI64NodeGen;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicI8NodeGen;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsicRootNodeFactory.LLVMIntrinsicExpressionNodeGen;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
@@ -304,20 +298,8 @@ public final class LLVMFunctionFactory {
 
     public static RootNode createFunctionSubstitutionRootNode(LLVMNode intrinsicNode) {
         RootNode functionRoot;
-        if (intrinsicNode instanceof LLVMI8Node) {
-            functionRoot = LLVMIntrinsicI8NodeGen.create((LLVMI8Node) intrinsicNode);
-        } else if (intrinsicNode instanceof LLVMI16Node) {
-            functionRoot = LLVMIntrinsicI16NodeGen.create((LLVMI16Node) intrinsicNode);
-        } else if (intrinsicNode instanceof LLVMI32Node) {
-            functionRoot = LLVMIntrinsicI32NodeGen.create((LLVMI32Node) intrinsicNode);
-        } else if (intrinsicNode instanceof LLVMI64Node) {
-            functionRoot = LLVMIntrinsicI64NodeGen.create((LLVMI64Node) intrinsicNode);
-        } else if (intrinsicNode instanceof LLVMFloatNode) {
-            functionRoot = LLVMIntrinsicFloatNodeGen.create((LLVMFloatNode) intrinsicNode);
-        } else if (intrinsicNode instanceof LLVMDoubleNode) {
-            functionRoot = LLVMIntrinsicDoubleNodeGen.create((LLVMDoubleNode) intrinsicNode);
-        } else if (intrinsicNode instanceof LLVMAddressNode) {
-            functionRoot = LLVMIntrinsicAddressNodeGen.create((LLVMAddressNode) intrinsicNode);
+        if (intrinsicNode instanceof LLVMExpressionNode) {
+            functionRoot = LLVMIntrinsicExpressionNodeGen.create((LLVMExpressionNode) intrinsicNode);
         } else if (intrinsicNode instanceof LLVMVoidIntrinsic) {
             functionRoot = new LLVMIntrinsicVoidNode(intrinsicNode);
         } else {


### PR DESCRIPTION
This change removes some unnecessary specializations for the intrinsic root nodes. Since the value is anyway boxed to an `Object`, we do not need specializations for values produced by the different node subclasses.