### PR TITLE
Fix global frame descriptor

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -354,6 +354,8 @@ public class LLVMVisitor implements LLVMParserRuntime {
     }
 
     private List<LLVMNode> addGlobalVars(LLVMVisitor visitor, List<GlobalVariable> globalVariables) {
+        frameDescriptor = globalFrameDescriptor = new FrameDescriptor();
+        stackPointerSlot = frameDescriptor.addFrameSlot(STACK_ADDRESS_FRAME_SLOT_ID, FrameSlotKind.Object);
         List<LLVMNode> globalVarNodes = new ArrayList<>();
         for (GlobalVariable globalVar : globalVariables) {
             LLVMNode globalVarWrite = visitor.visitGlobalVariable(globalVar);
@@ -385,7 +387,6 @@ public class LLVMVisitor implements LLVMParserRuntime {
                 throw new AssertionError("destructors not yet supported!");
             }
         }
-        globalFrameDescriptor = frameDescriptor;
         return globalVarNodes;
     }
 


### PR DESCRIPTION
Previously, the global frame descriptor always equalled the frame descriptor of the last function. It did not result in errors since both frame descriptors had all variables registered. This change fixes this by creating a new frame descriptor for the global scope.