### PR TITLE
Fix initialization order fix for .su files

### DIFF
--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -105,11 +105,11 @@ public class LLVM {
                             } catch (IOException e) {
                                 throw new UncheckedIOException(e);
                             }
-                            parserResult.getStaticInits().call();
                             context.getFunctionRegistry().register(parserResult.getParsedFunctions());
                             mainFunctions.add(parserResult.getMainFunction());
                             context.registerStaticInitializer(parserResult.getStaticInits());
                             context.registerStaticDestructor(parserResult.getStaticDestructors());
+                            parserResult.getStaticInits().call();
                         });
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);


### PR DESCRIPTION
This change calls the static initializers only after registering the functions of a `.su` file. Otherwise, function calls in the static initializers (through `__attribute__((constructor))`) cannot resolve the function to be called.

Fixes #188.