### PR TITLE
Function refactoring

### DIFF
--- a/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
+++ b/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
@@ -48,8 +48,8 @@ import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.LLVMOptions;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
-import com.oracle.truffle.llvm.types.LLVMFunction;
-import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
 public class NativeLookup {
 
@@ -59,9 +59,9 @@ public class NativeLookup {
 
     private static NativeLibraryHandle[] libraryHandles;
 
-    private final Map<LLVMFunction, Integer> nativeFunctionLookupStats;
+    private final Map<LLVMFunctionDescriptor, Integer> nativeFunctionLookupStats;
 
-    private final Map<LLVMFunction, NativeFunctionHandle> cachedNativeFunctions = new WeakHashMap<>();
+    private final Map<LLVMFunctionDescriptor, NativeFunctionHandle> cachedNativeFunctions = new WeakHashMap<>();
 
     private final NodeFactoryFacade facade;
 
@@ -143,7 +143,7 @@ public class NativeLookup {
         return lookupSymbol(name.substring(1));
     }
 
-    public NativeFunctionHandle getNativeHandle(LLVMFunction function, LLVMExpressionNode[] args) {
+    public NativeFunctionHandle getNativeHandle(LLVMFunctionDescriptor function, LLVMExpressionNode[] args) {
         CompilerAsserts.neverPartOfCompilation();
         if (cachedNativeFunctions.containsKey(function)) {
             return cachedNativeFunctions.get(function);
@@ -157,7 +157,7 @@ public class NativeLookup {
         }
     }
 
-    private NativeFunctionHandle uncachedGetNativeFunctionHandle(LLVMFunction function, LLVMExpressionNode[] args) {
+    private NativeFunctionHandle uncachedGetNativeFunctionHandle(LLVMFunctionDescriptor function, LLVMExpressionNode[] args) {
         Class<?> retType = getJavaClass(function.getLlvmReturnType());
         Class<?>[] paramTypes = getJavaClassses(args, function.getLlvmParamTypes());
         String functionName = function.getName().substring(1);
@@ -176,7 +176,7 @@ public class NativeLookup {
         return functionHandle;
     }
 
-    private void recordNativeFunctionCallSite(LLVMFunction function) {
+    private void recordNativeFunctionCallSite(LLVMFunctionDescriptor function) {
         CompilerAsserts.neverPartOfCompilation();
         Integer val = nativeFunctionLookupStats.get(function);
         int newVal;
@@ -227,7 +227,7 @@ public class NativeLookup {
         }
     }
 
-    public Map<LLVMFunction, Integer> getNativeFunctionLookupStats() {
+    public Map<LLVMFunctionDescriptor, Integer> getNativeFunctionLookupStats() {
         return nativeFunctionLookupStats;
     }
 

--- a/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
+++ b/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
@@ -158,8 +158,8 @@ public class NativeLookup {
     }
 
     private NativeFunctionHandle uncachedGetNativeFunctionHandle(LLVMFunctionDescriptor function, LLVMExpressionNode[] args) {
-        Class<?> retType = getJavaClass(function.getLlvmReturnType());
-        Class<?>[] paramTypes = getJavaClassses(args, function.getLlvmParamTypes());
+        Class<?> retType = getJavaClass(function.getReturnType());
+        Class<?>[] paramTypes = getJavaClassses(args, function.getParameterTypes());
         String functionName = function.getName().substring(1);
         NativeFunctionHandle functionHandle;
         if (functionName.equals("fork") || functionName.equals("pthread_create") || functionName.equals("pipe")) {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
@@ -40,7 +40,7 @@ import com.oracle.truffle.llvm.nativeint.NativeLookup;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.parser.NodeFactoryFacade;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
 public class LLVMContext extends ExecutionContext {
@@ -61,7 +61,7 @@ public class LLVMContext extends ExecutionContext {
 
     }
 
-    public RootCallTarget getFunction(LLVMFunction function) {
+    public RootCallTarget getFunction(LLVMFunctionDescriptor function) {
         return registry.lookup(function);
     }
 
@@ -70,7 +70,7 @@ public class LLVMContext extends ExecutionContext {
         return registry;
     }
 
-    public NativeFunctionHandle getNativeHandle(LLVMFunction function, LLVMExpressionNode[] args) {
+    public NativeFunctionHandle getNativeHandle(LLVMFunctionDescriptor function, LLVMExpressionNode[] args) {
         return nativeLookup.getNativeHandle(function, args);
     }
 
@@ -78,7 +78,7 @@ public class LLVMContext extends ExecutionContext {
         return nativeLookup.getNativeHandle(functionName);
     }
 
-    public Map<LLVMFunction, Integer> getNativeFunctionLookupStats() {
+    public Map<LLVMFunctionDescriptor, Integer> getNativeFunctionLookupStats() {
         return nativeLookup.getNativeFunctionLookupStats();
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionNode.java
@@ -31,11 +31,11 @@ package com.oracle.truffle.llvm.nodes.impl.base;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
 public abstract class LLVMFunctionNode extends LLVMExpressionNode {
 
-    public abstract LLVMFunction executeFunction(VirtualFrame frame);
+    public abstract LLVMFunctionDescriptor executeFunction(VirtualFrame frame);
 
     @Override
     public Object executeGeneric(VirtualFrame frame) {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
@@ -143,8 +143,15 @@ public class LLVMFunctionRegistry {
         return function;
     }
 
-    public LLVMFunctionDescriptor createFromIndex(long addr) {
-        LLVMFunctionDescriptor llvmFunction = functionDescriptors[(int) addr];
+    /**
+     * Creates a function descriptor from the given <code>index</code> that has previously been
+     * obtained by {@link LLVMFunctionDescriptor#getFunctionIndex()}}.
+     *
+     * @param index the function index
+     * @return the function descriptor
+     */
+    public LLVMFunctionDescriptor createFromIndex(long index) {
+        LLVMFunctionDescriptor llvmFunction = functionDescriptors[(int) index];
         assert llvmFunction != null;
         return llvmFunction;
     }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
@@ -54,7 +54,7 @@ public class LLVMFunctionRegistry {
     private final NodeFactoryFacade facade;
 
     /**
-     * The function index assigned to the next function descriptor
+     * The function index assigned to the next function descriptor.
      */
     private int currentFunctionIndex;
 
@@ -119,14 +119,23 @@ public class LLVMFunctionRegistry {
         }
     }
 
-    public LLVMFunctionDescriptor createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs) {
+    /**
+     * Creates an unique function descriptor identified by the given <code>name</code>.
+     *
+     * @param name the function's name
+     * @param returnType the function's return type
+     * @param paramTypes the function's
+     * @param varArgs
+     * @return the function descriptor
+     */
+    public LLVMFunctionDescriptor createFunctionDescriptor(String name, LLVMRuntimeType returnType, LLVMRuntimeType[] paramTypes, boolean varArgs) {
         CompilerAsserts.neverPartOfCompilation();
         for (int i = 0; i < functionDescriptors.length; i++) {
             if (functionDescriptors[i].getName().equals(name)) {
                 return functionDescriptors[i];
             }
         }
-        LLVMFunctionDescriptor function = LLVMFunctionDescriptor.create(name, convertType, convertTypes, varArgs, currentFunctionIndex++);
+        LLVMFunctionDescriptor function = LLVMFunctionDescriptor.create(name, returnType, paramTypes, varArgs, currentFunctionIndex++);
         LLVMFunctionDescriptor[] newFunctions = new LLVMFunctionDescriptor[functionDescriptors.length + 1];
         System.arraycopy(functionDescriptors, 0, newFunctions, 0, functionDescriptors.length);
         newFunctions[function.getFunctionIndex()] = function;

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
@@ -150,8 +150,8 @@ public class LLVMFunctionRegistry {
      * @param index the function index
      * @return the function descriptor
      */
-    public LLVMFunctionDescriptor createFromIndex(long index) {
-        LLVMFunctionDescriptor llvmFunction = functionDescriptors[(int) index];
+    public LLVMFunctionDescriptor createFromIndex(int index) {
+        LLVMFunctionDescriptor llvmFunction = functionDescriptors[index];
         assert llvmFunction != null;
         return llvmFunction;
     }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
@@ -41,7 +41,7 @@ import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.parser.NodeFactoryFacade;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
 /**
  * Manages Sulong functions and intrinsified native functions.
@@ -57,7 +57,7 @@ public class LLVMFunctionRegistry {
     }
 
     /**
-     * Maps a function index (see {@link LLVMFunction#getFunctionIndex()} to a call target.
+     * Maps a function index (see {@link LLVMFunctionDescriptor#getFunctionIndex()} to a call target.
      */
     @CompilationFinal private RootCallTarget[] functionPtrCallTargetMap;
 
@@ -68,7 +68,7 @@ public class LLVMFunctionRegistry {
      * @param function the function
      * @return the call target, <code>null</code> if not found.
      */
-    public RootCallTarget lookup(LLVMFunction function) {
+    public RootCallTarget lookup(LLVMFunctionDescriptor function) {
         int functionIndex = function.getFunctionIndex();
         if (functionIndex >= 0 && functionIndex < functionPtrCallTargetMap.length) {
             RootCallTarget result = functionPtrCallTargetMap[functionIndex];
@@ -78,17 +78,17 @@ public class LLVMFunctionRegistry {
         }
     }
 
-    public void register(Map<LLVMFunction, RootCallTarget> functionCallTargets) {
-        functionPtrCallTargetMap = new RootCallTarget[LLVMFunction.getNumberRegisteredFunctions() + intrinsics.size()];
+    public void register(Map<LLVMFunctionDescriptor, RootCallTarget> functionCallTargets) {
+        functionPtrCallTargetMap = new RootCallTarget[LLVMFunctionDescriptor.getNumberRegisteredFunctions() + intrinsics.size()];
         registerIntrinsics();
-        for (LLVMFunction func : functionCallTargets.keySet()) {
+        for (LLVMFunctionDescriptor func : functionCallTargets.keySet()) {
             functionPtrCallTargetMap[func.getFunctionIndex()] = functionCallTargets.get(func);
         }
     }
 
     private void registerIntrinsics() {
         for (String intrinsicFunction : intrinsics.keySet()) {
-            LLVMFunction function = LLVMFunction.createFromName(intrinsicFunction);
+            LLVMFunctionDescriptor function = LLVMFunctionDescriptor.createFromName(intrinsicFunction);
             NodeFactory<? extends LLVMNode> nodeFactory = intrinsics.get(intrinsicFunction);
             List<Class<? extends Node>> executionSignature = nodeFactory.getExecutionSignature();
             int nrArguments = executionSignature.size();
@@ -103,7 +103,7 @@ public class LLVMFunctionRegistry {
         }
     }
 
-    private void addToFunctionMap(LLVMFunction function, RootCallTarget callTarget) {
+    private void addToFunctionMap(LLVMFunctionDescriptor function, RootCallTarget callTarget) {
         assert functionPtrCallTargetMap[function.getFunctionIndex()] == null;
         functionPtrCallTargetMap[function.getFunctionIndex()] = callTarget;
     }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMLanguage.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMLanguage.java
@@ -36,7 +36,7 @@ import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.Source;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
 @TruffleLanguage.Registration(name = "Sulong", version = "0.01", mimeType = LLVMLanguage.LLVM_MIME_TYPE)
 public final class LLVMLanguage extends TruffleLanguage<LLVMContext> {
@@ -69,7 +69,7 @@ public final class LLVMLanguage extends TruffleLanguage<LLVMContext> {
 
     @Override
     protected Object findExportedSymbol(LLVMContext context, String globalName, boolean onlyExplicit) {
-        return LLVMFunction.createFromName(globalName);
+        return LLVMFunctionDescriptor.createFromName(globalName);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMLanguage.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMLanguage.java
@@ -36,7 +36,6 @@ import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.Source;
-import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
 @TruffleLanguage.Registration(name = "Sulong", version = "0.01", mimeType = LLVMLanguage.LLVM_MIME_TYPE)
 public final class LLVMLanguage extends TruffleLanguage<LLVMContext> {
@@ -69,7 +68,7 @@ public final class LLVMLanguage extends TruffleLanguage<LLVMContext> {
 
     @Override
     protected Object findExportedSymbol(LLVMContext context, String globalName, boolean onlyExplicit) {
-        return LLVMFunctionDescriptor.createFromName(globalName);
+        throw new AssertionError(globalName);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToAddressNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToAddressNode.java
@@ -37,7 +37,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI1Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
 public abstract class LLVMToAddressNode extends LLVMAddressNode {
 
@@ -72,7 +72,7 @@ public abstract class LLVMToAddressNode extends LLVMAddressNode {
     public abstract static class LLVMFunctionToAddressNode extends LLVMToAddressNode {
 
         @Specialization
-        public LLVMAddress executeI64(LLVMFunction from) {
+        public LLVMAddress executeI64(LLVMFunctionDescriptor from) {
             return LLVMAddress.fromLong(from.getFunctionAddress().getVal());
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToAddressNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToAddressNode.java
@@ -73,7 +73,7 @@ public abstract class LLVMToAddressNode extends LLVMAddressNode {
 
         @Specialization
         public LLVMAddress executeI64(LLVMFunctionDescriptor from) {
-            return LLVMAddress.fromLong(from.getFunctionAddress().getVal());
+            return LLVMAddress.fromLong(from.getFunctionIndex());
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI32Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI32Node.java
@@ -43,7 +43,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMIVarBitNode;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 
@@ -179,7 +179,7 @@ public abstract class LLVMToI32Node extends LLVMI32Node {
     public abstract static class LLVMFunctionToI32Node extends LLVMToI32Node {
 
         @Specialization
-        public int executeI32(LLVMFunction from) {
+        public int executeI32(LLVMFunctionDescriptor from) {
             return (int) from.getFunctionAddress().getVal();
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI32Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI32Node.java
@@ -180,7 +180,7 @@ public abstract class LLVMToI32Node extends LLVMI32Node {
 
         @Specialization
         public int executeI32(LLVMFunctionDescriptor from) {
-            return (int) from.getFunctionAddress().getVal();
+            return from.getFunctionIndex();
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI64Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI64Node.java
@@ -189,7 +189,7 @@ public abstract class LLVMToI64Node extends LLVMI64Node {
 
         @Specialization
         public long executeI64(LLVMFunctionDescriptor from) {
-            return from.getFunctionAddress().getVal();
+            return from.getFunctionIndex();
         }
     }
 }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI64Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI64Node.java
@@ -43,7 +43,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMIVarBitNode;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 
@@ -188,7 +188,7 @@ public abstract class LLVMToI64Node extends LLVMI64Node {
     public abstract static class LLVMFunctionToI64Node extends LLVMToI64Node {
 
         @Specialization
-        public long executeI64(LLVMFunction from) {
+        public long executeI64(LLVMFunctionDescriptor from) {
             return from.getFunctionAddress().getVal();
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/control/LLVMRetNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/control/LLVMRetNode.java
@@ -50,7 +50,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMIVarBitNode;
 import com.oracle.truffle.llvm.nodes.impl.base.vector.LLVMVectorNode;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 import com.oracle.truffle.llvm.types.memory.LLVMHeap;
@@ -181,7 +181,7 @@ public abstract class LLVMRetNode extends LLVMTerminatorNode {
     public abstract static class LLVMFunctionRetNode extends LLVMRetNode {
 
         @Specialization
-        public int executeGetSuccessorIndex(VirtualFrame frame, LLVMFunction retResult) {
+        public int executeGetSuccessorIndex(VirtualFrame frame, LLVMFunctionDescriptor retResult) {
             frame.setObject(getRetSlot(), retResult);
             return LLVMBasicBlockNode.DEFAULT_SUCCESSOR;
         }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMArgNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMArgNode.java
@@ -51,7 +51,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.vector.LLVMI32VectorNode;
 import com.oracle.truffle.llvm.nodes.impl.base.vector.LLVMI64VectorNode;
 import com.oracle.truffle.llvm.nodes.impl.base.vector.LLVMI8VectorNode;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 import com.oracle.truffle.llvm.types.vector.LLVMDoubleVector;
@@ -201,8 +201,8 @@ public class LLVMArgNode {
 
         @Specialization
         @Override
-        public LLVMFunction executeFunction(VirtualFrame frame) {
-            return (LLVMFunction) frame.getArguments()[getIndex()];
+        public LLVMFunctionDescriptor executeFunction(VirtualFrame frame) {
+            return (LLVMFunctionDescriptor) frame.getArguments()[getIndex()];
         }
 
     }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
@@ -195,9 +195,9 @@ public abstract class LLVMCallNode {
     }
 
     public static LLVMResolvedDirectNativeCallNode getResolvedNativeCall(LLVMFunctionDescriptor function, NativeFunctionHandle nativeHandle, LLVMExpressionNode[] args, LLVMContext context) {
-        if (function.getLlvmReturnType() == LLVMRuntimeType.ADDRESS || function.getLlvmReturnType() == LLVMRuntimeType.STRUCT) {
+        if (function.getReturnType() == LLVMRuntimeType.ADDRESS || function.getReturnType() == LLVMRuntimeType.STRUCT) {
             return new LLVMResolvedNativeAddressCallNode(function, nativeHandle, args, context);
-        } else if (function.getLlvmReturnType() == LLVMRuntimeType.X86_FP80) {
+        } else if (function.getReturnType() == LLVMRuntimeType.X86_FP80) {
             return new LLVMResolvedNative80BitFloatCallNode(function, nativeHandle, args, context);
         } else {
             return new LLVMResolvedDirectNativeCallNode(function, nativeHandle, args, context);

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
@@ -289,7 +289,7 @@ public abstract class LLVMCallNode {
             }
         }
 
-        @Specialization(limit = "INLINE_CACHE_SIZE", guards = "function.getFunctionAddress() == cachedFunction.getFunctionAddress()")
+        @Specialization(limit = "INLINE_CACHE_SIZE", guards = "function.getFunctionIndex() == cachedFunction.getFunctionIndex()")
         protected Object doDirect(VirtualFrame frame, @SuppressWarnings("unused") LLVMFunctionDescriptor function, Object[] arguments, //
                         @SuppressWarnings("unused") @Cached("function") LLVMFunctionDescriptor cachedFunction, //
                         @Cached("create(getIndirectCallTarget(getContext(), cachedFunction, getNodes()))") DirectCallNode callNode) {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
@@ -182,7 +182,8 @@ public abstract class LLVMCallNode {
 
         private final NativeFunctionHandle functionHandle;
 
-        public LLVMResolvedDirectNativeCallNode(@SuppressWarnings("unused") LLVMFunctionDescriptor function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args, LLVMContext context) {
+        public LLVMResolvedDirectNativeCallNode(@SuppressWarnings("unused") LLVMFunctionDescriptor function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args,
+                        LLVMContext context) {
             super(prepareForNative(args, context));
             functionHandle = nativeFunctionHandle;
         }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallUnboxNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallUnboxNode.java
@@ -47,7 +47,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMIVarBitNode;
 import com.oracle.truffle.llvm.nodes.impl.base.vector.LLVMVectorNode;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 import com.oracle.truffle.llvm.types.vector.LLVMVector;
@@ -177,8 +177,8 @@ public abstract class LLVMCallUnboxNode {
     public abstract static class LLVMFunctionCallUnboxNode extends LLVMFunctionNode {
 
         @Specialization
-        public LLVMFunction executeFunction(Object value) {
-            return (LLVMFunction) value;
+        public LLVMFunctionDescriptor executeFunction(Object value) {
+            return (LLVMFunctionDescriptor) value;
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
@@ -49,7 +49,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 import com.oracle.truffle.llvm.runtime.LLVMExitException;
 import com.oracle.truffle.llvm.runtime.LLVMOptions;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 
 /**
@@ -117,13 +117,13 @@ public class LLVMGlobalRootNode extends RootNode {
 
     @TruffleBoundary
     private static void printNativeCallStats(LLVMContext context) {
-        Map<LLVMFunction, Integer> nativeFunctionCallSites = context.getNativeFunctionLookupStats();
+        Map<LLVMFunctionDescriptor, Integer> nativeFunctionCallSites = context.getNativeFunctionLookupStats();
         // Checkstyle: stop
         if (!nativeFunctionCallSites.isEmpty()) {
             System.out.println("==========================");
             System.out.println("native function sites:");
             System.out.println("==========================");
-            for (LLVMFunction function : nativeFunctionCallSites.keySet()) {
+            for (LLVMFunctionDescriptor function : nativeFunctionCallSites.keySet()) {
                 String output = String.format("%15s: %3d", function.getName(), nativeFunctionCallSites.get(function));
                 System.out.println(output);
             }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMNativeCallConvertNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMNativeCallConvertNode.java
@@ -35,8 +35,8 @@ import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode.LLVMResolvedDirectNativeCallNode;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
-import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
 /**
  * This node converts the results of native functions to primitives or objects, that other Sulong
@@ -47,7 +47,7 @@ public abstract class LLVMNativeCallConvertNode {
     // FIXME: do not use inheritance
     public static class LLVMResolvedNativeAddressCallNode extends LLVMResolvedDirectNativeCallNode {
 
-        public LLVMResolvedNativeAddressCallNode(LLVMFunction function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args, LLVMContext context) {
+        public LLVMResolvedNativeAddressCallNode(LLVMFunctionDescriptor function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args, LLVMContext context) {
             super(function, nativeFunctionHandle, args, context);
             assert function.getLlvmReturnType() == LLVMRuntimeType.ADDRESS;
         }
@@ -61,7 +61,7 @@ public abstract class LLVMNativeCallConvertNode {
 
     public static class LLVMResolvedNative80BitFloatCallNode extends LLVMResolvedDirectNativeCallNode {
 
-        public LLVMResolvedNative80BitFloatCallNode(LLVMFunction function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args, LLVMContext context) {
+        public LLVMResolvedNative80BitFloatCallNode(LLVMFunctionDescriptor function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args, LLVMContext context) {
             super(function, nativeFunctionHandle, args, context);
             assert function.getLlvmReturnType() == LLVMRuntimeType.X86_FP80;
         }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMNativeCallConvertNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMNativeCallConvertNode.java
@@ -49,7 +49,7 @@ public abstract class LLVMNativeCallConvertNode {
 
         public LLVMResolvedNativeAddressCallNode(LLVMFunctionDescriptor function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args, LLVMContext context) {
             super(function, nativeFunctionHandle, args, context);
-            assert function.getLlvmReturnType() == LLVMRuntimeType.ADDRESS;
+            assert function.getReturnType() == LLVMRuntimeType.ADDRESS;
         }
 
         @Override
@@ -63,7 +63,7 @@ public abstract class LLVMNativeCallConvertNode {
 
         public LLVMResolvedNative80BitFloatCallNode(LLVMFunctionDescriptor function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args, LLVMContext context) {
             super(function, nativeFunctionHandle, args, context);
-            assert function.getLlvmReturnType() == LLVMRuntimeType.X86_FP80;
+            assert function.getReturnType() == LLVMRuntimeType.X86_FP80;
         }
 
         @Override

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/x86/LLVMX86_64BitVACopy.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/x86/LLVMX86_64BitVACopy.java
@@ -37,7 +37,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 
 @NodeChildren({@NodeChild(type = LLVMAddressNode.class), @NodeChild(type = LLVMAddressNode.class)})

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/x86/LLVMX86_64BitVAStart.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/x86/LLVMX86_64BitVAStart.java
@@ -34,7 +34,7 @@ import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 import com.oracle.truffle.llvm.types.memory.LLVMMemory;

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/literals/LLVMFunctionLiteralNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/literals/LLVMFunctionLiteralNode.java
@@ -32,15 +32,15 @@ package com.oracle.truffle.llvm.nodes.impl.literals;
 import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
-@NodeField(type = LLVMFunction.class, name = "function")
+@NodeField(type = LLVMFunctionDescriptor.class, name = "function")
 public abstract class LLVMFunctionLiteralNode extends LLVMFunctionNode {
 
-    public abstract LLVMFunction getFunction();
+    public abstract LLVMFunctionDescriptor getFunction();
 
     @Specialization
-    public LLVMFunction executeFunction() {
+    public LLVMFunctionDescriptor executeFunction() {
         return getFunction();
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/LLVMStoreNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/LLVMStoreNode.java
@@ -162,7 +162,7 @@ public abstract class LLVMStoreNode extends LLVMNode {
 
         @Specialization
         public void execute(LLVMAddress address, LLVMFunctionDescriptor function) {
-            LLVMHeap.putFunction(address, function);
+            LLVMHeap.putFunctionIndex(address, function.getFunctionIndex());
         }
 
     }
@@ -422,7 +422,7 @@ public abstract class LLVMStoreNode extends LLVMNode {
             LLVMAddress currentAddress = addr;
             for (int i = 0; i < values.length; i++) {
                 LLVMFunctionDescriptor currentValue = values[i].executeFunction(frame);
-                LLVMHeap.putFunction(currentAddress, currentValue);
+                LLVMHeap.putFunctionIndex(currentAddress, currentValue.getFunctionIndex());
                 currentAddress = currentAddress.increment(stride);
             }
             return addr;

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/LLVMStoreNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/LLVMStoreNode.java
@@ -48,7 +48,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMIVarBitNode;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 import com.oracle.truffle.llvm.types.memory.LLVMHeap;
@@ -161,7 +161,7 @@ public abstract class LLVMStoreNode extends LLVMNode {
     public abstract static class LLVMFunctionStoreNode extends LLVMStoreNode {
 
         @Specialization
-        public void execute(LLVMAddress address, LLVMFunction function) {
+        public void execute(LLVMAddress address, LLVMFunctionDescriptor function) {
             LLVMHeap.putFunction(address, function);
         }
 
@@ -421,7 +421,7 @@ public abstract class LLVMStoreNode extends LLVMNode {
         protected LLVMAddress writeDouble(VirtualFrame frame, LLVMAddress addr) {
             LLVMAddress currentAddress = addr;
             for (int i = 0; i < values.length; i++) {
-                LLVMFunction currentValue = values[i].executeFunction(frame);
+                LLVMFunctionDescriptor currentValue = values[i].executeFunction(frame);
                 LLVMHeap.putFunction(currentAddress, currentValue);
                 currentAddress = currentAddress.increment(stride);
             }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMDirectLoadNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMDirectLoadNode.java
@@ -37,7 +37,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVM80BitFloatNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMIVarBitNode;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 import com.oracle.truffle.llvm.types.memory.LLVMHeap;
@@ -70,7 +70,7 @@ public abstract class LLVMDirectLoadNode {
     public abstract static class LLVMFunctionDirectLoadNode extends LLVMFunctionNode {
 
         @Specialization
-        public LLVMFunction executeAddress(LLVMAddress addr) {
+        public LLVMFunctionDescriptor executeAddress(LLVMAddress addr) {
             return LLVMHeap.getFunction(addr);
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMDirectLoadNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMDirectLoadNode.java
@@ -34,6 +34,7 @@ import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionRegistry;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVM80BitFloatNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMIVarBitNode;
 import com.oracle.truffle.llvm.types.LLVMAddress;
@@ -67,11 +68,14 @@ public abstract class LLVMDirectLoadNode {
     }
 
     @NodeChild(type = LLVMAddressNode.class)
+    @NodeField(type = LLVMFunctionRegistry.class, name = "functionRegistry")
     public abstract static class LLVMFunctionDirectLoadNode extends LLVMFunctionNode {
+
+        public abstract LLVMFunctionRegistry getFunctionRegistry();
 
         @Specialization
         public LLVMFunctionDescriptor executeAddress(LLVMAddress addr) {
-            return LLVMHeap.getFunction(addr);
+            return getFunctionRegistry().createFromIndex(LLVMHeap.getFunctionIndex(addr));
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/op/compare/LLVMFunctionCompareNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/op/compare/LLVMFunctionCompareNode.java
@@ -34,21 +34,21 @@ import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI1Node;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
 @NodeChildren({@NodeChild(type = LLVMFunctionNode.class), @NodeChild(type = LLVMFunctionNode.class)})
 public abstract class LLVMFunctionCompareNode extends LLVMI1Node {
 
     public abstract static class LLVMFunctionEqNode extends LLVMFunctionCompareNode {
         @Specialization
-        public boolean executeI1(LLVMFunction val1, LLVMFunction val2) {
+        public boolean executeI1(LLVMFunctionDescriptor val1, LLVMFunctionDescriptor val2) {
             return val1.getFunctionAddress() == val2.getFunctionAddress();
         }
     }
 
     public abstract static class LLVMFunctionNeNode extends LLVMFunctionCompareNode {
         @Specialization
-        public boolean executeI1(LLVMFunction val1, LLVMFunction val2) {
+        public boolean executeI1(LLVMFunctionDescriptor val1, LLVMFunctionDescriptor val2) {
             return val1.getFunctionAddress() != val2.getFunctionAddress();
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/op/compare/LLVMFunctionCompareNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/op/compare/LLVMFunctionCompareNode.java
@@ -42,14 +42,14 @@ public abstract class LLVMFunctionCompareNode extends LLVMI1Node {
     public abstract static class LLVMFunctionEqNode extends LLVMFunctionCompareNode {
         @Specialization
         public boolean executeI1(LLVMFunctionDescriptor val1, LLVMFunctionDescriptor val2) {
-            return val1.getFunctionAddress() == val2.getFunctionAddress();
+            return val1.getFunctionIndex() == val2.getFunctionIndex();
         }
     }
 
     public abstract static class LLVMFunctionNeNode extends LLVMFunctionCompareNode {
         @Specialization
         public boolean executeI1(LLVMFunctionDescriptor val1, LLVMFunctionDescriptor val2) {
-            return val1.getFunctionAddress() != val2.getFunctionAddress();
+            return val1.getFunctionIndex() != val2.getFunctionIndex();
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMProfilingSelectNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMProfilingSelectNode.java
@@ -44,7 +44,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 
 public class LLVMProfilingSelectNode {
@@ -199,7 +199,7 @@ public class LLVMProfilingSelectNode {
         private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
 
         @Specialization
-        public LLVMFunction execute(boolean cond, LLVMFunction trueBranch, LLVMFunction elseBranch) {
+        public LLVMFunctionDescriptor execute(boolean cond, LLVMFunctionDescriptor trueBranch, LLVMFunctionDescriptor elseBranch) {
             if (conditionProfile.profile(cond)) {
                 return trueBranch;
             } else {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMSelectNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMSelectNode.java
@@ -43,7 +43,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 
 public abstract class LLVMSelectNode {
@@ -140,7 +140,7 @@ public abstract class LLVMSelectNode {
     public abstract static class LLVMFunctionSelectNode extends LLVMFunctionNode {
 
         @Specialization
-        public LLVMFunction execute(boolean cond, LLVMFunction trueBranch, LLVMFunction elseBranch) {
+        public LLVMFunctionDescriptor execute(boolean cond, LLVMFunctionDescriptor trueBranch, LLVMFunctionDescriptor elseBranch) {
             return cond ? trueBranch : elseBranch;
         }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/vars/LLVMReadNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/vars/LLVMReadNode.java
@@ -48,7 +48,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMIVarBitNode;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 
@@ -170,8 +170,8 @@ public abstract class LLVMReadNode extends LLVMExpressionNode {
         protected abstract FrameSlot getSlot();
 
         @Specialization
-        protected LLVMFunction readI32(VirtualFrame frame) {
-            return (LLVMFunction) FrameUtil.getObjectSafe(frame, getSlot());
+        protected LLVMFunctionDescriptor readI32(VirtualFrame frame) {
+            return (LLVMFunctionDescriptor) FrameUtil.getObjectSafe(frame, getSlot());
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/vars/LLVMWriteNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/vars/LLVMWriteNode.java
@@ -47,7 +47,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMIVarBitNode;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 
@@ -159,7 +159,7 @@ public abstract class LLVMWriteNode extends LLVMNode {
     public abstract static class LLVMWriteFunctionNode extends LLVMWriteNode {
 
         @Specialization
-        protected void writeAddress(VirtualFrame frame, LLVMFunction value) {
+        protected void writeAddress(VirtualFrame frame, LLVMFunctionDescriptor value) {
             frame.setObject(getSlot(), value);
         }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/vars/StructLiteralNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/vars/StructLiteralNode.java
@@ -43,7 +43,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 import com.oracle.truffle.llvm.types.memory.LLVMMemory;
@@ -247,7 +247,7 @@ public class StructLiteralNode extends LLVMAddressNode {
 
         @Override
         public void executeWrite(VirtualFrame frame, LLVMAddress address) {
-            LLVMFunction value = valueNode.executeFunction(frame);
+            LLVMFunctionDescriptor value = valueNode.executeFunction(frame);
             LLVMHeap.putFunction(address, value);
         }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/vars/StructLiteralNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/vars/StructLiteralNode.java
@@ -248,7 +248,7 @@ public class StructLiteralNode extends LLVMAddressNode {
         @Override
         public void executeWrite(VirtualFrame frame, LLVMAddress address) {
             LLVMFunctionDescriptor value = valueNode.executeFunction(frame);
-            LLVMHeap.putFunction(address, value);
+            LLVMHeap.putFunctionIndex(address, value.getFunctionIndex());
         }
 
     }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
@@ -108,7 +108,7 @@ import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
 import com.oracle.truffle.llvm.runtime.LLVMOptions;
-import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
 public final class LLVMFunctionFactory {
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
@@ -80,7 +80,7 @@ import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 
@@ -139,7 +139,7 @@ public final class LLVMLiteralFactory {
             case ADDRESS:
                 return new LLVMAddressLiteralNode(LLVMAddress.createUndefinedAddress());
             case FUNCTION_ADDRESS:
-                return LLVMFunctionLiteralNodeGen.create(LLVMFunction.createUndefinedFunction());
+                return LLVMFunctionLiteralNodeGen.create(LLVMFunctionDescriptor.createUndefinedFunction());
             default:
                 throw new AssertionError(type);
         }
@@ -192,7 +192,7 @@ public final class LLVMLiteralFactory {
                 }
             case FUNCTION_ADDRESS:
                 if (stringValue.equals("null")) {
-                    return LLVMFunctionLiteralNodeGen.create(LLVMFunction.createZeroFunction());
+                    return LLVMFunctionLiteralNodeGen.create(LLVMFunctionDescriptor.createZeroFunction());
                 } else {
                     throw new AssertionError(stringValue);
                 }
@@ -206,7 +206,7 @@ public final class LLVMLiteralFactory {
         return bigInteger.longValue();
     }
 
-    public static LLVMFunctionNode[] createFunctionLiteralNodes(int nrElements, LLVMFunction value) {
+    public static LLVMFunctionNode[] createFunctionLiteralNodes(int nrElements, LLVMFunctionDescriptor value) {
         LLVMFunctionNode[] functionZeroInits = new LLVMFunctionNode[nrElements];
         for (int i = 0; i < nrElements; i++) {
             functionZeroInits[i] = LLVMFunctionLiteralNodeGen.create(value);
@@ -353,7 +353,7 @@ public final class LLVMLiteralFactory {
             case ADDRESS:
                 return new LLVMAddressLiteralNode((LLVMAddress) value);
             case FUNCTION_ADDRESS:
-                return LLVMFunctionLiteralNodeGen.create((LLVMFunction) value);
+                return LLVMFunctionLiteralNodeGen.create((LLVMFunctionDescriptor) value);
             default:
                 throw new AssertionError(value + " " + type);
         }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
@@ -39,7 +39,9 @@ import com.intel.llvm.ireditor.types.ResolvedType;
 import com.intel.llvm.ireditor.types.ResolvedVectorType;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVM80BitFloatNode;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMDoubleNode;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMFloatNode;
@@ -82,6 +84,7 @@ import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 
 public final class LLVMLiteralFactory {
@@ -139,7 +142,9 @@ public final class LLVMLiteralFactory {
             case ADDRESS:
                 return new LLVMAddressLiteralNode(LLVMAddress.createUndefinedAddress());
             case FUNCTION_ADDRESS:
-                return LLVMFunctionLiteralNodeGen.create(LLVMFunctionDescriptor.createUndefinedFunction());
+                LLVMContext context = LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0());
+                LLVMFunctionDescriptor functionDescriptor = context.getFunctionRegistry().createFunctionDescriptor("<undefined function>", LLVMRuntimeType.ILLEGAL, new LLVMRuntimeType[0], false);
+                return LLVMFunctionLiteralNodeGen.create(functionDescriptor);
             default:
                 throw new AssertionError(type);
         }
@@ -192,7 +197,9 @@ public final class LLVMLiteralFactory {
                 }
             case FUNCTION_ADDRESS:
                 if (stringValue.equals("null")) {
-                    return LLVMFunctionLiteralNodeGen.create(LLVMFunctionDescriptor.createZeroFunction());
+                    LLVMContext context = LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0());
+                    LLVMFunctionDescriptor functionDescriptor = context.getFunctionRegistry().createFunctionDescriptor("<zero function>", LLVMRuntimeType.ILLEGAL, new LLVMRuntimeType[0], false);
+                    return LLVMFunctionLiteralNodeGen.create(functionDescriptor);
                 } else {
                     throw new AssertionError(stringValue);
                 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMMemoryReadWriteFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMMemoryReadWriteFactory.java
@@ -33,7 +33,9 @@ import com.intel.llvm.ireditor.types.ResolvedType;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVM80BitFloatNode;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMDoubleNode;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMFloatNode;
@@ -137,7 +139,8 @@ public final class LLVMMemoryReadWriteFactory {
             case ADDRESS:
                 return LLVMAddressDirectLoadNodeGen.create(loadTarget);
             case FUNCTION_ADDRESS:
-                return LLVMFunctionDirectLoadNodeGen.create(loadTarget);
+                LLVMContext context = LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0());
+                return LLVMFunctionDirectLoadNodeGen.create(loadTarget, context.getFunctionRegistry());
             case STRUCT:
             case ARRAY:
                 return LLVMStructDirectLoadNodeGen.create(loadTarget);

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -77,7 +77,7 @@ import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
 public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -77,6 +77,7 @@ import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
 import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
 public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
@@ -359,6 +360,11 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     @Override
     public RootNode createFunctionSubstitutionRootNode(LLVMNode intrinsicNode) {
         return LLVMFunctionFactory.createFunctionSubstitutionRootNode(intrinsicNode);
+    }
+
+    @Override
+    public LLVMFunctionDescriptor createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs) {
+        return LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0()).getFunctionRegistry().createFunctionDescriptor(name, convertType, convertTypes, varArgs);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -1247,7 +1247,7 @@ public class LLVMVisitor implements LLVMParserRuntime {
         for (int i = 0; i < params.size(); i++) {
             llvmParamTypes[i] = getLLVMType(params.get(i).getType().getType());
         }
-        return LLVMFunctionDescriptor.create(header.getName(), LLVMTypeHelper.convertType(llvmReturnType), LLVMTypeHelper.convertTypes(llvmParamTypes), varArgs);
+        return factoryFacade.createFunctionDescriptor(header.getName(), LLVMTypeHelper.convertType(llvmReturnType), LLVMTypeHelper.convertTypes(llvmParamTypes), varArgs);
     }
 
     private LLVMExpressionNode parseSimpleConstant(EObject type, SimpleConstant simpleConst) {

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -231,7 +231,7 @@ public class LLVMVisitor implements LLVMParserRuntime {
         Map<LLVMFunctionDescriptor, RootCallTarget> parsedFunctions = visit(model, facade);
         LLVMFunctionDescriptor mainFunction = searchFunction(parsedFunctions, "@main");
         RootCallTarget mainCallTarget = parsedFunctions.get(mainFunction);
-        int argParamCount = mainFunction.getLlvmParamTypes().length;
+        int argParamCount = mainFunction.getParameterTypes().length;
         RootNode globalFunction;
         LLVMNode[] staticInits = globalNodes.toArray(new LLVMNode[globalNodes.size()]);
         int argsCount = mainArgs.length + 1;
@@ -260,7 +260,7 @@ public class LLVMVisitor implements LLVMParserRuntime {
             }
         }
         RootCallTarget globalFunctionRoot = Truffle.getRuntime().createCallTarget(globalFunction);
-        RootNode globalRootNode = factoryFacade.createGlobalRootNodeWrapping(globalFunctionRoot, mainFunction.getLlvmReturnType());
+        RootNode globalRootNode = factoryFacade.createGlobalRootNodeWrapping(globalFunctionRoot, mainFunction.getReturnType());
         RootCallTarget wrappedCallTarget = Truffle.getRuntime().createCallTarget(globalRootNode);
         return new ParserResult(wrappedCallTarget, parsedFunctions);
     }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -56,7 +56,7 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
 /**
  * This interface decouples the parser and the concrete implementation of the nodes by only making

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -56,6 +56,7 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
 /**
@@ -291,5 +292,7 @@ public interface NodeFactoryFacade {
      * @return the root node for the intrinsic
      */
     RootNode createFunctionSubstitutionRootNode(LLVMNode intrinsicNode);
+
+    LLVMFunctionDescriptor createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs);
 
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -56,7 +56,7 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
 /**
  * This class implements an abstract adapter that returns a default value (mostly <code>null</code>)

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/util/LLVMTypeHelper.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/util/LLVMTypeHelper.java
@@ -48,7 +48,7 @@ import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction.LLVMRuntimeType;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 
 public class LLVMTypeHelper {

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
@@ -81,10 +81,6 @@ public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<L
         return func;
     }
 
-    public static LLVMFunctionDescriptor createFromName(String name) {
-        return create(name, LLVMRuntimeType.ILLEGAL, new LLVMRuntimeType[0], false, -1);
-    }
-
     public String getName() {
         return functionName;
     }

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
@@ -29,11 +29,7 @@
  */
 package com.oracle.truffle.llvm.types;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.oracle.truffle.api.CompilerAsserts;
-import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.interop.ForeignAccess;
 import com.oracle.truffle.api.interop.TruffleObject;
 
@@ -65,61 +61,28 @@ public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<L
         ILLEGAL;
     }
 
-    private static final Map<String, LLVMFunctionDescriptor> referenceMap = new HashMap<>();
-    @CompilationFinal private static LLVMFunctionDescriptor[] functions = new LLVMFunctionDescriptor[0];
-
-    // arbitrary number
-    public static final int FUNCTION_START_ADDR = 1000;
-    private static int functionCounter = 0;
-
-    // cache function headers for identity comparison
-
     private final String functionName;
     private final LLVMRuntimeType returnType;
     private final LLVMRuntimeType[] parameterTypes;
     private final boolean hasVarArgs;
-    private final LLVMAddress functionAddress;
+    private final int functionId;
 
-    public static void reset() {
-        referenceMap.clear();
-    }
-
-    private LLVMFunctionDescriptor(String name, LLVMRuntimeType llvmReturnType, LLVMRuntimeType[] llvmParamTypes, boolean varArgs) {
+    private LLVMFunctionDescriptor(String name, LLVMRuntimeType llvmReturnType, LLVMRuntimeType[] llvmParamTypes, boolean varArgs, int functionId) {
         this.functionName = name;
         this.returnType = llvmReturnType;
         this.parameterTypes = llvmParamTypes;
         this.hasVarArgs = varArgs;
-        this.functionAddress = LLVMAddress.fromLong(FUNCTION_START_ADDR + functionCounter++);
+        this.functionId = functionId;
     }
 
-    public static LLVMFunctionDescriptor create(String name, LLVMRuntimeType llvmReturnType, LLVMRuntimeType[] llvmParamTypes, boolean varArgs) {
-        final LLVMFunctionDescriptor result;
+    public static LLVMFunctionDescriptor create(String name, LLVMRuntimeType llvmReturnType, LLVMRuntimeType[] llvmParamTypes, boolean varArgs, int functionId) {
         CompilerAsserts.neverPartOfCompilation();
-        if (referenceMap.containsKey(name)) {
-            result = referenceMap.get(name);
-        } else {
-            LLVMFunctionDescriptor func = new LLVMFunctionDescriptor(name, llvmReturnType, llvmParamTypes, varArgs);
-            // FIXME instead finish initialization at the end
-            LLVMFunctionDescriptor[] newFunctions = new LLVMFunctionDescriptor[functions.length + 1];
-            System.arraycopy(functions, 0, newFunctions, 0, functions.length);
-            newFunctions[func.getFunctionIndex()] = func;
-            functions = newFunctions;
-            referenceMap.put(name, func);
-            result = func;
-        }
-        return result;
+        LLVMFunctionDescriptor func = new LLVMFunctionDescriptor(name, llvmReturnType, llvmParamTypes, varArgs, functionId);
+        return func;
     }
 
     public static LLVMFunctionDescriptor createFromName(String name) {
-        return create(name, LLVMRuntimeType.ILLEGAL, new LLVMRuntimeType[0], false);
-    }
-
-    public static LLVMFunctionDescriptor createUndefinedFunction() {
-        return createFromName("<undefined function>");
-    }
-
-    public static LLVMFunctionDescriptor createZeroFunction() {
-        return createFromName("<zero function>");
+        return create(name, LLVMRuntimeType.ILLEGAL, new LLVMRuntimeType[0], false, -1);
     }
 
     public String getName() {
@@ -139,41 +102,22 @@ public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<L
     }
 
     /**
-     * Gets an index for a function.
+     * Gets an unique index for a function descriptor.
      *
-     * @return an index between 0 and {@link #getNumberRegisteredFunctions()}
+     * @return the function's index
      */
     public int getFunctionIndex() {
-        return getFunctionIndex(getFunctionAddress());
-    }
-
-    public LLVMAddress getFunctionAddress() {
-        return functionAddress;
-    }
-
-    public static LLVMFunctionDescriptor createFromAddress(LLVMAddress addr) {
-        LLVMFunctionDescriptor llvmFunction = functions[getFunctionIndex(addr)];
-        assert llvmFunction != null;
-        return llvmFunction;
-    }
-
-    private static int getFunctionIndex(LLVMAddress addr) {
-        long functionAddr = addr.getVal() - FUNCTION_START_ADDR;
-        return (int) functionAddr;
+        return functionId;
     }
 
     @Override
     public String toString() {
-        return getName() + " " + getFunctionAddress();
+        return getName() + " " + getFunctionIndex();
     }
 
     @Override
     public ForeignAccess getForeignAccess() {
         throw new AssertionError();
-    }
-
-    public static int getNumberRegisteredFunctions() {
-        return functionCounter;
     }
 
     @Override
@@ -207,6 +151,10 @@ public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<L
                 return true;
             }
         }
+    }
+
+    public LLVMAddress getFunctionAddress() {
+        return LLVMAddress.fromLong(getFunctionIndex());
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
@@ -127,7 +127,7 @@ public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<L
 
     @Override
     public int hashCode() {
-        return getName().hashCode() + 11 * getReturnType().hashCode();
+        return getName().hashCode() + 11 * functionId;
     }
 
     @Override
@@ -136,25 +136,8 @@ public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<L
             return false;
         } else {
             LLVMFunctionDescriptor other = (LLVMFunctionDescriptor) obj;
-            if (!getName().equals(other.getName())) {
-                return false;
-            } else if (!getReturnType().equals(other.getReturnType())) {
-                return false;
-            } else if (getParameterTypes().length != other.getParameterTypes().length) {
-                return false;
-            } else {
-                for (int i = 0; i < getParameterTypes().length; i++) {
-                    if (!getParameterTypes()[i].equals(other.getParameterTypes()[i])) {
-                        return false;
-                    }
-                }
-                return true;
-            }
+            return getFunctionIndex() == other.getFunctionIndex();
         }
-    }
-
-    public LLVMAddress getFunctionAddress() {
-        return LLVMAddress.fromLong(getFunctionIndex());
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
@@ -37,7 +37,7 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.interop.ForeignAccess;
 import com.oracle.truffle.api.interop.TruffleObject;
 
-public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunction> {
+public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<LLVMFunctionDescriptor> {
 
     public static final int FRAME_START_INDEX = 2;
 
@@ -66,10 +66,10 @@ public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunctio
         VOID;
     }
 
-    private static final Map<String, LLVMFunction> referenceMap = new HashMap<>();
-    @CompilationFinal private static LLVMFunction[] functions = new LLVMFunction[0];
-    private static final LLVMFunction ZERO_FUNCTION = createFromName("<zero function>");
-    private static final LLVMFunction UNDEFINED_FUNCTION = createFromName("<undefined function>");
+    private static final Map<String, LLVMFunctionDescriptor> referenceMap = new HashMap<>();
+    @CompilationFinal private static LLVMFunctionDescriptor[] functions = new LLVMFunctionDescriptor[0];
+    private static final LLVMFunctionDescriptor ZERO_FUNCTION = createFromName("<zero function>");
+    private static final LLVMFunctionDescriptor UNDEFINED_FUNCTION = createFromName("<undefined function>");
 
     // arbitrary number
     public static final int FUNCTION_START_ADDR = 1000;
@@ -87,7 +87,7 @@ public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunctio
         referenceMap.clear();
     }
 
-    private LLVMFunction(String name, LLVMRuntimeType llvmReturnType, LLVMRuntimeType[] llvmParamTypes, boolean varArgs) {
+    private LLVMFunctionDescriptor(String name, LLVMRuntimeType llvmReturnType, LLVMRuntimeType[] llvmParamTypes, boolean varArgs) {
         this.name = name;
         this.llvmReturnType = llvmReturnType;
         this.llvmParamTypes = llvmParamTypes;
@@ -95,15 +95,15 @@ public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunctio
         this.functionAddress = LLVMAddress.fromLong(FUNCTION_START_ADDR + functionCounter++);
     }
 
-    public static LLVMFunction create(String name, LLVMRuntimeType llvmReturnType, LLVMRuntimeType[] llvmParamTypes, boolean varArgs) {
-        final LLVMFunction result;
+    public static LLVMFunctionDescriptor create(String name, LLVMRuntimeType llvmReturnType, LLVMRuntimeType[] llvmParamTypes, boolean varArgs) {
+        final LLVMFunctionDescriptor result;
         CompilerAsserts.neverPartOfCompilation();
         if (referenceMap.containsKey(name)) {
             result = referenceMap.get(name);
         } else {
-            LLVMFunction func = new LLVMFunction(name, llvmReturnType, llvmParamTypes, varArgs);
+            LLVMFunctionDescriptor func = new LLVMFunctionDescriptor(name, llvmReturnType, llvmParamTypes, varArgs);
             // FIXME instead finish initialization at the end
-            LLVMFunction[] newFunctions = new LLVMFunction[functions.length + 1];
+            LLVMFunctionDescriptor[] newFunctions = new LLVMFunctionDescriptor[functions.length + 1];
             System.arraycopy(functions, 0, newFunctions, 0, functions.length);
             newFunctions[func.getFunctionIndex()] = func;
             functions = newFunctions;
@@ -113,15 +113,15 @@ public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunctio
         return result;
     }
 
-    public static LLVMFunction createFromName(String name) {
+    public static LLVMFunctionDescriptor createFromName(String name) {
         return create(name, null, null, false);
     }
 
-    public static LLVMFunction createUndefinedFunction() {
+    public static LLVMFunctionDescriptor createUndefinedFunction() {
         return UNDEFINED_FUNCTION;
     }
 
-    public static LLVMFunction createZeroFunction() {
+    public static LLVMFunctionDescriptor createZeroFunction() {
         return ZERO_FUNCTION;
     }
 
@@ -150,7 +150,7 @@ public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunctio
         return getFunctionIndex(getFunctionAddress());
     }
 
-    public static LLVMFunction createFromFunctionIndex(int index) {
+    public static LLVMFunctionDescriptor createFromFunctionIndex(int index) {
         return functions[index];
     }
 
@@ -158,8 +158,8 @@ public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunctio
         return functionAddress;
     }
 
-    public static LLVMFunction createFromAddress(LLVMAddress addr) {
-        LLVMFunction llvmFunction = functions[getFunctionIndex(addr)];
+    public static LLVMFunctionDescriptor createFromAddress(LLVMAddress addr) {
+        LLVMFunctionDescriptor llvmFunction = functions[getFunctionIndex(addr)];
         assert llvmFunction != null;
         return llvmFunction;
     }
@@ -184,7 +184,7 @@ public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunctio
     }
 
     @Override
-    public int compareTo(LLVMFunction o) {
+    public int compareTo(LLVMFunctionDescriptor o) {
         return getName().compareTo(o.getName());
     }
 
@@ -195,10 +195,10 @@ public final class LLVMFunction implements TruffleObject, Comparable<LLVMFunctio
 
     @Override
     public boolean equals(Object obj) {
-        if (!(obj instanceof LLVMFunction)) {
+        if (!(obj instanceof LLVMFunctionDescriptor)) {
             return false;
         } else {
-            LLVMFunction other = (LLVMFunction) obj;
+            LLVMFunctionDescriptor other = (LLVMFunctionDescriptor) obj;
             if (!getName().equals(other.getName())) {
                 return false;
             } else if (!getLlvmReturnType().equals(other.getLlvmReturnType())) {

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
@@ -101,12 +101,12 @@ public class LLVMHeap extends LLVMMemory {
     // current hack: we cannot directly store the LLVMFunction in the native memory due to GC
     public static final int FUNCTION_PTR_SIZE_BYTE = 8;
 
-    public static void putFunctionIndex(LLVMAddress address, long functionIndex) {
-        UNSAFE.putLong(LLVMMemory.extractAddr(address), functionIndex);
+    public static void putFunctionIndex(LLVMAddress address, int functionIndex) {
+        UNSAFE.putInt(LLVMMemory.extractAddr(address), functionIndex);
     }
 
-    public static long getFunctionIndex(LLVMAddress addr) {
-        long functionIndex = UNSAFE.getLong(LLVMMemory.extractAddr(addr));
+    public static int getFunctionIndex(LLVMAddress addr) {
+        int functionIndex = UNSAFE.getInt(LLVMMemory.extractAddr(addr));
         return functionIndex;
     }
 

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
@@ -30,7 +30,7 @@
 package com.oracle.truffle.llvm.types.memory;
 
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
 public class LLVMHeap extends LLVMMemory {
 
@@ -102,14 +102,14 @@ public class LLVMHeap extends LLVMMemory {
     // current hack: we cannot directly store the LLVMFunction in the native memory due to GC
     public static final int FUNCTION_PTR_SIZE_BYTE = 8;
 
-    public static void putFunction(LLVMAddress address, LLVMFunction function) {
+    public static void putFunction(LLVMAddress address, LLVMFunctionDescriptor function) {
         LLVMAddress functionIndex = function.getFunctionAddress();
         UNSAFE.putLong(LLVMMemory.extractAddr(address), functionIndex.getVal());
     }
 
-    public static LLVMFunction getFunction(LLVMAddress addr) {
+    public static LLVMFunctionDescriptor getFunction(LLVMAddress addr) {
         long functionIndex = UNSAFE.getLong(LLVMMemory.extractAddr(addr));
-        return LLVMFunction.createFromAddress(LLVMAddress.fromLong(functionIndex));
+        return LLVMFunctionDescriptor.createFromAddress(LLVMAddress.fromLong(functionIndex));
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
@@ -30,7 +30,6 @@
 package com.oracle.truffle.llvm.types.memory;
 
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
 public class LLVMHeap extends LLVMMemory {
 
@@ -102,14 +101,13 @@ public class LLVMHeap extends LLVMMemory {
     // current hack: we cannot directly store the LLVMFunction in the native memory due to GC
     public static final int FUNCTION_PTR_SIZE_BYTE = 8;
 
-    public static void putFunction(LLVMAddress address, LLVMFunctionDescriptor function) {
-        LLVMAddress functionIndex = function.getFunctionAddress();
-        UNSAFE.putLong(LLVMMemory.extractAddr(address), functionIndex.getVal());
+    public static void putFunctionIndex(LLVMAddress address, long functionIndex) {
+        UNSAFE.putLong(LLVMMemory.extractAddr(address), functionIndex);
     }
 
-    public static LLVMFunctionDescriptor getFunction(LLVMAddress addr) {
+    public static long getFunctionIndex(LLVMAddress addr) {
         long functionIndex = UNSAFE.getLong(LLVMMemory.extractAddr(addr));
-        return LLVMFunctionDescriptor.createFromAddress(LLVMAddress.fromLong(functionIndex));
+        return functionIndex;
     }
 
 }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -55,7 +55,7 @@ import com.oracle.truffle.llvm.parser.impl.LLVMVisitor;
 import com.oracle.truffle.llvm.parser.impl.LLVMVisitor.ParserResult;
 import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.LLVMPropertyOptimizationConfiguration;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
 /**
  * This is the main LLVM execution class.
@@ -148,7 +148,7 @@ public class LLVM {
             throw new AssertionError(e);
         } finally {
             // FIXME w
-            LLVMFunction.reset();
+            LLVMFunctionDescriptor.reset();
         }
     }
 

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -55,7 +55,6 @@ import com.oracle.truffle.llvm.parser.impl.LLVMVisitor;
 import com.oracle.truffle.llvm.parser.impl.LLVMVisitor.ParserResult;
 import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.LLVMPropertyOptimizationConfiguration;
-import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
 /**
  * This is the main LLVM execution class.
@@ -146,9 +145,6 @@ public class LLVM {
             return result;
         } catch (IOException e) {
             throw new AssertionError(e);
-        } finally {
-            // FIXME w
-            LLVMFunctionDescriptor.reset();
         }
     }
 


### PR DESCRIPTION
This change removes static fields for assigning function indices and moves this logic to the `LLVMFunctionDescriptor` (previously `LLVMFunction`). Static fields are, e.g., a problem when several Sulong instances are started.