### PR TITLE
Bitcode libraries

### DIFF
--- a/mx.sulong/libs/test.c
+++ b/mx.sulong/libs/test.c
@@ -1,0 +1,3 @@
+int test() {
+	return 3;
+}

--- a/mx.sulong/libs/test.ll
+++ b/mx.sulong/libs/test.ll
@@ -1,0 +1,7 @@
+; ModuleID = '/home/manuel/phd/dev/sulong/mx.sulong/libs/test.c'
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @test() nounwind uwtable {
+  ret i32 3
+}

--- a/mx.sulong/libs/test2.c
+++ b/mx.sulong/libs/test2.c
@@ -1,0 +1,3 @@
+int test2() {
+	return 2;
+}

--- a/mx.sulong/libs/test2.ll
+++ b/mx.sulong/libs/test2.ll
@@ -1,0 +1,7 @@
+; ModuleID = '/home/manuel/phd/dev/sulong/mx.sulong/libs/test2.c'
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @test2() nounwind uwtable {
+  ret i32 2
+}

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -12,6 +12,8 @@ from mx_gate import Task, add_gate_runner
 from mx_jvmci import VM, buildvms
 
 _suite = mx.suite('sulong')
+_mx = join(_suite.dir, "mx.sulong/")
+_libPath = join(_mx, 'libs')
 _root = join(_suite.dir, "projects/")
 _parserDir = join(_root, "com.intel.llvm.ireditor")
 _testDir = join(_root, "com.oracle.truffle.llvm.test/")
@@ -471,6 +473,7 @@ def getCommonOptions(lib_args=None):
         '-Dgraal.TruffleCompilationExceptionsArePrinted=true',
         '-Dgraal.ExitVMOnException=true',
         '-Dsulong.IntrinsifyCFunctions=false',
+        getBitcodeLibrariesOption(),
         getSearchPathOption(lib_args)
     ]
 
@@ -688,6 +691,19 @@ def mdlCheck(args=None):
             if f.endswith('.md') and (path.startswith('./projects') or path is '.'):
                 absPath = path + '/' + f
                 subprocess.check_output(['mdl', '-r~MD026,~MD002,~MD029,~MD032', absPath])
+
+def getBitcodeLibrariesOption():
+    libraries = []
+    for path, _, files in os.walk(_libPath):
+        for f in files:
+            # TODO: also allow other extensions, best introduce a command "compile" that compiles C, C++, Fortran and other files
+            if f.endswith('.c'):
+                bitcodeFile = f.rsplit( ".", 1 )[0] + '.ll'
+                absBitcodeFile = path + '/' + bitcodeFile
+                if not os.path.isfile(absBitcodeFile):
+                    compileWithClang(['-S', '-emit-llvm', path + '/' + f, '-o', absBitcodeFile])
+                libraries.append(absBitcodeFile)
+    return'-Dsulong.DynamicBitcodeLibraries=' + ':'.join(libraries)
 
 mx.update_commands(_suite, {
     'suoptbench' : [suOptBench, ''],

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -698,7 +698,7 @@ def getBitcodeLibrariesOption():
         for f in files:
             # TODO: also allow other extensions, best introduce a command "compile" that compiles C, C++, Fortran and other files
             if f.endswith('.c'):
-                bitcodeFile = f.rsplit( ".", 1 )[0] + '.ll'
+                bitcodeFile = f.rsplit(".", 1)[0] + '.ll'
                 absBitcodeFile = path + '/' + bitcodeFile
                 if not os.path.isfile(absBitcodeFile):
                     compileWithClang(['-S', '-emit-llvm', path + '/' + f, '-o', absBitcodeFile])

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -131,6 +131,7 @@ public class LLVMOptions {
                         LLVMOptions::parseString,
                         PropertyCategory.TESTS),
         DYN_LIBRARY_PATHS("DynamicNativeLibraryPath", "The native library search paths delimited by " + PATH_DELIMITER, null, LLVMOptions::parseDynamicLibraryPath, PropertyCategory.GENERAL),
+        DYN_BITCODE_LIBRARIES("DynamicBitcodeLibraries", "The paths to shared bitcode libraries delimited by " + PATH_DELIMITER, null, LLVMOptions::parseDynamicLibraryPath, PropertyCategory.GENERAL),
         PROJECT_ROOT("ProjectRoot", "Overrides the root of the project. This option exists to set the project root from mx", ".", LLVMOptions::parseString, PropertyCategory.MX),
         OPTIMIZATIONS_DISABLE_SPECULATIVE(
                         "DisableSpeculativeOptimizations",
@@ -349,6 +350,10 @@ public class LLVMOptions {
 
     public static boolean performanceWarningsAreFatal() {
         return getParsedProperty(Property.PERFORMANCE_WARNING_ARE_FATAL);
+    }
+
+    public static String[] getDynamicBitcodeLibraries() {
+        return getParsedProperty(Property.DYN_BITCODE_LIBRARIES);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -98,7 +98,7 @@ public class LLVM {
                     try {
                         library.readContents(dependentLibrary -> {
                             throw new UnsupportedOperationException();
-                        } , source -> {
+                        }, source -> {
                             ParserResult parserResult;
                             try {
                                 parserResult = parseString(source.getCode(), context);


### PR DESCRIPTION
This change implements the linking of bitcode libraries. mx compiles C files in `mx.sulong/libs` to bitcode and passes them with the `sulong.DynamicBitcodeLibraries` option to the Sulong runtime. The Sulong runtime parses the libraries and registers the functions, so that the main program can use them.