### PR TITLE
C format checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
     - gfortran-4.6
     - libgmp3-dev
     - llvm-3.3
+    - clang-format-3.4
     - gobjc++-4.6
     - gcc-4.6-plugin-dev
 install:
@@ -34,6 +35,7 @@ branches:
   only:
     - master
 env:
+  - TEST_COMMAND='mx/mx su-clangformatcheck'
   - TEST_COMMAND='mx/mx eclipseformat --primary'
   - TEST_COMMAND='mx/mx su-mdlcheck'
   - TEST_COMMAND='mx/mx su-gitlogcheck'

--- a/include/truffle.h
+++ b/include/truffle.h
@@ -83,7 +83,7 @@ double truffle_unbox_d(void *object);
 bool truffle_unbox_b(void *object);
 
 // Read
-void * truffle_read(void *object, const char *name);
+void *truffle_read(void *object, const char *name);
 int truffle_read_i(void *object, const char *name);
 long truffle_read_l(void *object, const char *name);
 char truffle_read_c(void *object, const char *name);
@@ -99,7 +99,6 @@ float truffle_read_idx_f(void *object, int idx);
 double truffle_read_idx_d(void *object, int idx);
 bool truffle_read_idx_b(void *object, int idx);
 
-
 // Write
 void truffle_write(void *object, const char *name, void *value);
 void truffle_write_i(void *object, const char *name, int value);
@@ -109,7 +108,6 @@ void truffle_write_f(void *object, const char *name, float value);
 void truffle_write_d(void *object, const char *name, double value);
 void truffle_write_b(void *object, const char *name, bool value);
 
-
 void truffle_write_idx(void *object, int idx, void *value);
 void truffle_write_idx_i(void *object, int idx, int value);
 void truffle_write_idx_l(void *object, int idx, long value);
@@ -117,7 +115,6 @@ void truffle_write_idx_c(void *object, int idx, char value);
 void truffle_write_idx_f(void *object, int idx, float value);
 void truffle_write_idx_d(void *object, int idx, double value);
 void truffle_write_idx_b(void *object, int idx, bool value);
-
 
 #if defined(__cplusplus)
 }

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -742,6 +742,19 @@ def getBitcodeLibrariesOption():
                 libraries.append(absBitcodeFile)
     return ['-Dsulong.DynamicBitcodeLibraries=' + ':'.join(libraries)] if libraries else []
 
+def clangformatcheck(args=None):
+    """ Performs a format check on the include/truffle.h file """
+    return checkCFile(_suite.dir + '/include/truffle.h')
+
+def checkCFile(targetFile):
+    formattedContent = subprocess.check_output(['clang-format-3.4', '-style={ColumnLimit: 150}', targetFile]).splitlines()
+    with open(targetFile) as f:
+        originalContent = f.read().splitlines()
+    if not formattedContent == originalContent:
+        print '\n'.join(formattedContent)
+        print '\nplease fix the formatting in', targetFile, 'to the format given above'
+        exit(-1)
+
 mx.update_commands(_suite, {
     'suoptbench' : [suOptBench, ''],
     'subench' : [suBench, ''],
@@ -777,5 +790,6 @@ mx.update_commands(_suite, {
     'su-travis1' : [travis1, ''],
     'su-travis2' : [travis2, ''],
     'su-gitlogcheck' : [logCheck, ''],
-    'su-mdlcheck' : [mdlCheck, '']
+    'su-mdlcheck' : [mdlCheck, ''],
+    'su-clangformatcheck' : [clangformatcheck, '']
 })


### PR DESCRIPTION
This change introduces a `clang-format` command to validate the format of the `include/truffle.h` file. It would make sense to also apply `clang-format` to our test cases in the future.