### PR TITLE
Revert branch probs remove

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/control/LLVMConditionalBranchNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/control/LLVMConditionalBranchNode.java
@@ -33,6 +33,7 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.api.profiles.ConditionProfile;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMTerminatorNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI1Node;
@@ -74,6 +75,32 @@ public abstract class LLVMConditionalBranchNode extends LLVMTerminatorNode {
                 return FALSE_SUCCESSOR;
             }
         }
+    }
+
+    public abstract static class LLVMBrConditionalInjectionNode extends LLVMConditionalBranchNode {
+
+        public LLVMBrConditionalInjectionNode(int trueSuccessor, int falseSuccessor, LLVMNode[] truePhiWriteNodes, LLVMNode[] falsePhiWriteNodes) {
+            super(trueSuccessor, falseSuccessor, truePhiWriteNodes, falsePhiWriteNodes);
+        }
+
+        private final ConditionProfile profile = ConditionProfile.createCountingProfile();
+
+        @ExplodeLoop
+        @Specialization
+        public int executeGetSuccessorIndex(VirtualFrame frame, boolean condition) {
+            if (profile.profile(condition)) {
+                for (int i = 0; i < truePhiWriteNodes.length; i++) {
+                    truePhiWriteNodes[i].executeVoid(frame);
+                }
+                return TRUE_SUCCESSOR;
+            } else {
+                for (int i = 0; i < falsePhiWriteNodes.length; i++) {
+                    falsePhiWriteNodes[i].executeVoid(frame);
+                }
+                return FALSE_SUCCESSOR;
+            }
+        }
+
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/control/LLVMSwitchNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/control/LLVMSwitchNode.java
@@ -30,8 +30,10 @@
 package com.oracle.truffle.llvm.nodes.impl.control;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.api.profiles.ConditionProfile;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMTerminatorNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
@@ -65,12 +67,21 @@ public abstract class LLVMSwitchNode extends LLVMTerminatorNode {
         }
     }
 
