### PR TITLE
Make findbugs warnings fatal in Travis and mx gate

### DIFF
--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -51,7 +51,8 @@ def executeGate():
         if t: buildvms(['-c', '--vms', 'server', '--builds', 'product'])
     with VM('server', 'product'):
         with Task('Findbugs', tasks) as t:
-            if t: mx_findbugs.findbugs([])
+            if t and mx_findbugs.findbugs([]) != 0:
+                t.abort('FindBugs warnings were found')
     with VM('server', 'product'):
         with Task('TestBenchmarks', tasks) as t:
             if t: runBenchmarkTestCases()
@@ -80,7 +81,8 @@ def travis1(args=None):
         if t: buildvms(['-c', '--vms', 'server', '--builds', 'product'])
     with VM('server', 'product'):
         with Task('Findbugs', tasks) as t:
-            if t: mx_findbugs.findbugs([])
+            if t and mx_findbugs.findbugs([]) != 0:
+                t.abort('FindBugs warnings were found')
     with VM('server', 'product'):
         with Task('TestBenchmarks', tasks) as t:
             if t: runBenchmarkTestCases()

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
@@ -64,8 +64,7 @@ public class LLVMContext extends ExecutionContext {
     public LLVMContext(NodeFactoryFacade facade, LLVMOptimizationConfiguration optimizationConfig) {
         nativeLookup = new NativeLookup(facade);
         this.registry = new LLVMFunctionRegistry(optimizationConfig, facade);
-
-        lastContext = this;
+        setLastContext(this);
     }
 
     public RootCallTarget getFunction(LLVMFunctionDescriptor function) {
@@ -115,6 +114,10 @@ public class LLVMContext extends ExecutionContext {
 
     public static CallTarget getCallTarget(LLVMFunctionDescriptor function) {
         return lastContext.registry.lookup(function);
+    }
+
+    private static void setLastContext(LLVMContext context) {
+        lastContext = context;
     }
 
     public static LLVMStack getStaticStack() {

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -83,14 +83,14 @@ public class LLVM {
                 LLVMContext context = LLVMLanguage.INSTANCE.findContext0(findContext);
                 parseDynamicBitcodeLibraries(context);
                 CallTarget mainFunction;
-                if (code.getMimeType() == LLVMLanguage.LLVM_MIME_TYPE) {
+                if (code.getMimeType().equals(LLVMLanguage.LLVM_MIME_TYPE)) {
                     ParserResult parserResult = parseFile(code.getPath(), context);
                     mainFunction = parserResult.getMainFunction();
                     context.getFunctionRegistry().register(parserResult.getParsedFunctions());
                     context.registerStaticInitializer(parserResult.getStaticInits());
                     context.registerStaticDestructor(parserResult.getStaticDestructors());
                     parserResult.getStaticInits().call();
-                } else if (code.getMimeType() == LLVMLanguage.SULONG_LIBRARY_MIME_TYPE) {
+                } else if (code.getMimeType().equals(LLVMLanguage.SULONG_LIBRARY_MIME_TYPE)) {
 
                     final List<CallTarget> mainFunctions = new ArrayList<>();
                     final SulongLibrary library = new SulongLibrary(new File(code.getPath()));


### PR DESCRIPTION
Previously, the mx and Travis gates ignored findbugs warnings. This change lets the gates abort if a findbugs warning is found. It also fixes the causes for two warnings. 