### PR TITLE
Lazily fail casts and inline assembler

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMTo80BitFloatingNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMTo80BitFloatingNode.java
@@ -33,6 +33,7 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVM80BitFloatNode;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMDoubleNode;
+import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMFloatNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI16Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
@@ -101,6 +102,16 @@ public abstract class LLVMTo80BitFloatingNode extends LLVM80BitFloatNode {
         @Specialization
         public LLVM80BitFloat executeLLVM80BitFloatNode(long from) {
             return LLVM80BitFloat.fromUnsignedLong(from);
+        }
+    }
+
+    @NodeChild(value = "fromNode", type = LLVMFloatNode.class)
+    public abstract static class LLVMFloatToLLVM80BitFloatNode extends LLVMTo80BitFloatingNode {
+
+        @Specialization
+        public LLVM80BitFloat executeLLVM80BitFloatNode(float from) {
+            // TODO implement
+            throw new AssertionError(from);
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToFunctionNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToFunctionNode.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.cast;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
+import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+
+public abstract class LLVMToFunctionNode extends LLVMFunctionNode {
+
+    @NodeChild(value = "fromNode", type = LLVMI64Node.class)
+    public abstract static class LLVMI64ToFunctionNode extends LLVMToFunctionNode {
+
+        @Specialization
+        public LLVMFunctionDescriptor executeI64(long from) {
+            // TODO implement
+            throw new AssertionError(from);
+        }
+    }
+
+    @NodeChild(value = "fromNode", type = LLVMAddressNode.class)
+    public abstract static class LLVMAddressToFunctionNode extends LLVMToFunctionNode {
+
+        @Specialization
+        public LLVMFunctionDescriptor executeI64(LLVMAddress from) {
+            // TODO implement
+            throw new AssertionError(from);
+        }
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMUnsupportedInlineAssemblerNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMUnsupportedInlineAssemblerNode.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.others;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVM80BitFloatNode;
+import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMDoubleNode;
+import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMFloatNode;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI16Node;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI1Node;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
+import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
+import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
+import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
+
+public class LLVMUnsupportedInlineAssemblerNode extends LLVMExpressionNode {
+
+    public static class LLVMI1UnsupportedInlineAssemblerNode extends LLVMI1Node {
+
+        @Override
+        public boolean executeI1(VirtualFrame frame) {
+            throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
+        }
+
+    }
+
+    public static class LLVMI8UnsupportedInlineAssemblerNode extends LLVMI8Node {
+
+        @Override
+        public byte executeI8(VirtualFrame frame) {
+            throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
+        }
+
+    }
+
+    public static class LLVMI16UnsupportedInlineAssemblerNode extends LLVMI16Node {
+
+        @Override
+        public short executeI16(VirtualFrame frame) {
+            throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
+        }
+
+    }
+
+    public static class LLVMI32UnsupportedInlineAssemblerNode extends LLVMI32Node {
+
+        @Override
+        public int executeI32(VirtualFrame frame) {
+            throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
+        }
+
+    }
+
+    public static class LLVMI64UnsupportedInlineAssemblerNode extends LLVMI64Node {
+
+        @Override
+        public long executeI64(VirtualFrame frame) {
+            throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
+        }
+
+    }
+
+    public static class LLVMFloatUnsupportedInlineAssemblerNode extends LLVMFloatNode {
+
+        @Override
+        public float executeFloat(VirtualFrame frame) {
+            throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
+        }
+
+    }
+
+    public static class LLVMDoubleUnsupportedInlineAssemblerNode extends LLVMDoubleNode {
+
+        @Override
+        public double executeDouble(VirtualFrame frame) {
+            throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
+        }
+
+    }
+
+    public static class LLVM80BitFloatUnsupportedInlineAssemblerNode extends LLVM80BitFloatNode {
+
+        @Override
+        public LLVM80BitFloat execute80BitFloat(VirtualFrame frame) {
+            throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
+        }
+
+    }
+
+    public static class LLVMAddressUnsupportedInlineAssemblerNode extends LLVMAddressNode {
+
+        @Override
+        public LLVMAddress executePointee(VirtualFrame frame) {
+            throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
+        }
+
+    }
+
+    public static class LLVMFunctionUnsupportedInlineAssemblerNode extends LLVMFunctionNode {
+
+        @Override
+        public LLVMFunctionDescriptor executeFunction(VirtualFrame frame) {
+            throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
+        }
+
+    }
+
+    @Override
+    public Object executeGeneric(VirtualFrame frame) {
+        throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMCastsFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMCastsFactory.java
@@ -45,6 +45,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMIVarBitNode;
 import com.oracle.truffle.llvm.nodes.impl.base.vector.LLVMI32VectorNode;
 import com.oracle.truffle.llvm.nodes.impl.base.vector.LLVMI8VectorNode;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMTo80BitFloatingNodeFactory.LLVMDoubleToLLVM80BitFloatNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.cast.LLVMTo80BitFloatingNodeFactory.LLVMFloatToLLVM80BitFloatNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMTo80BitFloatingNodeFactory.LLVMI32ToLLVM80BitFloatNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMTo80BitFloatingNodeFactory.LLVMI32ToLLVM80BitFloatUnsignedNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMTo80BitFloatingNodeFactory.LLVMI64ToLLVM80BitFloatNodeGen;
@@ -72,6 +73,8 @@ import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToFloatNodeFactory.LLVMI64ToF
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToFloatNodeFactory.LLVMI64ToFloatUnsignedNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToFloatNodeFactory.LLVMI8ToFloatNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToFloatNodeFactory.LLVMI8ToFloatZeroExtNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToFunctionNodeFactory.LLVMAddressToFunctionNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToFunctionNodeFactory.LLVMI64ToFunctionNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI16NodeFactory.LLVMDoubleToI16NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI16NodeFactory.LLVMFloatToI16NodeGen;
 import com.oracle.truffle.llvm.nodes.impl.cast.LLVMToI16NodeFactory.LLVMI1ToI16NodeGen;
@@ -298,6 +301,8 @@ public final class LLVMCastsFactory {
                     return LLVMFloatToI64NodeGen.create(fromNode);
                 case DOUBLE:
                     return LLVMFloatToDoubleNodeGen.create(fromNode);
+                case X86_FP80:
+                    return LLVMFloatToLLVM80BitFloatNodeGen.create(fromNode);
                 default:
                     throw new AssertionError(targetType + " " + conv);
             }
@@ -375,6 +380,8 @@ public final class LLVMCastsFactory {
                     // at the moment we still can directly cast from pointer to pointer (e.g. from
                     // I32* to I32Vector*)
                     return fromNode;
+                case FUNCTION_ADDRESS:
+                    return LLVMAddressToFunctionNodeGen.create(fromNode);
                 default:
                     throw new AssertionError(targetType + " " + conv);
             }
@@ -419,6 +426,8 @@ public final class LLVMCastsFactory {
                     return LLVMI64ToLLVM80BitFloatUnsignedNodeGen.create(fromNode);
                 case ADDRESS:
                     return LLVMI64ToAddressNodeGen.create(fromNode);
+                case FUNCTION_ADDRESS:
+                    return LLVMI64ToFunctionNodeGen.create(fromNode);
                 default:
                     throw new AssertionError(targetType + " " + conv);
             }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -69,6 +69,17 @@ import com.oracle.truffle.llvm.nodes.impl.literals.LLVMAggregateLiteralNode.LLVM
 import com.oracle.truffle.llvm.nodes.impl.memory.LLVMAddressZeroNode;
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMStaticInitsBlockNode;
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnreachableNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode.LLVM80BitFloatUnsupportedInlineAssemblerNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode.LLVMAddressUnsupportedInlineAssemblerNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode.LLVMDoubleUnsupportedInlineAssemblerNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode.LLVMFloatUnsupportedInlineAssemblerNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode.LLVMFunctionUnsupportedInlineAssemblerNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode.LLVMI16UnsupportedInlineAssemblerNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode.LLVMI1UnsupportedInlineAssemblerNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode.LLVMI32UnsupportedInlineAssemblerNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode.LLVMI64UnsupportedInlineAssemblerNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode.LLVMI8UnsupportedInlineAssemblerNode;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.NodeFactoryFacade;
@@ -79,8 +90,6 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
 import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
-import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
-import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
@@ -335,7 +344,32 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
 
     @Override
     public LLVMNode createInlineAssemblerExpression(String asmExpression, String asmFlags, LLVMExpressionNode[] args, LLVMBaseType retType) {
-        throw new LLVMUnsupportedException(UnsupportedReason.INLINE_ASSEMBLER);
+        switch (retType) {
+            case VOID:
+                return new LLVMUnsupportedInlineAssemblerNode();
+            case I1:
+                return new LLVMI1UnsupportedInlineAssemblerNode();
+            case I8:
+                return new LLVMI8UnsupportedInlineAssemblerNode();
+            case I16:
+                return new LLVMI16UnsupportedInlineAssemblerNode();
+            case I32:
+                return new LLVMI32UnsupportedInlineAssemblerNode();
+            case I64:
+                return new LLVMI64UnsupportedInlineAssemblerNode();
+            case FLOAT:
+                return new LLVMFloatUnsupportedInlineAssemblerNode();
+            case DOUBLE:
+                return new LLVMDoubleUnsupportedInlineAssemblerNode();
+            case X86_FP80:
+                return new LLVM80BitFloatUnsupportedInlineAssemblerNode();
+            case ADDRESS:
+                return new LLVMAddressUnsupportedInlineAssemblerNode();
+            case FUNCTION_ADDRESS:
+                return new LLVMFunctionUnsupportedInlineAssemblerNode();
+            default:
+                throw new AssertionError(retType);
+        }
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -895,7 +895,12 @@ public class LLVMVisitor implements LLVMParserRuntime {
             GlobalValueRef ref = (GlobalValueRef) currentRef;
             if (ref.getConstant() instanceof SimpleConstant) {
                 SimpleConstant simpleConstant = (SimpleConstant) ref.getConstant();
-                return Integer.parseInt(simpleConstant.getValue());
+                try {
+                    return Integer.parseInt(simpleConstant.getValue());
+                } catch (NumberFormatException e) {
+                    LLVMLogger.info("GEP index overflow (still parse as int");
+                    return (int) Long.parseLong(simpleConstant.getValue());
+                }
             }
         }
         return null;


### PR DESCRIPTION
To partially support larger parts of libraries that have some parts that rely on not yet implemented casts and inline assembler, this change lets such cases fail during run-time and not execution-time.