### PR TITLE
Bitcode libraries

### DIFF
--- a/mx.sulong/libs/test.c
+++ b/mx.sulong/libs/test.c
@@ -1,0 +1,3 @@
+int test() {
+	return 3;
+}

--- a/mx.sulong/libs/test.ll
+++ b/mx.sulong/libs/test.ll
@@ -1,0 +1,7 @@
+; ModuleID = '/home/manuel/phd/dev/sulong/mx.sulong/libs/test.c'
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @test() nounwind uwtable {
+  ret i32 3
+}

--- a/mx.sulong/libs/test2.c
+++ b/mx.sulong/libs/test2.c
@@ -1,0 +1,3 @@
+int test2() {
+	return 2;
+}

--- a/mx.sulong/libs/test2.ll
+++ b/mx.sulong/libs/test2.ll
@@ -1,0 +1,7 @@
+; ModuleID = '/home/manuel/phd/dev/sulong/mx.sulong/libs/test2.c'
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @test2() nounwind uwtable {
+  ret i32 2
+}

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -131,6 +131,7 @@ public class LLVMOptions {
                         LLVMOptions::parseString,
                         PropertyCategory.TESTS),
         DYN_LIBRARY_PATHS("DynamicNativeLibraryPath", "The native library search paths delimited by " + PATH_DELIMITER, null, LLVMOptions::parseDynamicLibraryPath, PropertyCategory.GENERAL),
+        DYN_BITCODE_LIBRARIES("DynamicBitcodeLibraries", "The paths to shared bitcode libraries delimited by " + PATH_DELIMITER, null, LLVMOptions::parseDynamicLibraryPath, PropertyCategory.GENERAL),
         PROJECT_ROOT("ProjectRoot", "Overrides the root of the project. This option exists to set the project root from mx", ".", LLVMOptions::parseString, PropertyCategory.MX),
         OPTIMIZATIONS_DISABLE_SPECULATIVE(
                         "DisableSpeculativeOptimizations",
@@ -349,6 +350,10 @@ public class LLVMOptions {
 
     public static boolean performanceWarningsAreFatal() {
         return getParsedProperty(Property.PERFORMANCE_WARNING_ARE_FATAL);
+    }
+
+    public static String[] getDynamicBitcodeLibraries() {
+        return getParsedProperty(Property.DYN_BITCODE_LIBRARIES);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -60,6 +60,7 @@ import com.oracle.truffle.llvm.parser.factories.NodeFactoryFacadeImpl;
 import com.oracle.truffle.llvm.parser.impl.LLVMVisitor;
 import com.oracle.truffle.llvm.parser.impl.LLVMVisitor.ParserResult;
 import com.oracle.truffle.llvm.runtime.LLVMLogger;
+import com.oracle.truffle.llvm.runtime.LLVMOptions;
 import com.oracle.truffle.llvm.runtime.LLVMPropertyOptimizationConfiguration;
 
 /**
@@ -80,7 +81,7 @@ public class LLVM {
             public CallTarget parse(Source code, Node contextNode, String... argumentNames) {
                 Node findContext = LLVMLanguage.INSTANCE.createFindContextNode0();
                 LLVMContext context = LLVMLanguage.INSTANCE.findContext0(findContext);
-
+                parseDynamicBitcodeLibraries(context);
                 CallTarget mainFunction;
                 if (code.getMimeType() == LLVMLanguage.LLVM_MIME_TYPE) {
                     ParserResult parserResult = parseFile(code.getPath(), context);
@@ -123,6 +124,16 @@ public class LLVM {
                     throw new IllegalArgumentException("undeclared mime type");
                 }
                 return mainFunction;
+            }
+
+            private void parseDynamicBitcodeLibraries(LLVMContext context) {
+                String[] dynamicLibraryPaths = LLVMOptions.getDynamicBitcodeLibraries();
+                if (dynamicLibraryPaths != null && dynamicLibraryPaths.length != 0) {
+                    for (String s : dynamicLibraryPaths) {
+                        ParserResult result = parseFile(s, context);
+                        context.getFunctionRegistry().register(result.getParsedFunctions());
+                    }
+                }
             }
 
             @Override


### PR DESCRIPTION
This change implements the linking of bitcode libraries. mx compiles C files in `mx.sulong/libs` to bitcode and passes them with the `sulong.DynamicBitcodeLibraries` option to the Sulong runtime. The Sulong runtime parses the libraries and registers the functions, so that the main program can use them.