-    public static class LLVMI8SwitchNode extends LLVMSwitchNode {
+    protected ConditionProfile[] createProfiles(int length) {
+        CompilerAsserts.neverPartOfCompilation();
+        ConditionProfile[] profiles = new ConditionProfile[length];
+        for (int i = 0; i < profiles.length; i++) {
+            profiles[i] = ConditionProfile.createCountingProfile();
+        }
+        return profiles;
+    }
+
+    public abstract static class LLVMI8SwitchBaseNode extends LLVMSwitchNode {
 
         @Child private LLVMI8Node cond;
         @Children private final LLVMI8Node[] cases;
 
-        public LLVMI8SwitchNode(LLVMI8Node cond, LLVMI8Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+        public LLVMI8SwitchBaseNode(LLVMI8Node cond, LLVMI8Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
             super(defaultLabel, successors, phiWriteNodes);
             this.cond = cond;
             this.cases = cases;
@@ -82,7 +93,7 @@ public abstract class LLVMSwitchNode extends LLVMTerminatorNode {
             int val = cond.executeI8(frame);
             for (int i = 0; i < cases.length; i++) {
                 int caseValue = cases[i].executeI8(frame);
-                if (val == caseValue) {
+                if (profile(i, val == caseValue)) {
                     executePhiWrites(frame);
                     return i + CASE_LABEL_START_INDEX;
                 }
@@ -91,14 +102,45 @@ public abstract class LLVMSwitchNode extends LLVMTerminatorNode {
             return DEFAULT_LABEL_INDEX;
         }
 
+        abstract boolean profile(int i, boolean value);
+
     }
 
-    public static class LLVMI32SwitchNode extends LLVMSwitchNode {
+    public static class LLVMI8SwitchNode extends LLVMI8SwitchBaseNode {
+
+        public LLVMI8SwitchNode(LLVMI8Node cond, LLVMI8Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+            super(cond, cases, successors, defaultLabel, phiWriteNodes);
+        }
+
+        @Override
+        boolean profile(int i, boolean value) {
+            return value;
+        }
+
+    }
+
+    public static class LLVMI8ProfilingSwitchNode extends LLVMI8SwitchBaseNode {
+
+        @CompilationFinal private final ConditionProfile[] profiles;
+
+        public LLVMI8ProfilingSwitchNode(LLVMI8Node cond, LLVMI8Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+            super(cond, cases, successors, defaultLabel, phiWriteNodes);
+            profiles = createProfiles(cases.length);
+        }
+
+        @Override
+        boolean profile(int i, boolean value) {
+            return profiles[i].profile(value);
+        }
+
+    }
+
+    public abstract static class LLVMI32SwitchBaseNode extends LLVMSwitchNode {
 
         @Child private LLVMI32Node cond;
         @Children private final LLVMI32Node[] cases;
 
-        public LLVMI32SwitchNode(LLVMI32Node cond, LLVMI32Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+        public LLVMI32SwitchBaseNode(LLVMI32Node cond, LLVMI32Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
             super(defaultLabel, successors, phiWriteNodes);
             this.cond = cond;
             this.cases = cases;
@@ -110,7 +152,7 @@ public abstract class LLVMSwitchNode extends LLVMTerminatorNode {
             int val = cond.executeI32(frame);
             for (int i = 0; i < cases.length; i++) {
                 int caseValue = cases[i].executeI32(frame);
-                if (val == caseValue) {
+                if (profile(i, val == caseValue)) {
                     executePhiWrites(frame);
                     return i + CASE_LABEL_START_INDEX;
                 }
@@ -119,14 +161,48 @@ public abstract class LLVMSwitchNode extends LLVMTerminatorNode {
             return DEFAULT_LABEL_INDEX;
         }
 
+        abstract boolean profile(int i, boolean value);
+
     }
 
-    public static class LLVMI64SwitchNode extends LLVMSwitchNode {
+    public static class LLVMI32ProfilingSwitchNode extends LLVMI32SwitchBaseNode {
+
+        @CompilationFinal private final ConditionProfile[] profiles;
+
+        public LLVMI32ProfilingSwitchNode(LLVMI32Node cond, LLVMI32Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+            super(cond, cases, successors, defaultLabel, phiWriteNodes);
+            profiles = createProfiles(cases.length);
+        }
+
+        @Override
+        boolean profile(int i, boolean value) {
+            return profiles[i].profile(value);
+        }
+
+    }
+
+    public static class LLVMI32SwitchNode extends LLVMI32SwitchBaseNode {
+
+        @CompilationFinal private ConditionProfile[] profiles;
+
+        public LLVMI32SwitchNode(LLVMI32Node cond, LLVMI32Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+            super(cond, cases, successors, defaultLabel, phiWriteNodes);
+            profiles = createProfiles(cases.length);
+        }
+
+        @Override
+        boolean profile(int i, boolean value) {
+            return value;
+        }
+
+    }
+
+    public abstract static class LLVMI64SwitchBaseNode extends LLVMSwitchNode {
 
         @Child private LLVMI64Node cond;
         @Children private final LLVMI64Node[] cases;
 
-        public LLVMI64SwitchNode(LLVMI64Node cond, LLVMI64Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+        public LLVMI64SwitchBaseNode(LLVMI64Node cond, LLVMI64Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
             super(defaultLabel, successors, phiWriteNodes);
             this.cond = cond;
             this.cases = cases;
@@ -138,13 +214,44 @@ public abstract class LLVMSwitchNode extends LLVMTerminatorNode {
             long val = cond.executeI64(frame);
             for (int i = 0; i < cases.length; i++) {
                 long caseValue = cases[i].executeI64(frame);
-                if (val == caseValue) {
+                if (profile(i, val == caseValue)) {
                     executePhiWrites(frame);
                     return i + CASE_LABEL_START_INDEX;
                 }
             }
             executePhiWrites(frame);
             return DEFAULT_LABEL_INDEX;
+        }
+
+        abstract boolean profile(int i, boolean value);
+
+    }
+
+    public static class LLVMI64ProfilingSwitchNode extends LLVMI64SwitchBaseNode {
+
+        @CompilationFinal private final ConditionProfile[] profiles;
+
+        public LLVMI64ProfilingSwitchNode(LLVMI64Node cond, LLVMI64Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+            super(cond, cases, successors, defaultLabel, phiWriteNodes);
+            profiles = createProfiles(cases.length);
+        }
+
+        @Override
+        boolean profile(int i, boolean value) {
+            return profiles[i].profile(value);
+        }
+
+    }
+
+    public static class LLVMI64SwitchNode extends LLVMI64SwitchBaseNode {
+
+        public LLVMI64SwitchNode(LLVMI64Node cond, LLVMI64Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+            super(cond, cases, successors, defaultLabel, phiWriteNodes);
+        }
+
+        @Override
+        boolean profile(int i, boolean value) {
+            return value;
         }
 
     }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMBlockNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMBlockNode.java
@@ -50,7 +50,7 @@ public abstract class LLVMBlockNode extends LLVMExpressionNode {
         @Children private final LLVMBasicBlockNode[] bodyNodes;
         @CompilationFinal private final LLVMStackFrameNuller[][] indexToSlotNuller;
         private final FrameSlot returnSlot;
-        private final boolean injectBranchProbabilities = LLVMOptions.injectBranchProbabilities();
+        private final boolean injectBranchProbabilities = LLVMOptions.injectBranchProbabilitiesSuccessors();
 
         public LLVMBlockControlFlowNode(LLVMBasicBlockNode[] bodyNodes, LLVMStackFrameNuller[][] indexToSlotNuller, FrameSlot returnSlot) {
             this.bodyNodes = bodyNodes;

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMProfilingSelectNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/others/LLVMProfilingSelectNode.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.others;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.profiles.ConditionProfile;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVM80BitFloatNode;
+import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMDoubleNode;
+import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMFloatNode;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI16Node;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI1Node;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
+import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
+
+public class LLVMProfilingSelectNode {
+
+    @NodeChildren({@NodeChild(type = LLVMI1Node.class), @NodeChild(type = LLVMI1Node.class), @NodeChild(type = LLVMI1Node.class)})
+    public abstract static class LLVMI1ProfilingSelectNode extends LLVMI1Node {
+
+        private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
+
+        @Specialization
+        public boolean execute(boolean cond, boolean trueBranch, boolean elseBranch) {
+            if (conditionProfile.profile(cond)) {
+                return trueBranch;
+            } else {
+                return elseBranch;
+            }
+        }
+
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMI1Node.class), @NodeChild(type = LLVMI8Node.class), @NodeChild(type = LLVMI8Node.class)})
+    public abstract static class LLVMI8ProfilingSelectNode extends LLVMI8Node {
+
+        private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
+
+        @Specialization
+        public byte execute(boolean cond, byte trueBranch, byte elseBranch) {
+            if (conditionProfile.profile(cond)) {
+                return trueBranch;
+            } else {
+                return elseBranch;
+            }
+        }
+
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMI1Node.class), @NodeChild(type = LLVMI16Node.class), @NodeChild(type = LLVMI16Node.class)})
+    public abstract static class LLVMI16ProfilingSelectNode extends LLVMI16Node {
+
+        private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
+
+        @Specialization
+        public short execute(boolean cond, short trueBranch, short elseBranch) {
+            if (conditionProfile.profile(cond)) {
+                return trueBranch;
+            } else {
+                return elseBranch;
+            }
+        }
+
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMI1Node.class), @NodeChild(type = LLVMI32Node.class), @NodeChild(type = LLVMI32Node.class)})
+    public abstract static class LLVMI32ProfilingSelectNode extends LLVMI32Node {
+
+        private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
+
+        @Specialization
+        public int execute(boolean cond, int trueBranch, int elseBranch) {
+            if (conditionProfile.profile(cond)) {
+                return trueBranch;
+            } else {
+                return elseBranch;
+            }
+        }
+
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMI1Node.class), @NodeChild(type = LLVMI64Node.class), @NodeChild(type = LLVMI64Node.class)})
+    public abstract static class LLVMI64ProfilingSelectNode extends LLVMI64Node {
+
+        private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
+
+        @Specialization
+        public long execute(boolean cond, long trueBranch, long elseBranch) {
+            if (conditionProfile.profile(cond)) {
+                return trueBranch;
+            } else {
+                return elseBranch;
+            }
+        }
+
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMI1Node.class), @NodeChild(type = LLVMFloatNode.class), @NodeChild(type = LLVMFloatNode.class)})
+    public abstract static class LLVMFloatProfilingSelectNode extends LLVMFloatNode {
+
+        private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
+
+        @Specialization
+        public float execute(boolean cond, float trueBranch, float elseBranch) {
+            if (conditionProfile.profile(cond)) {
+                return trueBranch;
+            } else {
+                return elseBranch;
+            }
+        }
+
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMI1Node.class), @NodeChild(type = LLVMDoubleNode.class), @NodeChild(type = LLVMDoubleNode.class)})
+    public abstract static class LLVMDoubleProfilingSelectNode extends LLVMDoubleNode {
+
+        private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
+
+        @Specialization
+        public double execute(boolean cond, double trueBranch, double elseBranch) {
+            if (conditionProfile.profile(cond)) {
+                return trueBranch;
+            } else {
+                return elseBranch;
+            }
+        }
+
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMI1Node.class), @NodeChild(type = LLVM80BitFloatNode.class), @NodeChild(type = LLVM80BitFloatNode.class)})
+    public abstract static class LLVM80BitFloatProfilingSelectNode extends LLVM80BitFloatNode {
+
+        private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
+
+        @Specialization
+        public LLVM80BitFloat execute(boolean cond, LLVM80BitFloat trueBranch, LLVM80BitFloat elseBranch) {
+            if (conditionProfile.profile(cond)) {
+                return trueBranch;
+            } else {
+                return elseBranch;
+            }
+        }
+
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMI1Node.class), @NodeChild(type = LLVMAddressNode.class), @NodeChild(type = LLVMAddressNode.class)})
+    public abstract static class LLVMAddressProfilingSelectNode extends LLVMAddressNode {
+
+        private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
+
+        @Specialization
+        public LLVMAddress execute(boolean cond, LLVMAddress trueBranch, LLVMAddress elseBranch) {
+            if (conditionProfile.profile(cond)) {
+                return trueBranch;
+            } else {
+                return elseBranch;
+            }
+        }
+
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMI1Node.class), @NodeChild(type = LLVMFunctionNode.class), @NodeChild(type = LLVMFunctionNode.class)})
+    public abstract static class LLVMFunctionProfilingSelectNode extends LLVMFunctionNode {
+
+        private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
+
+        @Specialization
+        public LLVMFunctionDescriptor execute(boolean cond, LLVMFunctionDescriptor trueBranch, LLVMFunctionDescriptor elseBranch) {
+            if (conditionProfile.profile(cond)) {
+                return trueBranch;
+            } else {
+                return elseBranch;
+            }
+        }
+
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMBranchFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMBranchFactory.java
@@ -36,7 +36,10 @@ import com.oracle.truffle.llvm.nodes.impl.base.LLVMTerminatorNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI1Node;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMBrUnconditionalNode;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMConditionalBranchNodeFactory;
+import com.oracle.truffle.llvm.nodes.impl.control.LLVMConditionalBranchNodeFactory.LLVMBrConditionalInjectionNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMIndirectBranchNode;
+import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
+import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 
 public class LLVMBranchFactory {
 
@@ -44,9 +47,18 @@ public class LLVMBranchFactory {
         return new LLVMIndirectBranchNode((LLVMAddressNode) value, labelTargets, phiWrites);
     }
 
-    public static LLVMTerminatorNode createConditionalBranch(int trueIndex, int falseIndex, LLVMExpressionNode conditionNode, LLVMNode[] truePhiWriteNodes,
+    public static LLVMTerminatorNode createConditionalBranch(LLVMParserRuntime runtime, int trueIndex, int falseIndex, LLVMExpressionNode conditionNode, LLVMNode[] truePhiWriteNodes,
                     LLVMNode[] falsePhiWriteNodes) {
-        return LLVMConditionalBranchNodeFactory.LLVMBrConditionalNodeGen.create(trueIndex, falseIndex, truePhiWriteNodes, falsePhiWriteNodes, (LLVMI1Node) conditionNode);
+        return createConditionalBranch(runtime.getOptimizationConfiguration(), trueIndex, falseIndex, conditionNode, truePhiWriteNodes, falsePhiWriteNodes);
+    }
+
+    public static LLVMTerminatorNode createConditionalBranch(LLVMOptimizationConfiguration configuration, int trueIndex, int falseIndex, LLVMExpressionNode conditionNode, LLVMNode[] truePhiWriteNodes,
+                    LLVMNode[] falsePhiWriteNodes) {
+        if (configuration.injectBranchProbabilitiesForConditionalBranch()) {
+            return LLVMBrConditionalInjectionNodeGen.create(trueIndex, falseIndex, truePhiWriteNodes, falsePhiWriteNodes, (LLVMI1Node) conditionNode);
+        } else {
+            return LLVMConditionalBranchNodeFactory.LLVMBrConditionalNodeGen.create(trueIndex, falseIndex, truePhiWriteNodes, falsePhiWriteNodes, (LLVMI1Node) conditionNode);
+        }
     }
 
     public static LLVMTerminatorNode createUnconditionalBranch(int unconditionalIndex, LLVMNode[] phiWrites) {

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMSelectFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMSelectFactory.java
@@ -42,6 +42,16 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
 import com.oracle.truffle.llvm.nodes.impl.base.vector.LLVMI1VectorNode;
 import com.oracle.truffle.llvm.nodes.impl.base.vector.LLVMI32VectorNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMProfilingSelectNodeFactory.LLVM80BitFloatProfilingSelectNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMProfilingSelectNodeFactory.LLVMAddressProfilingSelectNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMProfilingSelectNodeFactory.LLVMDoubleProfilingSelectNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMProfilingSelectNodeFactory.LLVMFloatProfilingSelectNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMProfilingSelectNodeFactory.LLVMFunctionProfilingSelectNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMProfilingSelectNodeFactory.LLVMI16ProfilingSelectNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMProfilingSelectNodeFactory.LLVMI1ProfilingSelectNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMProfilingSelectNodeFactory.LLVMI32ProfilingSelectNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMProfilingSelectNodeFactory.LLVMI64ProfilingSelectNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMProfilingSelectNodeFactory.LLVMI8ProfilingSelectNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMSelectNodeFactory.LLVM80BitFloatSelectNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMSelectNodeFactory.LLVMAddressSelectNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMSelectNodeFactory.LLVMDoubleSelectNodeGen;
@@ -54,37 +64,67 @@ import com.oracle.truffle.llvm.nodes.impl.others.LLVMSelectNodeFactory.LLVMI64Se
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMSelectNodeFactory.LLVMI8SelectNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMVectorSelectNodeFactory.LLVMI32VectorSelectNodeGen;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
+import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
+import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 
 public class LLVMSelectFactory {
 
-    public static LLVMExpressionNode createSelect(LLVMBaseType llvmType, LLVMExpressionNode condition, LLVMExpressionNode trueValue, LLVMExpressionNode falseValue) {
-        return createSelect(llvmType, (LLVMI1Node) condition, trueValue, falseValue);
+    public static LLVMExpressionNode createSelect(LLVMBaseType llvmType, LLVMExpressionNode condition, LLVMExpressionNode trueValue, LLVMExpressionNode falseValue, LLVMParserRuntime runtime) {
+        return createSelect(llvmType, (LLVMI1Node) condition, trueValue, falseValue, runtime.getOptimizationConfiguration());
     }
 
-    public static LLVMExpressionNode createSelect(LLVMBaseType llvmType, LLVMI1Node condition, LLVMExpressionNode trueValue, LLVMExpressionNode falseValue) {
-        switch (llvmType) {
-            case I1:
-                return LLVMI1SelectNodeGen.create(condition, (LLVMI1Node) trueValue, (LLVMI1Node) falseValue);
-            case I8:
-                return LLVMI8SelectNodeGen.create(condition, (LLVMI8Node) trueValue, (LLVMI8Node) falseValue);
-            case I16:
-                return LLVMI16SelectNodeGen.create(condition, (LLVMI16Node) trueValue, (LLVMI16Node) falseValue);
-            case I32:
-                return LLVMI32SelectNodeGen.create(condition, (LLVMI32Node) trueValue, (LLVMI32Node) falseValue);
-            case I64:
-                return LLVMI64SelectNodeGen.create(condition, (LLVMI64Node) trueValue, (LLVMI64Node) falseValue);
-            case FLOAT:
-                return LLVMFloatSelectNodeGen.create(condition, (LLVMFloatNode) trueValue, (LLVMFloatNode) falseValue);
-            case DOUBLE:
-                return LLVMDoubleSelectNodeGen.create(condition, (LLVMDoubleNode) trueValue, (LLVMDoubleNode) falseValue);
-            case X86_FP80:
-                return LLVM80BitFloatSelectNodeGen.create(condition, (LLVM80BitFloatNode) trueValue, (LLVM80BitFloatNode) falseValue);
-            case ADDRESS:
-                return LLVMAddressSelectNodeGen.create(condition, (LLVMAddressNode) trueValue, (LLVMAddressNode) falseValue);
-            case FUNCTION_ADDRESS:
-                return LLVMFunctionSelectNodeGen.create(condition, (LLVMFunctionNode) trueValue, (LLVMFunctionNode) falseValue);
-            default:
-                throw new AssertionError(llvmType);
+    public static LLVMExpressionNode createSelect(LLVMBaseType llvmType, LLVMI1Node condition, LLVMExpressionNode trueValue, LLVMExpressionNode falseValue,
+                    LLVMOptimizationConfiguration configuration) {
+        if (configuration.injectBranchProbabilitiesForSelect()) {
+            switch (llvmType) {
+                case I1:
+                    return LLVMI1ProfilingSelectNodeGen.create(condition, (LLVMI1Node) trueValue, (LLVMI1Node) falseValue);
+                case I8:
+                    return LLVMI8ProfilingSelectNodeGen.create(condition, (LLVMI8Node) trueValue, (LLVMI8Node) falseValue);
+                case I16:
+                    return LLVMI16ProfilingSelectNodeGen.create(condition, (LLVMI16Node) trueValue, (LLVMI16Node) falseValue);
+                case I32:
+                    return LLVMI32ProfilingSelectNodeGen.create(condition, (LLVMI32Node) trueValue, (LLVMI32Node) falseValue);
+                case I64:
+                    return LLVMI64ProfilingSelectNodeGen.create(condition, (LLVMI64Node) trueValue, (LLVMI64Node) falseValue);
+                case FLOAT:
+                    return LLVMFloatProfilingSelectNodeGen.create(condition, (LLVMFloatNode) trueValue, (LLVMFloatNode) falseValue);
+                case DOUBLE:
+                    return LLVMDoubleProfilingSelectNodeGen.create(condition, (LLVMDoubleNode) trueValue, (LLVMDoubleNode) falseValue);
+                case X86_FP80:
+                    return LLVM80BitFloatProfilingSelectNodeGen.create(condition, (LLVM80BitFloatNode) trueValue, (LLVM80BitFloatNode) falseValue);
+                case ADDRESS:
+                    return LLVMAddressProfilingSelectNodeGen.create(condition, (LLVMAddressNode) trueValue, (LLVMAddressNode) falseValue);
+                case FUNCTION_ADDRESS:
+                    return LLVMFunctionProfilingSelectNodeGen.create(condition, (LLVMFunctionNode) trueValue, (LLVMFunctionNode) falseValue);
+                default:
+                    throw new AssertionError(llvmType);
+            }
+        } else {
+            switch (llvmType) {
+                case I1:
+                    return LLVMI1SelectNodeGen.create(condition, (LLVMI1Node) trueValue, (LLVMI1Node) falseValue);
+                case I8:
+                    return LLVMI8SelectNodeGen.create(condition, (LLVMI8Node) trueValue, (LLVMI8Node) falseValue);
+                case I16:
+                    return LLVMI16SelectNodeGen.create(condition, (LLVMI16Node) trueValue, (LLVMI16Node) falseValue);
+                case I32:
+                    return LLVMI32SelectNodeGen.create(condition, (LLVMI32Node) trueValue, (LLVMI32Node) falseValue);
+                case I64:
+                    return LLVMI64SelectNodeGen.create(condition, (LLVMI64Node) trueValue, (LLVMI64Node) falseValue);
+                case FLOAT:
+                    return LLVMFloatSelectNodeGen.create(condition, (LLVMFloatNode) trueValue, (LLVMFloatNode) falseValue);
+                case DOUBLE:
+                    return LLVMDoubleSelectNodeGen.create(condition, (LLVMDoubleNode) trueValue, (LLVMDoubleNode) falseValue);
+                case X86_FP80:
+                    return LLVM80BitFloatSelectNodeGen.create(condition, (LLVM80BitFloatNode) trueValue, (LLVM80BitFloatNode) falseValue);
+                case ADDRESS:
+                    return LLVMAddressSelectNodeGen.create(condition, (LLVMAddressNode) trueValue, (LLVMAddressNode) falseValue);
+                case FUNCTION_ADDRESS:
+                    return LLVMFunctionSelectNodeGen.create(condition, (LLVMFunctionNode) trueValue, (LLVMFunctionNode) falseValue);
+                default:
+                    throw new AssertionError(llvmType);
+            }
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMSwitchFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMSwitchFactory.java
@@ -37,10 +37,14 @@ import com.oracle.truffle.llvm.nodes.impl.base.LLVMTerminatorNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
+import com.oracle.truffle.llvm.nodes.impl.control.LLVMSwitchNode.LLVMI32ProfilingSwitchNode;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMSwitchNode.LLVMI32SwitchNode;
+import com.oracle.truffle.llvm.nodes.impl.control.LLVMSwitchNode.LLVMI64ProfilingSwitchNode;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMSwitchNode.LLVMI64SwitchNode;
+import com.oracle.truffle.llvm.nodes.impl.control.LLVMSwitchNode.LLVMI8ProfilingSwitchNode;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMSwitchNode.LLVMI8SwitchNode;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
+import com.oracle.truffle.llvm.runtime.LLVMOptions;
 
 public class LLVMSwitchFactory {
 
@@ -49,13 +53,25 @@ public class LLVMSwitchFactory {
         switch (llvmType) {
             case I8:
                 LLVMI8Node[] i8Cases = Arrays.copyOf(cases, cases.length, LLVMI8Node[].class);
-                return new LLVMI8SwitchNode((LLVMI8Node) cond, i8Cases, otherLabels, defaultLabel, phiWriteNodes);
+                if (LLVMOptions.injectBranchProbabilitiesForSwitch()) {
+                    return new LLVMI8ProfilingSwitchNode((LLVMI8Node) cond, i8Cases, otherLabels, defaultLabel, phiWriteNodes);
+                } else {
+                    return new LLVMI8SwitchNode((LLVMI8Node) cond, i8Cases, otherLabels, defaultLabel, phiWriteNodes);
+                }
             case I32:
                 LLVMI32Node[] i32Cases = Arrays.copyOf(cases, cases.length, LLVMI32Node[].class);
-                return new LLVMI32SwitchNode((LLVMI32Node) cond, i32Cases, otherLabels, defaultLabel, phiWriteNodes);
+                if (LLVMOptions.injectBranchProbabilitiesForSwitch()) {
+                    return new LLVMI32ProfilingSwitchNode((LLVMI32Node) cond, i32Cases, otherLabels, defaultLabel, phiWriteNodes);
+                } else {
+                    return new LLVMI32SwitchNode((LLVMI32Node) cond, i32Cases, otherLabels, defaultLabel, phiWriteNodes);
+                }
             case I64:
                 LLVMI64Node[] i64Cases = Arrays.copyOf(cases, cases.length, LLVMI64Node[].class);
-                return new LLVMI64SwitchNode((LLVMI64Node) cond, i64Cases, otherLabels, defaultLabel, phiWriteNodes);
+                if (LLVMOptions.injectBranchProbabilitiesForSwitch()) {
+                    return new LLVMI64ProfilingSwitchNode((LLVMI64Node) cond, i64Cases, otherLabels, defaultLabel, phiWriteNodes);
+                } else {
+                    return new LLVMI64SwitchNode((LLVMI64Node) cond, i64Cases, otherLabels, defaultLabel, phiWriteNodes);
+                }
             default:
                 throw new AssertionError(llvmType);
         }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -236,7 +236,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
 
     @Override
     public LLVMExpressionNode createSelect(LLVMBaseType llvmType, LLVMExpressionNode condition, LLVMExpressionNode trueValue, LLVMExpressionNode falseValue) {
-        return LLVMSelectFactory.createSelect(llvmType, condition, trueValue, falseValue);
+        return LLVMSelectFactory.createSelect(llvmType, condition, trueValue, falseValue, runtime);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -267,7 +267,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
 
     @Override
     public LLVMTerminatorNode createConditionalBranch(int trueIndex, int falseIndex, LLVMExpressionNode conditionNode, LLVMNode[] truePhiWriteNodes, LLVMNode[] falsePhiWriteNodes) {
-        return LLVMBranchFactory.createConditionalBranch(trueIndex, falseIndex, conditionNode, truePhiWriteNodes, falsePhiWriteNodes);
+        return LLVMBranchFactory.createConditionalBranch(runtime, trueIndex, falseIndex, conditionNode, truePhiWriteNodes, falsePhiWriteNodes);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptimizationConfiguration.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptimizationConfiguration.java
@@ -50,4 +50,9 @@ public interface LLVMOptimizationConfiguration {
      */
     boolean intrinsifyCLibraryFunctions();
 
+    /**
+     * Record branch probabilities for the LLVM <code>br</code> instruction.
+     */
+    boolean injectBranchProbabilitiesForConditionalBranch();
+
 }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptimizationConfiguration.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptimizationConfiguration.java
@@ -45,6 +45,11 @@ public interface LLVMOptimizationConfiguration {
     boolean valueProfileMemoryReads();
 
     /**
+     * Record branch probabilities for the LLVM <code>select</code> instruction.
+     */
+    boolean injectBranchProbabilitiesForSelect();
+
+    /**
      * Substitute common C library functions by Java implementations. Note that some functions such
      * as exit or abort are substituted in each case, to allow the VM to terminate gracefully.
      */

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -142,7 +142,12 @@ public class LLVMOptions {
         OPTIMIZATION_SPECIALIZE_EXPECT_INTRINSIC("SpecializeExpectIntrinsic", "Specialize the llvm.expect intrinsic", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_VALUE_PROFILE_MEMORY_READS("ValueProfileMemoryReads", "Enable value profiling for memory reads", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_VALUE_PROFILE_FUNCTION_ARGS("ValueProfileFunctionArgs", "Enable value profiling for function arguments", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
-        OPTIMIZATION_BRANCH_PROBABILITIES("InjectBranchProbabilities", "Injects branch probabilities for the basic block successors", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
+        OPTIMIZATION_INJECT_PROBS_SUCCESSORS(
+                        "InjectProbabilitySuccessors",
+                        "Injects branch probabilities for the basic block successors",
+                        "true",
+                        LLVMOptions::parseBoolean,
+                        PropertyCategory.PERFORMANCE),
         OPTIMIZATION_INJECT_PROBS_SELECT("InjectProbabilitySelect", "Inject branch probabilities for select", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_INJECT_PROBS_SWITCH("InjectProbabilitySwitch", "Inject branch probabilities for switch", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_INTRINSIFY_C_FUNCTIONS("IntrinsifyCFunctions", "Substitute C functions by Java equivalents where possible", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
@@ -318,8 +323,8 @@ public class LLVMOptions {
         return !disableSpeculativeOptimizations() && (boolean) getParsedProperty(Property.OPTIMIZATION_INJECT_PROBS_COND_BRANCH);
     }
 
-    public static boolean injectBranchProbabilities() {
-        return !disableSpeculativeOptimizations() && (boolean) getParsedProperty(Property.OPTIMIZATION_BRANCH_PROBABILITIES);
+    public static boolean injectBranchProbabilitiesSuccessors() {
+        return !disableSpeculativeOptimizations() && (boolean) getParsedProperty(Property.OPTIMIZATION_INJECT_PROBS_SUCCESSORS);
     }
 
     public static boolean printNativeCallStats() {

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -143,6 +143,7 @@ public class LLVMOptions {
         OPTIMIZATION_VALUE_PROFILE_MEMORY_READS("ValueProfileMemoryReads", "Enable value profiling for memory reads", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_VALUE_PROFILE_FUNCTION_ARGS("ValueProfileFunctionArgs", "Enable value profiling for function arguments", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_BRANCH_PROBABILITIES("InjectBranchProbabilities", "Injects branch probabilities for the basic block successors", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
+        OPTIMIZATION_INJECT_PROBS_SELECT("InjectProbabilitySelect", "Inject branch probabilities for select", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_INJECT_PROBS_SWITCH("InjectProbabilitySwitch", "Inject branch probabilities for switch", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_INTRINSIFY_C_FUNCTIONS("IntrinsifyCFunctions", "Substitute C functions by Java equivalents where possible", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_INJECT_PROBS_COND_BRANCH("InjectProbabilityBr", "Inject branch probabilities for conditional branches", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
@@ -299,6 +300,10 @@ public class LLVMOptions {
 
     public static boolean valueProfileMemoryReads() {
         return !disableSpeculativeOptimizations() && (boolean) getParsedProperty(Property.OPTIMIZATION_VALUE_PROFILE_MEMORY_READS);
+    }
+
+    public static boolean injectBranchProbabilitiesForSelect() {
+        return !disableSpeculativeOptimizations() && (boolean) getParsedProperty(Property.OPTIMIZATION_INJECT_PROBS_SELECT);
     }
 
     public static boolean injectBranchProbabilitiesForSwitch() {

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -145,6 +145,7 @@ public class LLVMOptions {
         OPTIMIZATION_BRANCH_PROBABILITIES("InjectBranchProbabilities", "Injects branch probabilities for the basic block successors", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_INJECT_PROBS_SWITCH("InjectProbabilitySwitch", "Inject branch probabilities for switch", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_INTRINSIFY_C_FUNCTIONS("IntrinsifyCFunctions", "Substitute C functions by Java equivalents where possible", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
+        OPTIMIZATION_INJECT_PROBS_COND_BRANCH("InjectProbabilityBr", "Inject branch probabilities for conditional branches", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_INLINE_CACHE_SIZE("InlineCacheSize", "Specifies the size of the polymorphic inline cache", "5", LLVMOptions::parseInteger, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_LIFE_TIME_ANALYSIS(
                         "EnableLifetimeAnalysis",
@@ -306,6 +307,10 @@ public class LLVMOptions {
 
     public static boolean intrinsifyCLibraryFunctions() {
         return getParsedProperty(Property.OPTIMIZATION_INTRINSIFY_C_FUNCTIONS);
+    }
+
+    public static boolean injectBranchProbabilitiesForConditionalBranch() {
+        return !disableSpeculativeOptimizations() && (boolean) getParsedProperty(Property.OPTIMIZATION_INJECT_PROBS_COND_BRANCH);
     }
 
     public static boolean injectBranchProbabilities() {

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java
@@ -143,6 +143,7 @@ public class LLVMOptions {
         OPTIMIZATION_VALUE_PROFILE_MEMORY_READS("ValueProfileMemoryReads", "Enable value profiling for memory reads", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_VALUE_PROFILE_FUNCTION_ARGS("ValueProfileFunctionArgs", "Enable value profiling for function arguments", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_BRANCH_PROBABILITIES("InjectBranchProbabilities", "Injects branch probabilities for the basic block successors", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
+        OPTIMIZATION_INJECT_PROBS_SWITCH("InjectProbabilitySwitch", "Inject branch probabilities for switch", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_INTRINSIFY_C_FUNCTIONS("IntrinsifyCFunctions", "Substitute C functions by Java equivalents where possible", "true", LLVMOptions::parseBoolean, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_INLINE_CACHE_SIZE("InlineCacheSize", "Specifies the size of the polymorphic inline cache", "5", LLVMOptions::parseInteger, PropertyCategory.PERFORMANCE),
         OPTIMIZATION_LIFE_TIME_ANALYSIS(
@@ -297,6 +298,10 @@ public class LLVMOptions {
 
     public static boolean valueProfileMemoryReads() {
         return !disableSpeculativeOptimizations() && (boolean) getParsedProperty(Property.OPTIMIZATION_VALUE_PROFILE_MEMORY_READS);
+    }
+
+    public static boolean injectBranchProbabilitiesForSwitch() {
+        return !disableSpeculativeOptimizations() && (boolean) getParsedProperty(Property.OPTIMIZATION_INJECT_PROBS_SWITCH);
     }
 
     public static boolean intrinsifyCLibraryFunctions() {

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMPropertyOptimizationConfiguration.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMPropertyOptimizationConfiguration.java
@@ -45,6 +45,11 @@ public class LLVMPropertyOptimizationConfiguration implements LLVMOptimizationCo
     }
 
     @Override
+    public boolean injectBranchProbabilitiesForSelect() {
+        return LLVMOptions.injectBranchProbabilitiesForSelect();
+    }
+
+    @Override
     public boolean intrinsifyCLibraryFunctions() {
         return LLVMOptions.intrinsifyCLibraryFunctions();
     }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMPropertyOptimizationConfiguration.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMPropertyOptimizationConfiguration.java
@@ -49,4 +49,9 @@ public class LLVMPropertyOptimizationConfiguration implements LLVMOptimizationCo
         return LLVMOptions.intrinsifyCLibraryFunctions();
     }
 
+    @Override
+    public boolean injectBranchProbabilitiesForConditionalBranch() {
+        return LLVMOptions.injectBranchProbabilitiesForConditionalBranch();
+    }
+
 }


### PR DESCRIPTION
I previously assumed that branch probability profiling for successors in #211 made the profiling in switches, selects, and indirect branches redundant. However, removing them made most benchmarks slower. For example, removing the indirect branch profiling for indirect branches alone makes the whetstone benchmark 10% slower. Hence, this change reverts the removal of the branch profiling in the switch, br, and select nodes.