### PR TITLE
Require that commit messages start with an upper case character

### DIFF
--- a/mx.sulong/mx_gitlogcheck.py
+++ b/mx.sulong/mx_gitlogcheck.py
@@ -29,9 +29,9 @@ def checkCommitMessage(quotedCommitMessage):
     error = False
     message = ''
     commitMessage = quotedCommitMessage[1:-1]
-    if commitMessage[0].islower():
+    if not commitMessage[0].isupper():
         error = True
-        message = quotedCommitMessage + ' starts with a lower case character'
+        message = quotedCommitMessage + ' does not start with an upper case character'
     if titleWithEndingPunct.match(commitMessage):
         error = True
         message = quotedCommitMessage + ' ends with period, question mark, or exclamation mark'


### PR DESCRIPTION
The CONTRIBUTING.md states that each commit message should start with an upper case character. The current check only requires that the first character is not a lower case character. With this change, each commit message has to start with an upper case character as specified by the CONTRIBUTING.md.