### PR TITLE
Execute constructors and destructors for Sulong libraries

### DIFF
--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -77,6 +77,9 @@ def travis1(args=None):
         with Task('TestBenchmarks', tasks) as t:
             if t: runBenchmarkTestCases()
     with VM('server', 'product'):
+        with Task('TestPolglot', tasks) as t:
+            if t: runPolyglotTestCases()
+    with VM('server', 'product'):
         with Task('TestTypes', tasks) as t:
             if t: runTypeTestCases()
     with VM('server', 'product'):

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
@@ -29,6 +29,8 @@
  */
 package com.oracle.truffle.llvm.nodes.impl.base;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import com.oracle.nfi.api.NativeFunctionHandle;
@@ -45,6 +47,8 @@ import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
 public class LLVMContext extends ExecutionContext {
+
+    private final List<RootCallTarget> staticDestructors = new ArrayList<>();
 
     private final LLVMFunctionRegistry registry;
 
@@ -114,6 +118,14 @@ public class LLVMContext extends ExecutionContext {
 
     public static LLVMStack getStaticStack() {
         return lastContext.stack;
+    }
+
+    public void registerStaticDestructor(RootCallTarget staticDestructor) {
+        getStaticDestructors().add(staticDestructor);
+    }
+
+    public List<RootCallTarget> getStaticDestructors() {
+        return staticDestructors;
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
@@ -48,6 +48,7 @@ import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
 public class LLVMContext extends ExecutionContext {
 
+    private final List<RootCallTarget> staticInitializers = new ArrayList<>();
     private final List<RootCallTarget> staticDestructors = new ArrayList<>();
 
     private final LLVMFunctionRegistry registry;
@@ -121,11 +122,19 @@ public class LLVMContext extends ExecutionContext {
     }
 
     public void registerStaticDestructor(RootCallTarget staticDestructor) {
-        getStaticDestructors().add(staticDestructor);
+        staticDestructors.add(staticDestructor);
+    }
+
+    public void registerStaticInitializer(RootCallTarget staticInitializer) {
+        staticInitializers.add(staticInitializer);
     }
 
     public List<RootCallTarget> getStaticDestructors() {
         return staticDestructors;
+    }
+
+    public List<RootCallTarget> getStaticInitializers() {
+        return staticInitializers;
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
@@ -149,7 +149,7 @@ public class LLVMFunctionRegistry {
 
     /**
      * Creates a function descriptor from the given <code>index</code> that has previously been
-     * obtained by {@link LLVMFunctionDescriptor#getFunctionIndex()}}.
+     * obtained by {@link LLVMFunctionDescriptor#getFunctionIndex()} .
      *
      * @param index the function index
      * @return the function descriptor

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
@@ -160,4 +160,8 @@ public class LLVMFunctionRegistry {
         return llvmFunction;
     }
 
+    public LLVMFunctionDescriptor[] getFunctionDescriptors() {
+        return functionDescriptors;
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMLanguage.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMLanguage.java
@@ -36,6 +36,7 @@ import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
 @TruffleLanguage.Registration(name = "Sulong", version = "0.01", mimeType = {LLVMLanguage.LLVM_MIME_TYPE, LLVMLanguage.SULONG_LIBRARY_MIME_TYPE})
 public final class LLVMLanguage extends TruffleLanguage<LLVMContext> {
@@ -91,6 +92,11 @@ public final class LLVMLanguage extends TruffleLanguage<LLVMContext> {
 
     @Override
     protected Object findExportedSymbol(LLVMContext context, String globalName, boolean onlyExplicit) {
+        for (LLVMFunctionDescriptor descr : context.getFunctionRegistry().getFunctionDescriptors()) {
+            if (descr != null && descr.getName().equals(globalName)) {
+                return descr;
+            }
+        }
         throw new AssertionError(globalName);
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMLanguage.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMLanguage.java
@@ -65,6 +65,8 @@ public final class LLVMLanguage extends TruffleLanguage<LLVMContext> {
         LLVMContext createContext(com.oracle.truffle.api.TruffleLanguage.Env env);
 
         CallTarget parse(Source code, Node context, String... argumentNames);
+
+        void disposeContext(LLVMContext context);
     }
 
     public static LLVMLanguageProvider provider;
@@ -75,6 +77,11 @@ public final class LLVMLanguage extends TruffleLanguage<LLVMContext> {
     @Override
     protected LLVMContext createContext(com.oracle.truffle.api.TruffleLanguage.Env env) {
         return provider.createContext(env);
+    }
+
+    @Override
+    protected void disposeContext(LLVMContext context) {
+        provider.disposeContext(context);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
@@ -41,7 +41,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.RootNode;
-import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMFrameUtil;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
@@ -55,7 +54,6 @@ import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
  */
 public class LLVMGlobalRootNode extends RootNode {
 
-    @Children private final LLVMNode[] staticDestructors;
     private final DirectCallNode main;
     @CompilationFinal private final Object[] arguments;
     private final LLVMContext context;
@@ -63,12 +61,11 @@ public class LLVMGlobalRootNode extends RootNode {
     private final boolean printNativeStats = LLVMOptions.printNativeCallStats();
     private final FrameSlot stackPointerSlot;
 
-    public LLVMGlobalRootNode(FrameSlot stackSlot, FrameDescriptor descriptor, LLVMContext context, CallTarget main, LLVMNode[] staticDestructors, Object... arguments) {
+    public LLVMGlobalRootNode(FrameSlot stackSlot, FrameDescriptor descriptor, LLVMContext context, CallTarget main, Object... arguments) {
         super(LLVMLanguage.class, null, descriptor);
         this.stackPointerSlot = stackSlot;
         this.context = context;
         this.main = Truffle.getRuntime().createDirectCallNode(main);
-        this.staticDestructors = staticDestructors;
         this.arguments = arguments;
     }
 
@@ -95,9 +92,6 @@ public class LLVMGlobalRootNode extends RootNode {
             }
             return result;
         } finally {
-            for (LLVMNode node : staticDestructors) {
-                node.executeVoid(frame);
-            }
             if (printNativeStats) {
                 printNativeCallStats(context);
             }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
@@ -75,7 +75,7 @@ public class LLVMGlobalRootNode extends RootNode {
     @Override
     @ExplodeLoop
     public Object execute(VirtualFrame frame) {
-        LLVMAddress stackPointer = LLVMAddress.fromLong(context.getStack().getUpperBounds());
+        LLVMAddress stackPointer = context.getStack().getUpperBounds();
         try {
             Object result = null;
             for (int i = 0; i < executionCount; i++) {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
@@ -79,8 +79,6 @@ public class LLVMGlobalRootNode extends RootNode {
             return executeProgram(frame, stackPointer);
         } catch (LLVMExitException e) {
             return e.getReturnCode();
-        } finally {
-            context.getStack().free();
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
@@ -50,7 +50,6 @@ import com.oracle.truffle.llvm.runtime.LLVMExitException;
 import com.oracle.truffle.llvm.runtime.LLVMOptions;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
-import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 
 /**
  * The global entry point initializes the global scope and starts execution with the main function.
@@ -58,21 +57,21 @@ import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 public class LLVMGlobalRootNode extends RootNode {
 
     @Children private final LLVMNode[] staticInits;
+    @Children private final LLVMNode[] staticDestructors;
     private final DirectCallNode main;
-    @CompilationFinal private final LLVMAddress[] llvmAddresses;
     @CompilationFinal private final Object[] arguments;
     private final LLVMContext context;
     // FIXME instead make the option system "PE safe"
     private final boolean printNativeStats = LLVMOptions.printNativeCallStats();
     private final FrameSlot stackPointerSlot;
 
-    public LLVMGlobalRootNode(FrameSlot stackSlot, FrameDescriptor descriptor, LLVMContext context, LLVMNode[] staticInits, CallTarget main, LLVMAddress[] llvmAddresses, Object... arguments) {
+    public LLVMGlobalRootNode(FrameSlot stackSlot, FrameDescriptor descriptor, LLVMContext context, LLVMNode[] staticInits, CallTarget main, LLVMNode[] staticDestructors, Object... arguments) {
         super(LLVMLanguage.class, null, descriptor);
         this.stackPointerSlot = stackSlot;
         this.context = context;
         this.staticInits = staticInits;
         this.main = Truffle.getRuntime().createDirectCallNode(main);
-        this.llvmAddresses = llvmAddresses;
+        this.staticDestructors = staticDestructors;
         this.arguments = arguments;
     }
 
@@ -105,8 +104,8 @@ public class LLVMGlobalRootNode extends RootNode {
             }
             return result;
         } finally {
-            for (LLVMAddress alloc : llvmAddresses) {
-                LLVMHeap.freeMemory(alloc);
+            for (LLVMNode node : staticInits) {
+                node.executeVoid(frame);
             }
             if (printNativeStats) {
                 printNativeCallStats(context);

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMStaticInitsBlockNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMStaticInitsBlockNode.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.others;
+
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.api.nodes.RootNode;
+import com.oracle.truffle.llvm.nodes.base.LLVMNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
+import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.memory.LLVMStack;
+
+public class LLVMStaticInitsBlockNode extends RootNode {
+
+    @Children private final LLVMNode[] nodes;
+    private final FrameSlot stackSlot;
+    private final LLVMStack stack;
+
+    public LLVMStaticInitsBlockNode(LLVMNode[] nodes, FrameDescriptor descriptor, LLVMContext llvmContext, FrameSlot stackSlot) {
+        super(LLVMLanguage.class, null, descriptor);
+        this.nodes = nodes;
+        this.stackSlot = stackSlot;
+        stack = llvmContext.getStack();
+
+    }
+
+    @ExplodeLoop
+    @Override
+    public Object execute(VirtualFrame frame) {
+        frame.setObject(stackSlot, LLVMAddress.fromLong(stack.getUpperBounds()));
+        for (LLVMNode node : nodes) {
+            node.executeVoid(frame);
+        }
+        return null;
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMStaticInitsBlockNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMStaticInitsBlockNode.java
@@ -37,7 +37,6 @@ import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
-import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
 public class LLVMStaticInitsBlockNode extends RootNode {
@@ -57,7 +56,7 @@ public class LLVMStaticInitsBlockNode extends RootNode {
     @ExplodeLoop
     @Override
     public Object execute(VirtualFrame frame) {
-        frame.setObject(stackSlot, LLVMAddress.fromLong(stack.getUpperBounds()));
+        frame.setObject(stackSlot, stack.getUpperBounds());
         for (LLVMNode node : nodes) {
             node.executeVoid(frame);
         }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRootNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRootNodeFactory.java
@@ -44,11 +44,11 @@ import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 
 public class LLVMRootNodeFactory {
 
-    public static LLVMGlobalRootNode createGlobalRootNode(LLVMParserRuntime runtime, LLVMNode[] staticInits, RootCallTarget mainCallTarget, LLVMAddress[] allocatedGlobalAddresses, Object[] args,
+    public static LLVMGlobalRootNode createGlobalRootNode(LLVMParserRuntime runtime, LLVMNode[] staticInits, RootCallTarget mainCallTarget, LLVMNode[] staticDestructors, Object[] args,
                     Source sourceFile, LLVMRuntimeType[] mainTypes) {
         return new LLVMGlobalRootNode(runtime.getStackPointerSlot(), runtime.getGlobalFrameDescriptor(), LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0()),
                         staticInits,
-                        mainCallTarget, allocatedGlobalAddresses,
+                        mainCallTarget, staticDestructors,
                         createArgs(sourceFile, args, mainTypes));
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRootNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRootNodeFactory.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.source.Source;
-import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMGlobalRootNode;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
@@ -44,10 +43,10 @@ import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 
 public class LLVMRootNodeFactory {
 
-    public static LLVMGlobalRootNode createGlobalRootNode(LLVMParserRuntime runtime, RootCallTarget mainCallTarget, LLVMNode[] staticDestructors, Object[] args,
+    public static LLVMGlobalRootNode createGlobalRootNode(LLVMParserRuntime runtime, RootCallTarget mainCallTarget, Object[] args,
                     Source sourceFile, LLVMRuntimeType[] mainTypes) {
         return new LLVMGlobalRootNode(runtime.getStackPointerSlot(), runtime.getGlobalFrameDescriptor(), LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0()),
-                        mainCallTarget, staticDestructors,
+                        mainCallTarget,
                         createArgs(sourceFile, args, mainTypes));
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRootNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRootNodeFactory.java
@@ -44,10 +44,9 @@ import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 
 public class LLVMRootNodeFactory {
 
-    public static LLVMGlobalRootNode createGlobalRootNode(LLVMParserRuntime runtime, LLVMNode[] staticInits, RootCallTarget mainCallTarget, LLVMNode[] staticDestructors, Object[] args,
+    public static LLVMGlobalRootNode createGlobalRootNode(LLVMParserRuntime runtime, RootCallTarget mainCallTarget, LLVMNode[] staticDestructors, Object[] args,
                     Source sourceFile, LLVMRuntimeType[] mainTypes) {
         return new LLVMGlobalRootNode(runtime.getStackPointerSlot(), runtime.getGlobalFrameDescriptor(), LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0()),
-                        staticInits,
                         mainCallTarget, staticDestructors,
                         createArgs(sourceFile, args, mainTypes));
     }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -304,9 +304,9 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMGlobalRootNode createGlobalRootNode(RootCallTarget mainCallTarget, LLVMNode[] staticDestructors,
+    public LLVMGlobalRootNode createGlobalRootNode(RootCallTarget mainCallTarget,
                     Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes) {
-        return LLVMRootNodeFactory.createGlobalRootNode(runtime, mainCallTarget, staticDestructors, args, sourceFile, mainTypes);
+        return LLVMRootNodeFactory.createGlobalRootNode(runtime, mainCallTarget, args, sourceFile, mainTypes);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -68,6 +68,7 @@ import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMFreeFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMMemCopyFactory.LLVMMemI32CopyFactory;
 import com.oracle.truffle.llvm.nodes.impl.literals.LLVMAggregateLiteralNode.LLVMEmptyStructLiteralNode;
 import com.oracle.truffle.llvm.nodes.impl.memory.LLVMAddressZeroNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMStaticInitsBlockNode;
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnreachableNode;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
@@ -303,9 +304,9 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMGlobalRootNode createGlobalRootNode(LLVMNode[] staticInits, RootCallTarget mainCallTarget, LLVMNode[] staticDestructors,
+    public LLVMGlobalRootNode createGlobalRootNode(RootCallTarget mainCallTarget, LLVMNode[] staticDestructors,
                     Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes) {
-        return LLVMRootNodeFactory.createGlobalRootNode(runtime, staticInits, mainCallTarget, staticDestructors, args, sourceFile, mainTypes);
+        return LLVMRootNodeFactory.createGlobalRootNode(runtime, mainCallTarget, staticDestructors, args, sourceFile, mainTypes);
     }
 
     @Override
@@ -378,6 +379,12 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
         LLVMAddressNode addressLiteralNode = (LLVMAddressNode) createLiteral(allocation, LLVMBaseType.ADDRESS);
         runtime.addDestructor(LLVMFreeFactory.create(addressLiteralNode));
         return allocation;
+    }
+
+    @Override
+    public RootNode createStaticInitsRootNode(LLVMNode[] staticInits) {
+        return new LLVMStaticInitsBlockNode(staticInits, runtime.getGlobalFrameDescriptor(), LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0()),
+                        runtime.getStackPointerSlot());
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMConstantEvaluator.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMConstantEvaluator.java
@@ -77,7 +77,7 @@ public class LLVMConstantEvaluator {
     }
 
     private static Object evaluateGlobalVariable(GlobalVariable ref) {
-        LLVMAddress addr = runtime.getGlobalAddress(ref);
+        Object addr = runtime.getGlobalAddress(ref);
         assert addr != null;
         return addr;
     }

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -200,10 +200,12 @@ public class LLVMVisitor implements LLVMParserRuntime {
     public class ParserResult {
 
         private final RootCallTarget mainFunction;
+        private final RootCallTarget staticInits;
         private final Map<LLVMFunctionDescriptor, RootCallTarget> parsedFunctions;
 
-        public ParserResult(RootCallTarget mainFunction, Map<LLVMFunctionDescriptor, RootCallTarget> parsedFunctions) {
+        public ParserResult(RootCallTarget mainFunction, RootCallTarget staticInits, Map<LLVMFunctionDescriptor, RootCallTarget> parsedFunctions) {
             this.mainFunction = mainFunction;
+            this.staticInits = staticInits;
             this.parsedFunctions = parsedFunctions;
         }
 
@@ -213,6 +215,10 @@ public class LLVMVisitor implements LLVMParserRuntime {
 
         public Map<LLVMFunctionDescriptor, RootCallTarget> getParsedFunctions() {
             return parsedFunctions;
+        }
+
+        public RootCallTarget getStaticInits() {
+            return staticInits;
         }
     }
 
@@ -228,17 +234,18 @@ public class LLVMVisitor implements LLVMParserRuntime {
     public ParserResult getMain(Model model, NodeFactoryFacade facade) {
         Map<LLVMFunctionDescriptor, RootCallTarget> parsedFunctions = visit(model, facade);
         LLVMFunctionDescriptor mainFunction = searchFunction(parsedFunctions, "@main");
+        LLVMNode[] staticInits = globalNodes.toArray(new LLVMNode[globalNodes.size()]);
+        RootCallTarget staticInitsTarget = Truffle.getRuntime().createCallTarget(factoryFacade.createStaticInitsRootNode(staticInits));
         if (mainFunction == null) {
-            return new ParserResult(Truffle.getRuntime().createCallTarget(RootNode.createConstantNode(null)), parsedFunctions);
+            return new ParserResult(Truffle.getRuntime().createCallTarget(RootNode.createConstantNode(null)), staticInitsTarget, parsedFunctions);
         }
         RootCallTarget mainCallTarget = parsedFunctions.get(mainFunction);
         RootNode globalFunction;
-        LLVMNode[] staticInits = globalNodes.toArray(new LLVMNode[globalNodes.size()]);
-        globalFunction = factoryFacade.createGlobalRootNode(staticInits, mainCallTarget, deallocations, mainArgs, sourceFile, mainFunction.getParameterTypes());
+        globalFunction = factoryFacade.createGlobalRootNode(mainCallTarget, deallocations, mainArgs, sourceFile, mainFunction.getParameterTypes());
         RootCallTarget globalFunctionRoot = Truffle.getRuntime().createCallTarget(globalFunction);
         RootNode globalRootNode = factoryFacade.createGlobalRootNodeWrapping(globalFunctionRoot, mainFunction.getReturnType());
         RootCallTarget wrappedCallTarget = Truffle.getRuntime().createCallTarget(globalRootNode);
-        return new ParserResult(wrappedCallTarget, parsedFunctions);
+        return new ParserResult(wrappedCallTarget, staticInitsTarget, parsedFunctions);
     }
 
     public Map<LLVMFunctionDescriptor, RootCallTarget> visit(Model model, NodeFactoryFacade facade) {

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -201,11 +201,13 @@ public class LLVMVisitor implements LLVMParserRuntime {
 
         private final RootCallTarget mainFunction;
         private final RootCallTarget staticInits;
+        private final RootCallTarget staticDestructors;
         private final Map<LLVMFunctionDescriptor, RootCallTarget> parsedFunctions;
 
-        public ParserResult(RootCallTarget mainFunction, RootCallTarget staticInits, Map<LLVMFunctionDescriptor, RootCallTarget> parsedFunctions) {
+        public ParserResult(RootCallTarget mainFunction, RootCallTarget staticInits, RootCallTarget staticDestructors, Map<LLVMFunctionDescriptor, RootCallTarget> parsedFunctions) {
             this.mainFunction = mainFunction;
             this.staticInits = staticInits;
+            this.staticDestructors = staticDestructors;
             this.parsedFunctions = parsedFunctions;
         }
 
@@ -219,6 +221,10 @@ public class LLVMVisitor implements LLVMParserRuntime {
 
         public RootCallTarget getStaticInits() {
             return staticInits;
+        }
+
+        public RootCallTarget getStaticDestructors() {
+            return staticDestructors;
         }
     }
 
@@ -236,16 +242,17 @@ public class LLVMVisitor implements LLVMParserRuntime {
         LLVMFunctionDescriptor mainFunction = searchFunction(parsedFunctions, "@main");
         LLVMNode[] staticInits = globalNodes.toArray(new LLVMNode[globalNodes.size()]);
         RootCallTarget staticInitsTarget = Truffle.getRuntime().createCallTarget(factoryFacade.createStaticInitsRootNode(staticInits));
+        deallocations = globalDeallocations.toArray(new LLVMNode[globalDeallocations.size()]);
+        RootCallTarget staticDestructorsTarget = Truffle.getRuntime().createCallTarget(factoryFacade.createStaticInitsRootNode(deallocations));
         if (mainFunction == null) {
-            return new ParserResult(Truffle.getRuntime().createCallTarget(RootNode.createConstantNode(null)), staticInitsTarget, parsedFunctions);
+            return new ParserResult(Truffle.getRuntime().createCallTarget(RootNode.createConstantNode(null)), staticInitsTarget, staticDestructorsTarget, parsedFunctions);
         }
         RootCallTarget mainCallTarget = parsedFunctions.get(mainFunction);
-        RootNode globalFunction;
-        globalFunction = factoryFacade.createGlobalRootNode(mainCallTarget, deallocations, mainArgs, sourceFile, mainFunction.getParameterTypes());
+        RootNode globalFunction = factoryFacade.createGlobalRootNode(mainCallTarget, mainArgs, sourceFile, mainFunction.getParameterTypes());
         RootCallTarget globalFunctionRoot = Truffle.getRuntime().createCallTarget(globalFunction);
         RootNode globalRootNode = factoryFacade.createGlobalRootNodeWrapping(globalFunctionRoot, mainFunction.getReturnType());
         RootCallTarget wrappedCallTarget = Truffle.getRuntime().createCallTarget(globalRootNode);
-        return new ParserResult(wrappedCallTarget, staticInitsTarget, parsedFunctions);
+        return new ParserResult(wrappedCallTarget, staticInitsTarget, staticDestructorsTarget, parsedFunctions);
     }
 
     public Map<LLVMFunctionDescriptor, RootCallTarget> visit(Model model, NodeFactoryFacade facade) {
@@ -289,7 +296,6 @@ public class LLVMVisitor implements LLVMParserRuntime {
         }
         List<LLVMNode> globalVarNodes = addGlobalVars(this, staticVars);
         globalNodes.addAll(globalVarNodes);
-        deallocations = globalDeallocations.toArray(new LLVMNode[globalDeallocations.size()]);
         return functionCallTargets;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParserRuntime.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParserRuntime.java
@@ -36,8 +36,8 @@ import com.intel.llvm.ireditor.types.ResolvedType;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
+import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
-import com.oracle.truffle.llvm.types.LLVMAddress;
 
 public interface LLVMParserRuntime {
 
@@ -65,7 +65,7 @@ public interface LLVMParserRuntime {
 
     LLVMExpressionNode allocateVectorResult(EObject type);
 
-    LLVMAddress getGlobalAddress(GlobalVariable var);
+    Object getGlobalAddress(GlobalVariable var);
 
     FrameSlot getStackPointerSlot();
 
@@ -74,4 +74,11 @@ public interface LLVMParserRuntime {
     int getBitAlignment(LLVMBaseType type);
 
     FrameDescriptor getGlobalFrameDescriptor();
+
+    /**
+     * Adds a destructor node that is executed after returning from the main function.
+     *
+     * @param destructorNode
+     */
+    void addDestructor(LLVMNode destructorNode);
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -58,7 +58,6 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
-import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
@@ -196,7 +195,6 @@ public interface NodeFactoryFacade {
     /**
      * Creates the global root (e.g., the main function in C).
      *
-     * @param staticInits
      * @param mainCallTarget
      * @param staticDestructors
      * @param args
@@ -204,7 +202,7 @@ public interface NodeFactoryFacade {
      * @param sourceFile
      * @return the global root
      */
-    RootNode createGlobalRootNode(LLVMNode[] staticInits, RootCallTarget mainCallTarget, LLVMNode[] staticDestructors, Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes);
+    RootNode createGlobalRootNode(RootCallTarget mainCallTarget, LLVMNode[] staticDestructors, Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes);
 
     /**
      * Wraps the global root (e.g., the main function in C) to convert its result.
@@ -302,4 +300,5 @@ public interface NodeFactoryFacade {
 
     Object allocateGlobalVariable(GlobalVariable globalVariable);
 
+    RootNode createStaticInitsRootNode(LLVMNode[] staticInits);
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -37,6 +37,7 @@ import org.eclipse.emf.ecore.EObject;
 
 import com.intel.llvm.ireditor.lLVM_IR.BitwiseBinaryInstruction;
 import com.intel.llvm.ireditor.lLVM_IR.FunctionDef;
+import com.intel.llvm.ireditor.lLVM_IR.GlobalVariable;
 import com.intel.llvm.ireditor.lLVM_IR.Type;
 import com.intel.llvm.ireditor.types.ResolvedType;
 import com.intel.llvm.ireditor.types.ResolvedVectorType;
@@ -197,13 +198,13 @@ public interface NodeFactoryFacade {
      *
      * @param staticInits
      * @param mainCallTarget
-     * @param allocatedGlobalAddresses
+     * @param staticDestructors
      * @param args
      * @param mainTypes
      * @param sourceFile
      * @return the global root
      */
-    RootNode createGlobalRootNode(LLVMNode[] staticInits, RootCallTarget mainCallTarget, LLVMAddress[] allocatedGlobalAddresses, Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes);
+    RootNode createGlobalRootNode(LLVMNode[] staticInits, RootCallTarget mainCallTarget, LLVMNode[] staticDestructors, Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes);
 
     /**
      * Wraps the global root (e.g., the main function in C) to convert its result.
@@ -298,5 +299,7 @@ public interface NodeFactoryFacade {
     RootNode createFunctionSubstitutionRootNode(LLVMNode intrinsicNode);
 
     LLVMFunctionDescriptor createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs);
+
+    Object allocateGlobalVariable(GlobalVariable globalVariable);
 
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -196,13 +196,12 @@ public interface NodeFactoryFacade {
      * Creates the global root (e.g., the main function in C).
      *
      * @param mainCallTarget
-     * @param staticDestructors
      * @param args
      * @param mainTypes
      * @param sourceFile
      * @return the global root
      */
-    RootNode createGlobalRootNode(RootCallTarget mainCallTarget, LLVMNode[] staticDestructors, Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes);
+    RootNode createGlobalRootNode(RootCallTarget mainCallTarget, Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes);
 
     /**
      * Wraps the global root (e.g., the main function in C) to convert its result.

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -262,7 +262,7 @@ public abstract class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public RootNode createGlobalRootNode(LLVMNode[] staticInits, RootCallTarget mainCallTarget, LLVMAddress[] allocatedGlobalAddresses, Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes) {
+    public RootNode createGlobalRootNode(LLVMNode[] staticInits, RootCallTarget mainCallTarget, LLVMNode[] destructors, Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes) {
         return null;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -30,8 +30,8 @@
 package com.oracle.truffle.llvm.parser;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Map;
+import java.util.Optional;
 
 import org.eclipse.emf.ecore.EObject;
 
@@ -57,7 +57,6 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
-import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
 /**
@@ -262,7 +261,7 @@ public abstract class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public RootNode createGlobalRootNode(LLVMNode[] staticInits, RootCallTarget mainCallTarget, LLVMNode[] destructors, Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes) {
+    public RootNode createGlobalRootNode(RootCallTarget mainCallTarget, LLVMNode[] destructors, Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes) {
         return null;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -263,7 +263,7 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public RootNode createGlobalRootNode(RootCallTarget mainCallTarget, LLVMNode[] destructors, Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes) {
+    public RootNode createGlobalRootNode(RootCallTarget mainCallTarget, Object[] args, Source sourceFile, LLVMRuntimeType[] mainTypes) {
         return null;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -37,6 +37,7 @@ import org.eclipse.emf.ecore.EObject;
 
 import com.intel.llvm.ireditor.lLVM_IR.BitwiseBinaryInstruction;
 import com.intel.llvm.ireditor.lLVM_IR.FunctionDef;
+import com.intel.llvm.ireditor.lLVM_IR.GlobalVariable;
 import com.intel.llvm.ireditor.lLVM_IR.Type;
 import com.intel.llvm.ireditor.types.ResolvedType;
 import com.intel.llvm.ireditor.types.ResolvedVectorType;
@@ -57,13 +58,14 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
 /**
  * This class implements an abstract adapter that returns <code>null</code> for each implemented
  * method.
  */
-public abstract class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
+public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
 
     @Override
     public LLVMExpressionNode createInsertElement(LLVMBaseType resultType, LLVMExpressionNode vector, Type vectorType, LLVMExpressionNode element, LLVMExpressionNode index) {
@@ -318,6 +320,21 @@ public abstract class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
 
     @Override
     public RootNode createFunctionSubstitutionRootNode(LLVMNode intrinsicNode) {
+        return null;
+    }
+
+    @Override
+    public LLVMFunctionDescriptor createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs) {
+        return null;
+    }
+
+    @Override
+    public Object allocateGlobalVariable(GlobalVariable globalVariable) {
+        return null;
+    }
+
+    @Override
+    public RootNode createStaticInitsRootNode(LLVMNode[] staticInits) {
         return null;
     }
 

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -105,7 +105,7 @@ public class LLVMOptions {
         PRINT_PERFORMANCE_WARNINGS("PrintPerformanceWarnings", "Prints performance warnings", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
         PERFORMANCE_WARNING_ARE_FATAL("PerformanceWarningsAreFatal", "Terminates the program after a performance issue is encountered", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
         PRINT_FUNCTION_ASTS("PrintASTs", "Prints the Truffle ASTs for the parsed functions", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
-        EXECUTION_COUNT("ExecutionCount", "Execute each program for as many times as specified by this option", "1", LLVMOptions::parseInteger, PropertyCategory.DEBUG),
+        EXECUTION_COUNT("ExecutionCount", "Execute each main function for as many times as specified by this option", "1", LLVMOptions::parseInteger, PropertyCategory.DEBUG),
         /*
          * The boot classpath that should be used to execute the remote JVM when executing the LLVM
          * test suite (and other tests). These rely on comparing output sent to stdout that cannot

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -105,7 +105,7 @@ public class LLVMOptions {
         PRINT_PERFORMANCE_WARNINGS("PrintPerformanceWarnings", "Prints performance warnings", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
         PERFORMANCE_WARNING_ARE_FATAL("PerformanceWarningsAreFatal", "Terminates the program after a performance issue is encountered", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
         PRINT_FUNCTION_ASTS("PrintASTs", "Prints the Truffle ASTs for the parsed functions", "false", LLVMOptions::parseBoolean, PropertyCategory.DEBUG),
-        EXECUTION_COUNT("ExecutionCount", "Execute each main function for as many times as specified by this option", "1", LLVMOptions::parseInteger, PropertyCategory.DEBUG),
+        EXECUTION_COUNT("ExecutionCount", "Execute each program for as many times as specified by this option", "1", LLVMOptions::parseInteger, PropertyCategory.DEBUG),
         /*
          * The boot classpath that should be used to execute the remote JVM when executing the LLVM
          * test suite (and other tests). These rely on comparing output sent to stdout that cannot

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
@@ -227,7 +227,7 @@ public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<L
             assert ForeignAccess.getArguments(frame).isEmpty();
             final LLVMFunctionDescriptor function = (LLVMFunctionDescriptor) ForeignAccess.getReceiver(frame);
             final CallTarget callTarget = getCallTarget(function);
-            return callNode.call(frame, callTarget, new Object[]{LLVMAddress.fromLong(stack.getUpperBounds())});
+            return callNode.call(frame, callTarget, new Object[]{stack.getUpperBounds()});
         }
 
         // TODO No static access to these classes at the moment

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
@@ -227,7 +227,7 @@ public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<L
             assert ForeignAccess.getArguments(frame).isEmpty();
             final LLVMFunctionDescriptor function = (LLVMFunctionDescriptor) ForeignAccess.getReceiver(frame);
             final CallTarget callTarget = getCallTarget(function);
-            return callNode.call(frame, callTarget, new Object[]{stack.getUpperBounds()});
+            return callNode.call(frame, callTarget, new Object[]{LLVMAddress.fromLong(stack.getUpperBounds())});
         }
 
         // TODO No static access to these classes at the moment

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
@@ -227,11 +227,7 @@ public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<L
             assert ForeignAccess.getArguments(frame).isEmpty();
             final LLVMFunctionDescriptor function = (LLVMFunctionDescriptor) ForeignAccess.getReceiver(frame);
             final CallTarget callTarget = getCallTarget(function);
-            try {
-                return callNode.call(frame, callTarget, new Object[]{stack.allocate()});
-            } finally {
-                stack.free();
-            }
+            return callNode.call(frame, callTarget, new Object[]{stack.getUpperBounds()});
         }
 
         // TODO No static access to these classes at the moment

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
@@ -127,4 +127,8 @@ public class LLVMStack extends LLVMMemory {
         }
     }
 
+    public long getUpperBounds() {
+        return upperBounds;
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
@@ -127,8 +127,8 @@ public class LLVMStack extends LLVMMemory {
         }
     }
 
-    public long getUpperBounds() {
-        return upperBounds;
+    public LLVMAddress getUpperBounds() {
+        return LLVMAddress.fromLong(upperBounds);
     }
 
     public boolean isFreed() {

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
@@ -131,4 +131,8 @@ public class LLVMStack extends LLVMMemory {
         return upperBounds;
     }
 
+    public boolean isFreed() {
+        return isFreed;
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -86,6 +86,7 @@ public class LLVM {
                     ParserResult parserResult = parseFile(code.getPath(), llvmContext);
                     mainFunction = parserResult.getMainFunction();
                     llvmContext.getFunctionRegistry().register(parserResult.getParsedFunctions());
+                    llvmContext.registerStaticInitializer(parserResult.getStaticInits());
                     llvmContext.registerStaticDestructor(parserResult.getStaticDestructors());
                     parserResult.getStaticInits().call();
                 } else if (code.getMimeType() == LLVMLanguage.SULONG_LIBRARY_MIME_TYPE) {
@@ -106,6 +107,7 @@ public class LLVM {
                             parserResult.getStaticInits().call();
                             llvmContext.getFunctionRegistry().register(parserResult.getParsedFunctions());
                             mainFunctions.add(parserResult.getMainFunction());
+                            llvmContext.registerStaticInitializer(parserResult.getStaticInits());
                             llvmContext.registerStaticDestructor(parserResult.getStaticDestructors());
                         });
                     } catch (IOException e) {

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -97,7 +97,7 @@ public class LLVM {
                     try {
                         library.readContents(dependentLibrary -> {
                             throw new UnsupportedOperationException();
-                        } , source -> {
+                        }, source -> {
                             ParserResult parserResult;
                             try {
                                 parserResult = parseString(source.getCode(), context);

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -77,17 +77,17 @@ public class LLVM {
         return new LLVMLanguage.LLVMLanguageProvider() {
 
             @Override
-            public CallTarget parse(Source code, Node context, String... argumentNames) {
+            public CallTarget parse(Source code, Node contextNode, String... argumentNames) {
                 Node findContext = LLVMLanguage.INSTANCE.createFindContextNode0();
-                LLVMContext llvmContext = LLVMLanguage.INSTANCE.findContext0(findContext);
+                LLVMContext context = LLVMLanguage.INSTANCE.findContext0(findContext);
 
                 CallTarget mainFunction;
                 if (code.getMimeType() == LLVMLanguage.LLVM_MIME_TYPE) {
-                    ParserResult parserResult = parseFile(code.getPath(), llvmContext);
+                    ParserResult parserResult = parseFile(code.getPath(), context);
                     mainFunction = parserResult.getMainFunction();
-                    llvmContext.getFunctionRegistry().register(parserResult.getParsedFunctions());
-                    llvmContext.registerStaticInitializer(parserResult.getStaticInits());
-                    llvmContext.registerStaticDestructor(parserResult.getStaticDestructors());
+                    context.getFunctionRegistry().register(parserResult.getParsedFunctions());
+                    context.registerStaticInitializer(parserResult.getStaticInits());
+                    context.registerStaticDestructor(parserResult.getStaticDestructors());
                     parserResult.getStaticInits().call();
                 } else if (code.getMimeType() == LLVMLanguage.SULONG_LIBRARY_MIME_TYPE) {
 
@@ -100,15 +100,15 @@ public class LLVM {
                         } , source -> {
                             ParserResult parserResult;
                             try {
-                                parserResult = parseString(source.getCode(), llvmContext);
+                                parserResult = parseString(source.getCode(), context);
                             } catch (IOException e) {
                                 throw new UncheckedIOException(e);
                             }
                             parserResult.getStaticInits().call();
-                            llvmContext.getFunctionRegistry().register(parserResult.getParsedFunctions());
+                            context.getFunctionRegistry().register(parserResult.getParsedFunctions());
                             mainFunctions.add(parserResult.getMainFunction());
-                            llvmContext.registerStaticInitializer(parserResult.getStaticInits());
-                            llvmContext.registerStaticDestructor(parserResult.getStaticDestructors());
+                            context.registerStaticInitializer(parserResult.getStaticInits());
+                            context.registerStaticDestructor(parserResult.getStaticDestructors());
                         });
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -92,7 +92,7 @@ public class LLVM {
                     try {
                         library.readContents(dependentLibrary -> {
                             throw new UnsupportedOperationException();
-                        }, source -> {
+                        } , source -> {
                             ParserResult parserResult;
                             try {
                                 parserResult = parseString(source.getCode(), llvmContext);

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -48,6 +48,7 @@ import com.google.inject.Injector;
 import com.intel.llvm.ireditor.LLVM_IRStandaloneSetup;
 import com.intel.llvm.ireditor.lLVM_IR.Model;
 import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.TruffleLanguage.Env;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.Source;
@@ -82,8 +83,11 @@ public class LLVM {
 
                 if (code.getMimeType() == LLVMLanguage.LLVM_MIME_TYPE) {
                     ParserResult parserResult = parseFile(code.getPath(), llvmContext);
+                    RootCallTarget mainFunction = parserResult.getMainFunction();
                     llvmContext.getFunctionRegistry().register(parserResult.getParsedFunctions());
-                    return parserResult.getMainFunction();
+                    llvmContext.getStack().allocate();
+                    parserResult.getStaticInits().call();
+                    return mainFunction;
                 } else if (code.getMimeType() == LLVMLanguage.SULONG_LIBRARY_MIME_TYPE) {
                     final List<CallTarget> mainFunctions = new ArrayList<>();
 


### PR DESCRIPTION
This change factors out the static initializers and static destructors. Instead of executing them in the `LLVMGlobalRootNode` the static initializer nodes are executed when a source file is parsed, and the static destructors are executed when the `PolyglotEngine` is disposed.

Addresses #150 and https://github.com/jruby/jruby/pull/3800.