### PR TITLE
Enable compiler warnings in the travis gate

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMCastsFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMCastsFactory.java
@@ -283,7 +283,7 @@ public final class LLVMCastsFactory {
         }
     }
 
-    private LLVMExpressionNode castFromI8Vector(LLVMAddressNode target, LLVMI8VectorNode fromNode) {
+    private LLVMExpressionNode castFromI8Vector(@SuppressWarnings("unused") LLVMAddressNode target, LLVMI8VectorNode fromNode) {
         if (targetType == LLVMBaseType.I8_VECTOR) {
             return fromNode;
         }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -236,7 +236,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
 
     @Override
     public LLVMExpressionNode createSelect(LLVMBaseType llvmType, LLVMExpressionNode condition, LLVMExpressionNode trueValue, LLVMExpressionNode falseValue) {
-        return LLVMSelectFactory.createSelect(llvmType, (LLVMI1Node) condition, trueValue, falseValue, runtime);
+        return LLVMSelectFactory.createSelect(llvmType, condition, trueValue, falseValue, runtime);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMIVarBit.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMIVarBit.java
@@ -37,7 +37,6 @@ import java.util.BitSet;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.llvm.runtime.LLVMLogger;
-import com.oracle.truffle.llvm.types.floating.BinaryHelper;
 
 // see https://bugs.chromium.org/p/nativeclient/issues/detail?id=3360 for use cases where variable ints arise
 public abstract class LLVMIVarBit {


### PR DESCRIPTION
With this change, one of the two Travis jobs compiles the Java projects both with Ecj and Javac to find compiler warnings before using buildvms. It also fixes three compiler warnings that were recently introduced.