### PR TITLE
Global variable aliases

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMParserAsserts.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMParserAsserts.java
@@ -40,4 +40,10 @@ public class LLVMParserAsserts {
         return objects;
     }
 
+    public static void assertNotNull(Object object) {
+        if (object == null) {
+            throw new AssertionError();
+        }
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm.test/tests/c/alias/globalVar1.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/alias/globalVar1.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+int original = 1324342;
+extern int alias __attribute__((alias("original")));
+
+int main() {
+	if (alias != original) {
+		abort();
+	}
+	return 0;
+}

--- a/projects/com.oracle.truffle.llvm.test/tests/c/alias/globalVar2.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/alias/globalVar2.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+int original = 1324342;
+extern int alias __attribute__((alias("original")));
+
+int main() {
+	if (alias != original) {
+		abort();
+	}
+	return 0;
+}

--- a/projects/com.oracle.truffle.llvm.test/tests/c/alias/globalVar3.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/alias/globalVar3.c
@@ -1,0 +1,12 @@
+#include <stdlib.h>
+
+int original = 1324342;
+extern int alias __attribute__((alias("original")));
+
+int main() {
+	original = 3;
+	if (alias != 3) {
+		abort();
+	}
+	return 0;
+}

--- a/projects/com.oracle.truffle.llvm.test/tests/c/alias/globalVar4.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/alias/globalVar4.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+
+int original = 1324342;
+extern int alias __attribute__((alias("original")));
+extern int alias2 __attribute__((alias("alias")));
+extern int alias3 __attribute__((alias("alias2")));
+
+int main() {
+	if (original != 1324342 || alias != 1324342 || alias2 != 1324342 || alias3 != 1324342) {
+		abort();
+	}
+	alias2 = 4;
+	if (original != 4 || alias != 4 || alias2 != 4 || alias3 != 4) {
+		abort();
+	}	
+	return 0;
+}


### PR DESCRIPTION
This change adds basic support for aliases to global variables and other global variable aliases. Such aliases can be produced by GCC's `__attribute__((alias("varname")))` attribute