### PR TITLE
Simplification of ordered double comparisons

### DIFF
--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -23,7 +23,7 @@ _toolDir = join(_root, "com.oracle.truffle.llvm.tools/")
 _clangPath = _toolDir + 'tools/llvm/bin/clang'
 
 _testDir = join(_root, "com.oracle.truffle.llvm.test/tests/")
-_interopTestDir = _testDir = join(_root, "com.oracle.truffle.llvm.test/interoptests/")
+_interopTestDir = join(_root, "com.oracle.truffle.llvm.test/interoptests/")
 
 _gccSuiteDir = join(_root, "com.oracle.truffle.llvm.test/suites/gcc/")
 _gccSuiteDirRoot = join(_gccSuiteDir, 'gcc-5.2.0/gcc/testsuite/')

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/op/compare/LLVMDoubleCompareNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/op/compare/LLVMDoubleCompareNode.java
@@ -54,42 +54,71 @@ public abstract class LLVMDoubleCompareNode extends LLVMI1Node {
     public abstract static class LLVMDoubleOltNode extends LLVMDoubleCompareNode {
         @Specialization
         public boolean executeI1(double val1, double val2) {
-            return areOrdered(val1, val2) && val1 < val2;
+            if (val1 < val2) {
+                assert areOrdered(val1, val2);
+                return true;
+            } else {
+                return false;
+            }
         }
     }
 
     public abstract static class LLVMDoubleOgtNode extends LLVMDoubleCompareNode {
         @Specialization
         public boolean executeI1(double val1, double val2) {
-            return areOrdered(val1, val2) && val1 > val2;
+            if (val1 > val2) {
+                assert areOrdered(val1, val2);
+                return true;
+            } else {
+                return false;
+            }
         }
     }
 
     public abstract static class LLVMDoubleOgeNode extends LLVMDoubleCompareNode {
         @Specialization
         public boolean executeI1(double val1, double val2) {
-            return areOrdered(val1, val2) && val1 >= val2;
+            if (val1 >= val2) {
+                assert areOrdered(val1, val2);
+                return true;
+            } else {
+                return false;
+            }
         }
     }
 
     public abstract static class LLVMDoubleOleNode extends LLVMDoubleCompareNode {
         @Specialization
         public boolean executeI1(double val1, double val2) {
-            return areOrdered(val1, val2) && val1 <= val2;
+            if (val1 <= val2) {
+                assert areOrdered(val1, val2);
+                return true;
+            } else {
+                return false;
+            }
         }
     }
 
     public abstract static class LLVMDoubleOeqNode extends LLVMDoubleCompareNode {
         @Specialization
         public boolean executeI1(double val1, double val2) {
-            return areOrdered(val1, val2) && val1 == val2;
+            if (val1 == val2) {
+                assert areOrdered(val1, val2);
+                return true;
+            } else {
+                return false;
+            }
         }
     }
 
     public abstract static class LLVMDoubleOneNode extends LLVMDoubleCompareNode {
         @Specialization
         public boolean executeI1(double val1, double val2) {
-            return areOrdered(val1, val2) && val1 != val2;
+            if (val1 != val2) {
+                return areOrdered(val1, val2);
+            } else {
+                return false;
+            }
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.test/tests/c/float-comparison/minus-plus-zero.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/float-comparison/minus-plus-zero.c
@@ -1,0 +1,40 @@
+#include <stdlib.h>
+
+void assert_true(int val) {
+  if (!val) {
+    abort();
+  }
+}
+
+void assert_false(int val) {
+  if (val) {
+    abort();
+  }
+}
+
+int main() {
+  // ==
+  assert_true(0.0 == 0.0);
+  assert_true(0.0 == -0.0);
+  assert_true(-0.0 == 0.0);
+  // !=
+  assert_false(0.0 != 0.0);
+  assert_false(0.0 != -0.0);
+  assert_false(-0.0 != 0.0);
+  // <
+  assert_false(0.0 < 0.0);
+  assert_false(0.0 < -0.0);
+  assert_false(-0.0 < 0.0);
+  // <=
+  assert_true(0.0 <= 0.0);
+  assert_true(0.0 <= -0.0);
+  assert_true(-0.0 <= 0.0);
+  // >
+  assert_false(0.0 > 0.0);
+  assert_false(0.0 > -0.0);
+  assert_false(-0.0 > 0.0);
+  // >=
+  assert_true(0.0 >= 0.0);
+  assert_true(0.0 >= -0.0);
+  assert_true(-0.0 >= 0.0);
+}

--- a/projects/com.oracle.truffle.llvm.test/tests/c/float-comparison/ordered-comparison-nan-inf.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/float-comparison/ordered-comparison-nan-inf.c
@@ -1,0 +1,43 @@
+#include <stdlib.h>
+
+void assert_true(int val) {
+  if (!val) {
+    abort();
+  }
+}
+
+void assert_false(int val) {
+  if (val) {
+    abort();
+  }
+}
+
+double volatile INF = 1.0 / 0.0;
+double volatile NAN = 0.0 / 0.0;
+
+int main() {
+  // ==
+  assert_false(NAN == INF);
+  assert_false(INF == NAN);
+  assert_false(NAN == NAN);
+  // !=
+  assert_true(NAN != INF);
+  assert_true(INF != NAN);
+  assert_true(NAN != NAN);
+  // <
+  assert_false(NAN < INF);
+  assert_false(INF < NAN);
+  assert_false(NAN < NAN);
+  // <=
+  assert_false(NAN <= INF);
+  assert_false(INF <= NAN);
+  assert_false(NAN <= NAN);
+  // >
+  assert_false(NAN > INF);
+  assert_false(INF > NAN);
+  assert_false(NAN > NAN);
+  // >=
+  assert_false(NAN >= INF);
+  assert_false(INF >= NAN);
+  assert_false(NAN >= NAN);
+}

--- a/projects/com.oracle.truffle.llvm.test/tests/c/float-comparison/ordered-comparison-nan-neginf.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/float-comparison/ordered-comparison-nan-neginf.c
@@ -1,0 +1,43 @@
+#include <stdlib.h>
+
+void assert_true(int val) {
+  if (!val) {
+    abort();
+  }
+}
+
+void assert_false(int val) {
+  if (val) {
+    abort();
+  }
+}
+
+double volatile INF = 1.0 / 0.0;
+double volatile NAN = 0.0 / 0.0;
+
+int main() {
+  // ==
+  assert_false(NAN == -INF);
+  assert_false(-INF == NAN);
+  assert_false(NAN == NAN);
+  // !=
+  assert_true(NAN != -INF);
+  assert_true(-INF != NAN);
+  assert_true(NAN != NAN);
+  // <
+  assert_false(NAN < -INF);
+  assert_false(-INF < NAN);
+  assert_false(NAN < NAN);
+  // <=
+  assert_false(NAN <= -INF);
+  assert_false(-INF <= NAN);
+  assert_false(NAN <= NAN);
+  // >
+  assert_false(NAN > -INF);
+  assert_false(-INF > NAN);
+  assert_false(NAN > NAN);
+  // >=
+  assert_false(NAN >= -INF);
+  assert_false(-INF >= NAN);
+  assert_false(NAN >= NAN);
+}

--- a/projects/com.oracle.truffle.llvm.test/tests/c/float-comparison/ordered-comparison-nan.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/float-comparison/ordered-comparison-nan.c
@@ -1,0 +1,43 @@
+#include <stdlib.h>
+
+void assert_true(int val) {
+  if (!val) {
+    abort();
+  }
+}
+
+void assert_false(int val) {
+  if (val) {
+    abort();
+  }
+}
+
+double volatile NUM = 3;
+double volatile NAN = 0.0 / 0.0;
+
+int main() {
+  // ==
+  assert_false(NAN == NUM);
+  assert_false(NUM == NAN);
+  assert_false(NAN == NAN);
+  // !=
+  assert_true(NAN != NUM);
+  assert_true(NUM != NAN);
+  assert_true(NAN != NAN);
+  // <
+  assert_false(NAN < NUM);
+  assert_false(NUM < NAN);
+  assert_false(NAN < NAN);
+  // <=
+  assert_false(NAN <= NUM);
+  assert_false(NUM <= NAN);
+  assert_false(NAN <= NAN);
+  // >
+  assert_false(NAN > NUM);
+  assert_false(NUM > NAN);
+  assert_false(NAN > NAN);
+  // >=
+  assert_false(NAN >= NUM);
+  assert_false(NUM >= NAN);
+  assert_false(NAN >= NAN);
+}


### PR DESCRIPTION
This change removes isOrdered checks in ordered double comparisons based on the fact that NaN comparisons always result in false. It also adds some test cases for ordered double comparisons.