### PR TITLE
Add truffle_import_cached in truffle.h

### DIFF
--- a/include/truffle.h
+++ b/include/truffle.h
@@ -45,6 +45,10 @@ extern "C" {
 */
 
 void *truffle_import(const char *name);
+/* This import function caches the result (i.e. the imported object) for a given name,
+i.e., a subsequent import with the same name does not do a lookup but returns the cached value.
+*/
+void *truffle_import_cached(const char *name);
 // void truffle_export(const char *name, void *value);
 
 // Binary:

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMTruffleImportCached.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMTruffleImportCached.java
@@ -32,6 +32,7 @@ package com.oracle.truffle.llvm.nodes.impl.intrinsics.interop;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.dsl.internal.SuppressFBWarnings;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
@@ -57,13 +58,18 @@ public abstract class LLVMTruffleImportCached extends LLVMAddressIntrinsic {
         public abstract LLVMTruffleObject execute(String name);
 
         @SuppressWarnings("unused")
-        @Specialization(limit = "10", guards = {"cachedName.equals(name)"})
+        @Specialization(limit = "10", guards = {"stringEquals(name, cachedName)"})
         public LLVMTruffleObject importValue(String name, @Cached("name") String cachedName, @Cached("resolve(cachedName)") TruffleObject value) {
             return new LLVMTruffleObject(value);
         }
 
         protected static TruffleObject resolve(String name) {
             return (TruffleObject) LLVMLanguage.INSTANCE.getEnvironment().importSymbol(name);
+        }
+
+        @SuppressFBWarnings("ES_COMPARING_STRINGS_WITH_EQ")
+        protected static boolean stringEquals(String s1, String s2) {
+            return s1.equals(s2);
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMTruffleImportCached.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMTruffleImportCached.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.intrinsics.interop;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleImportCachedFactory.ImportCacheNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsic.LLVMAddressIntrinsic;
+import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.LLVMTruffleObject;
+
+@NodeChild(type = LLVMAddressNode.class)
+public abstract class LLVMTruffleImportCached extends LLVMAddressIntrinsic {
+
+    @Child private ImportCache cache = ImportCacheNodeGen.create();
+
+    @Specialization
+    public Object executeIntrinsic(LLVMAddress value) {
+        String id = LLVMTruffleIntrinsicUtil.readString(value);
+        return cache.execute(id);
+    }
+
+    abstract static class ImportCache extends Node {
+
+        public abstract LLVMTruffleObject execute(String name);
+
+        @SuppressWarnings("unused")
+        @Specialization(limit = "10", guards = {"cachedName.equals(name)"})
+        public LLVMTruffleObject importValue(String name, @Cached("name") String cachedName, @Cached("resolve(cachedName)") TruffleObject value) {
+            return new LLVMTruffleObject(value);
+        }
+
+        protected static TruffleObject resolve(String name) {
+            return (TruffleObject) LLVMLanguage.INSTANCE.getEnvironment().importSymbol(name);
+        }
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
@@ -51,6 +51,7 @@ import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleExecuteF
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleExecuteFactory.LLVMTruffleExecuteLFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleExecuteFactory.LLVMTruffleExecutePFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleGetSizeFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleImportCachedFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleImportFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleInvokeFactory.LLVMTruffleInvokeBFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleInvokeFactory.LLVMTruffleInvokeCFactory;
@@ -113,6 +114,7 @@ public class LLVMRuntimeIntrinsicFactory {
 
         // Interop intrinsics
         intrinsics.put("@truffle_import", LLVMTruffleImportFactory.getInstance());
+        intrinsics.put("@truffle_import_cached", LLVMTruffleImportCachedFactory.getInstance());
 
         intrinsics.put("@truffle_read", LLVMTruffleReadPFactory.getInstance());
         intrinsics.put("@truffle_read_i", LLVMTruffleReadIFactory.getInstance());

--- a/projects/com.oracle.truffle.llvm.test/interoptests/interop023.c
+++ b/projects/com.oracle.truffle.llvm.test/interoptests/interop023.c
@@ -1,11 +1,11 @@
-#include<truffle.h>
+#include <truffle.h>
 
 int main() {
-	foo("foreign");
-	return foo("foreign");
+  foo("foreign");
+  return foo("foreign");
 }
 
 int foo(const char *name) {
-	void *obj = truffle_import_cached(name);
-	return truffle_read_i(obj, "valueI");
+  void *obj = truffle_import_cached(name);
+  return truffle_read_i(obj, "valueI");
 }

--- a/projects/com.oracle.truffle.llvm.test/interoptests/interop023.c
+++ b/projects/com.oracle.truffle.llvm.test/interoptests/interop023.c
@@ -1,0 +1,11 @@
+#include<truffle.h>
+
+int main() {
+	foo("foreign");
+	return foo("foreign");
+}
+
+int foo(const char *name) {
+	void *obj = truffle_import_cached(name);
+	return truffle_read_i(obj, "valueI");
+}

--- a/projects/com.oracle.truffle.llvm.test/interoptests/interop024.c
+++ b/projects/com.oracle.truffle.llvm.test/interoptests/interop024.c
@@ -1,0 +1,11 @@
+#include<truffle.h>
+
+int main() {
+	foo("foreign");
+	return foo("foreign2");
+}
+
+int foo(const char *name) {
+	void *obj = truffle_import_cached(name);
+	return truffle_read_i(obj, "valueI");
+}

--- a/projects/com.oracle.truffle.llvm.test/interoptests/interop024.c
+++ b/projects/com.oracle.truffle.llvm.test/interoptests/interop024.c
@@ -1,11 +1,11 @@
-#include<truffle.h>
+#include <truffle.h>
 
 int main() {
-	foo("foreign");
-	return foo("foreign2");
+  foo("foreign");
+  return foo("foreign2");
 }
 
 int foo(const char *name) {
-	void *obj = truffle_import_cached(name);
-	return truffle_read_i(obj, "valueI");
+  void *obj = truffle_import_cached(name);
+  return truffle_read_i(obj, "valueI");
 }

--- a/projects/com.oracle.truffle.llvm.test/interoptests/interop025.c
+++ b/projects/com.oracle.truffle.llvm.test/interoptests/interop025.c
@@ -1,0 +1,12 @@
+#include<truffle.h>
+
+int main() {
+	foo("foreign");
+	foo("foreign2");
+	return foo("foreign3");
+}
+
+int foo(const char *name) {
+	void *obj = truffle_import_cached(name);
+	return truffle_read_i(obj, "valueI");
+}

--- a/projects/com.oracle.truffle.llvm.test/interoptests/interop025.c
+++ b/projects/com.oracle.truffle.llvm.test/interoptests/interop025.c
@@ -1,12 +1,12 @@
-#include<truffle.h>
+#include <truffle.h>
 
 int main() {
-	foo("foreign");
-	foo("foreign2");
-	return foo("foreign3");
+  foo("foreign");
+  foo("foreign2");
+  return foo("foreign3");
 }
 
 int foo(const char *name) {
-	void *obj = truffle_import_cached(name);
-	return truffle_read_i(obj, "valueI");
+  void *obj = truffle_import_cached(name);
+  return truffle_read_i(obj, "valueI");
 }

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/interop/LLVMInteropTest.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/interop/LLVMInteropTest.java
@@ -54,40 +54,44 @@ public final class LLVMInteropTest {
 
     @Test
     public void test001() {
-        String file = "interop001";
-        Assert.assertEquals(42, run(file, null, null));
+        Runner runner = new Runner("interop001");
+        Assert.assertEquals(42, runner.run());
     }
 
     @Test
     public void test002() {
-        String file = "interop002";
+        Runner runner = new Runner("interop002");
         ClassA a = new ClassA();
         TruffleObject to = JavaInterop.asTruffleObject(a);
-        Assert.assertEquals(42, run(file, to, "foreign"));
+        runner.export(to, "foreign");
+        Assert.assertEquals(42, runner.run());
     }
 
     @Test
     public void test003() {
-        String file = "interop003";
+        Runner runner = new Runner("interop003");
         ClassA a = new ClassA();
         TruffleObject to = JavaInterop.asTruffleObject(a);
-        Assert.assertEquals(215, run(file, to, "foreign"));
+        runner.export(to, "foreign");
+        Assert.assertEquals(215, runner.run());
     }
 
     @Test
     public void test004() {
-        String file = "interop004";
+        Runner runner = new Runner("interop004");
         ClassB a = new ClassB();
         TruffleObject to = JavaInterop.asTruffleObject(a);
-        Assert.assertEquals(73, run(file, to, "foreign"));
+        runner.export(to, "foreign");
+        Assert.assertEquals(73, runner.run());
     }
 
     @Test
     public void test005() {
-        String file = "interop005";
+        Runner runner = new Runner("interop005");
         ClassA a = new ClassA();
         TruffleObject to = JavaInterop.asTruffleObject(a);
-        run(file, to, "foreign");
+        runner.export(to, "foreign");
+        runner.run();
 
         Assert.assertEquals(a.valueBool, false);
         Assert.assertEquals(a.valueI, 2);
@@ -99,10 +103,11 @@ public final class LLVMInteropTest {
 
     @Test
     public void test006() {
-        String file = "interop006";
+        Runner runner = new Runner("interop006");
         ClassB a = new ClassB();
         TruffleObject to = JavaInterop.asTruffleObject(a);
-        run(file, to, "foreign");
+        runner.export(to, "foreign");
+        runner.run();
 
         Assert.assertEquals(a.valueI[0], 1);
         Assert.assertEquals(a.valueI[1], 2);
@@ -122,10 +127,11 @@ public final class LLVMInteropTest {
 
     @Test
     public void test007() {
-        String file = "interop007";
+        Runner runner = new Runner("interop007");
         ClassC a = new ClassC();
         TruffleObject to = JavaInterop.asTruffleObject(a);
-        Assert.assertEquals(36, run(file, to, "foreign"));
+        runner.export(to, "foreign");
+        Assert.assertEquals(36, runner.run());
 
         Assert.assertEquals(a.valueI, 4);
         Assert.assertEquals(a.valueB, 3);
@@ -136,111 +142,168 @@ public final class LLVMInteropTest {
 
     @Test
     public void test008() {
-        String file = "interop008";
+        Runner runner = new Runner("interop008");
         TruffleObject to = JavaInterop.asTruffleFunction(FuncBInterface.class, (a, b) -> (byte) (a + b));
-        Assert.assertEquals(42, run(file, to, "foreign"));
+        runner.export(to, "foreign");
+        Assert.assertEquals(42, runner.run());
     }
 
     @Test
     public void test009() {
-        String file = "interop009";
+        Runner runner = new Runner("interop009");
         TruffleObject to = JavaInterop.asTruffleFunction(FuncIInterface.class, (a, b) -> (a + b));
-        Assert.assertEquals(42, run(file, to, "foreign"));
+        runner.export(to, "foreign");
+        Assert.assertEquals(42, runner.run());
     }
 
     @Test
     public void test010() {
-        String file = "interop010";
+        Runner runner = new Runner("interop010");
         TruffleObject to = JavaInterop.asTruffleFunction(FuncLInterface.class, (a, b) -> (a + b));
-        Assert.assertEquals(42, run(file, to, "foreign"));
+        runner.export(to, "foreign");
+        Assert.assertEquals(42, runner.run());
     }
 
     @Test
     public void test011() {
-        String file = "interop011";
+        Runner runner = new Runner("interop011");
         TruffleObject to = JavaInterop.asTruffleFunction(FuncFInterface.class, (a, b) -> (a + b));
-        Assert.assertEquals(42.0, run(file, to, "foreign"), 0.1);
+        runner.export(to, "foreign");
+        Assert.assertEquals(42.0, runner.run(), 0.1);
     }
 
     @Test
     public void test012() {
-        String file = "interop012";
+        Runner runner = new Runner("interop012");
         TruffleObject to = JavaInterop.asTruffleFunction(FuncDInterface.class, (a, b) -> (a + b));
-        Assert.assertEquals(42.0, run(file, to, "foreign"), 0.1);
+        runner.export(to, "foreign");
+        Assert.assertEquals(42.0, runner.run(), 0.1);
     }
 
     @Test
     public void test013() {
-        String file = "interop013";
+        Runner runner = new Runner("interop013");
         TruffleObject to = JavaInterop.asTruffleObject(new MyBoxedInt());
-        Assert.assertEquals(42, run(file, to, "foreign"));
+        runner.export(to, "foreign");
+        Assert.assertEquals(42, runner.run());
     }
 
     @Test
     public void test014() {
-        String file = "interop014";
+        Runner runner = new Runner("interop014");
         TruffleObject to = JavaInterop.asTruffleObject(new MyBoxedInt());
-        Assert.assertEquals(42, run(file, to, "foreign"), 0.1);
+        runner.export(to, "foreign");
+        Assert.assertEquals(42, runner.run(), 0.1);
     }
 
     @Test
     public void test015() {
-        String file = "interop015";
+        Runner runner = new Runner("interop015");
         TruffleObject to = JavaInterop.asTruffleFunction(FuncDInterface.class, (a, b) -> (a + b));
-        Assert.assertEquals(42, run(file, to, "foreign"), 0.1);
+        runner.export(to, "foreign");
+        Assert.assertEquals(42, runner.run(), 0.1);
     }
 
     @Test
     public void test016() {
-        String file = "interop016";
+        Runner runner = new Runner("interop016");
         TruffleObject to = JavaInterop.asTruffleObject(null);
-        Assert.assertEquals(42, run(file, to, "foreign"), 0.1);
+        runner.export(to, "foreign");
+        Assert.assertEquals(42, runner.run(), 0.1);
     }
 
     @Test
     public void test017() {
-        String file = "interop017";
+        Runner runner = new Runner("interop017");
         TruffleObject to = JavaInterop.asTruffleObject(new int[]{1, 2, 3});
-        Assert.assertEquals(42, run(file, to, "foreign"), 0.1);
+        runner.export(to, "foreign");
+        Assert.assertEquals(42, runner.run(), 0.1);
     }
 
     @Test
     public void test018() {
-        String file = "interop018";
+        Runner runner = new Runner("interop018");
         TruffleObject to = JavaInterop.asTruffleObject(new int[]{1, 2, 3});
-        Assert.assertEquals(3, run(file, to, "foreign"));
+        runner.export(to, "foreign");
+        Assert.assertEquals(3, runner.run());
     }
 
     @Test
     public void test019() {
-        String file = "interop019";
+        Runner runner = new Runner("interop019");
         TruffleObject to = JavaInterop.asTruffleObject(new int[]{40, 41, 42, 43, 44});
-        Assert.assertEquals(210, run(file, to, "foreign"));
+        runner.export(to, "foreign");
+        Assert.assertEquals(210, runner.run());
     }
 
     @Test
     public void test020() {
-        String file = "interop020";
+        Runner runner = new Runner("interop020");
         int[] arr = new int[]{40, 41, 42, 43, 44};
         TruffleObject to = JavaInterop.asTruffleObject(arr);
-        run(file, to, "foreign");
+        runner.export(to, "foreign");
+        runner.run();
         Assert.assertArrayEquals(new int[]{30, 31, 32, 33, 34}, arr);
     }
 
     @Test
     public void test021() {
-        String file = "interop021";
+        Runner runner = new Runner("interop021");
         TruffleObject to = JavaInterop.asTruffleObject(new double[]{40, 41, 42, 43, 44});
-        Assert.assertEquals(210, run(file, to, "foreign"));
+        runner.export(to, "foreign");
+        Assert.assertEquals(210, runner.run());
     }
 
     @Test
     public void test022() {
-        String file = "interop022";
+        Runner runner = new Runner("interop022");
         double[] arr = new double[]{40, 41, 42, 43, 44};
         TruffleObject to = JavaInterop.asTruffleObject(arr);
-        run(file, to, "foreign");
+        runner.export(to, "foreign");
+        runner.run();
         Assert.assertArrayEquals(new double[]{30, 31, 32, 33, 34}, arr, 0.1);
+    }
+
+    @Test
+    public void test023() {
+        Runner runner = new Runner("interop023");
+        ClassA a = new ClassA();
+        ClassA b = new ClassA();
+        TruffleObject to = JavaInterop.asTruffleObject(a);
+        TruffleObject to2 = JavaInterop.asTruffleObject(b);
+        runner.export(to, "foreign");
+        runner.export(to2, "foreign2");
+        Assert.assertEquals(42, runner.run());
+    }
+
+    @Test
+    public void test024() {
+        Runner runner = new Runner("interop024");
+        ClassA a = new ClassA();
+        ClassA b = new ClassA();
+        b.valueI = 55;
+        TruffleObject to = JavaInterop.asTruffleObject(a);
+        TruffleObject to2 = JavaInterop.asTruffleObject(b);
+        runner.export(to, "foreign");
+        runner.export(to2, "foreign2");
+        Assert.assertEquals(55, runner.run());
+    }
+
+    @Test
+    public void test025() {
+        Runner runner = new Runner("interop025");
+        ClassA a = new ClassA();
+        ClassA b = new ClassA();
+        ClassA c = new ClassA();
+        b.valueI = 55;
+        c.valueI = 66;
+        TruffleObject to = JavaInterop.asTruffleObject(a);
+        TruffleObject to2 = JavaInterop.asTruffleObject(b);
+        TruffleObject to3 = JavaInterop.asTruffleObject(c);
+        runner.export(to, "foreign");
+        runner.export(to2, "foreign2");
+        runner.export(to3, "foreign3");
+        Assert.assertEquals(66, runner.run());
     }
 
     public static final class ClassA {
@@ -333,21 +396,32 @@ public final class LLVMInteropTest {
         double eval(double a, double b);
     }
 
-    private static int run(String fileName, TruffleObject foreignObject, String foreignObjectName) {
-        Builder builder = PolyglotEngine.newBuilder();
-        builder.globalSymbol(foreignObjectName, foreignObject);
-        final PolyglotEngine engine = builder.build();
-        try {
-            File cFile = new File(PATH, fileName + ".c");
-            File bcFile = File.createTempFile(PATH + "/" + "bc_" + fileName, ".ll");
-            File bcOptFile = File.createTempFile(PATH + "/" + "bcopt_" + fileName, ".ll");
-            Clang.compileToLLVMIR(cFile, bcFile, ClangOptions.builder());
-            Opt.optimizeBitcodeFile(bcFile, bcOptFile, OptOptions.builder().pass(Pass.MEM_TO_REG));
-            return engine.eval(Source.fromFileName(bcOptFile.getPath())).as(Integer.class);
-        } catch (IOException e) {
-            throw new AssertionError(e);
-        } finally {
-            engine.dispose();
+    private static final class Runner {
+        private final Builder builder = PolyglotEngine.newBuilder();
+        private final String fileName;
+
+        Runner(String fileName) {
+            this.fileName = fileName;
+        }
+
+        void export(TruffleObject foreignObject, String name) {
+            builder.globalSymbol(name, foreignObject);
+        }
+
+        int run() {
+            final PolyglotEngine engine = builder.build();
+            try {
+                File cFile = new File(PATH, fileName + ".c");
+                File bcFile = File.createTempFile(PATH + "/" + "bc_" + fileName, ".ll");
+                File bcOptFile = File.createTempFile(PATH + "/" + "bcopt_" + fileName, ".ll");
+                Clang.compileToLLVMIR(cFile, bcFile, ClangOptions.builder());
+                Opt.optimizeBitcodeFile(bcFile, bcOptFile, OptOptions.builder().pass(Pass.MEM_TO_REG));
+                return engine.eval(Source.fromFileName(bcOptFile.getPath())).as(Integer.class);
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            } finally {
+                engine.dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
This function allows us to import a foreign value (see also truffle_import function).
In contrast to truffle_import,  truffle_import_cached caches the imported value internally.
This caching guarantees good performance because we save the foreign value look-up.

Truffle_import_cached allows you to import a foreign value and keep is as a function local (rather than a global variable) without a loss in performance (which would be introduced by importing a foreign value every time truffle_import is called). 

For example:

Rather than writing 
```C
static void *ruby_cext;

__attribute__((constructor))
void truffle_ruby_load() {
  ruby_cext = truffle_import("ruby_cext");
}
```

one can now do

```C
__attribute__((constructor))
void truffle_ruby_load() {
  void *ruby_cext = truffle_import_cached("ruby_cext");
}
```
.

This should solve #196.