### PR TITLE
Do not execute destructors for multiple program executions

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
@@ -85,7 +85,7 @@ public class LLVMGlobalRootNode extends RootNode {
                 System.arraycopy(arguments, 0, realArgs, LLVMCallNode.ARG_START_INDEX, arguments.length);
                 result = main.call(frame, realArgs);
                 if (i != executionCount - 1) {
-                    executeDestructorsAndStaticInit();
+                    executeStaticInits();
                 }
             }
             return result;
@@ -99,11 +99,7 @@ public class LLVMGlobalRootNode extends RootNode {
     }
 
     @TruffleBoundary
-    private void executeDestructorsAndStaticInit() {
-        List<RootCallTarget> staticDestructors = context.getStaticDestructors();
-        for (RootCallTarget staticDestructor : staticDestructors) {
-            staticDestructor.call(staticDestructor);
-        }
+    private void executeStaticInits() {
         List<RootCallTarget> staticInits = context.getStaticInitializers();
         for (RootCallTarget callTarget : staticInits) {
             callTarget.call(staticInits);


### PR DESCRIPTION
The destructors should only be executed once after the last program run. If they get executed before the start of a new program run they deallocate global variables that are not allocated in the static constructors, but in the parser.