### PR TITLE
Gitlogcheck client-side hook and refactoring

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,13 @@ ensure the request is processed in a timely manner.
 Before submitting a pull request please run "mx gate" to validate that
 your changes do not break tests and conform with the coding conventions.
 
-Please comply with the following guidelines for Commit messages and PR
-requests:
+Please comply with the guidelines for commit messages and PR
+requests listed below. The compliance with these guidelines is partially
+checked by the `su-gitlogcheck` command. You can add a client-side git
+hook that checks messages before issuing a commit by copying
+[mx.sulong/commit-msg](mx.sulong/commit-msg) to `.git/hooks`. This way,
+you do not have to rewrite the history of your commits after a gate check
+fails.
 
 Commit messages
 ================

--- a/mx.sulong/commit-msg
+++ b/mx.sulong/commit-msg
@@ -1,0 +1,21 @@
+#!/usr/bin/python2.7
+
+# move this file to sulong/.git/hooks for automatic git message checks on git commit
+
+import sys
+import os
+
+sys.path.append(os.path.dirname(__file__) + '/../../mx.sulong/')
+from mx_gitlogcheck import checkCommitMessage
+
+commitMessageFile = sys.argv[1]
+
+with open(commitMessageFile) as f:
+    content = f.readlines()
+
+(error, message) = checkCommitMessage('"' + '\n'.join(content) + '"')
+
+if error:
+    print message
+    exit(-1)
+    

--- a/mx.sulong/mx_gitlogcheck.py
+++ b/mx.sulong/mx_gitlogcheck.py
@@ -3,9 +3,29 @@ import subprocess
 
 gitLogOneLine = re.compile(r'^(?P<message>.*)$')
 titleWithEndingPunct = re.compile(r'^(.*)[\.!?]$')
-pastTenseWords = ['installed', 'implemented', 'fixed', 'merged', 'improved', 'simplified', 'enhanced', 'changed', 'removed', 'replaced', 'substituted', 'corrected', 'used', 'moved', 'refactored']
+pastTenseWords = [
+    'closed',
+    'corrected',
+    'changed',
+    'enhanced',
+    'fixed',
+    'installed',
+    'implemented',
+    'improved',
+    'moved',
+    'merged',
+    'refactored',
+    'renamed',
+    'resolved',
+    'removed',
+    'replaced',
+    'simplified',
+    'substituted',
+    'used',
+]
 
 def checkCommitMessage(quotedCommitMessage):
+    """checks the syntax of a single commit message"""
     error = False
     message = ''
     commitMessage = quotedCommitMessage[1:-1]
@@ -21,6 +41,7 @@ def checkCommitMessage(quotedCommitMessage):
     return (error, message)
 
 def logCheck(args=None):
+    """checks the syntax of git log messages"""
     output = subprocess.check_output(['git', 'log', '--pretty=format:"%s"', 'master@{u}..'])
     foundErrors = []
     for s in output.splitlines():

--- a/mx.sulong/mx_gitlogcheck.py
+++ b/mx.sulong/mx_gitlogcheck.py
@@ -1,0 +1,36 @@
+import re
+import subprocess
+
+gitLogOneLine = re.compile(r'^(?P<message>.*)$')
+titleWithEndingPunct = re.compile(r'^(.*)[\.!?]$')
+pastTenseWords = ['installed', 'implemented', 'fixed', 'merged', 'improved', 'simplified', 'enhanced', 'changed', 'removed', 'replaced', 'substituted', 'corrected', 'used', 'moved', 'refactored']
+
+def checkCommitMessage(quotedCommitMessage):
+    error = False
+    message = ''
+    commitMessage = quotedCommitMessage[1:-1]
+    if commitMessage[0].islower():
+        error = True
+        message = quotedCommitMessage + ' starts with a lower case character'
+    if titleWithEndingPunct.match(commitMessage):
+        error = True
+        message = quotedCommitMessage + ' ends with period, question mark, or exclamation mark'
+    if commitMessage.lower().split()[0] in pastTenseWords:
+        error = True
+        print quotedCommitMessage, 'starts with past tense word "' + commitMessage.lower().split()[0] + '"'
+    return (error, message)
+
+def logCheck(args=None):
+    output = subprocess.check_output(['git', 'log', '--pretty=format:"%s"', 'master@{u}..'])
+    foundErrors = []
+    for s in output.splitlines():
+        match = gitLogOneLine.match(s)
+        commitMessage = match.group('message')
+        (isError, curMessage) = checkCommitMessage(commitMessage)
+        if isError:
+            foundErrors.append(curMessage)
+    if foundErrors:
+        for curMessage in foundErrors:
+            print curMessage
+        print "\nFound illegal git log messages! Please check CONTRIBUTING.md for commit message guidelines."
+        exit(-1)


### PR DESCRIPTION
This change adds a `su-gitlogcheck` script plus description on how to add the script as a git commit hook, so that `su-gitlogcheck` is executed before every commit. The change also moved `su-gitlogcheck` into a separate file.