### PR TITLE
Fix buffer overflow in array test case

### DIFF
--- a/projects/com.oracle.truffle.llvm.test/tests/c/truffle-c/arrayTest/constSizeVarArray5.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/truffle-c/arrayTest/constSizeVarArray5.c
@@ -2,11 +2,11 @@ int main() {
 	int n = 5;
 	int x[3*n++];
 	int i;
-	for (i = 0; i < 16; i++) {
+	for (i = 0; i < 15; i++) {
 		x[i] = i;
 	}
 	int sum = 0;
-	for (i = 0; i < 16; i++) {
+	for (i = 0; i < 15; i++) {
 		sum += x[i];
 	}
 	return sum + n;


### PR DESCRIPTION
The result of the test case is dependent on the order local variables are allocated on the stack.