### PR TITLE
Binary jvmci dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
     - gobjc++-4.6
     - gcc-4.6-plugin-dev
 install:
+  - export MX_BINARY_SUITES="jvmci"
   - gem install mdl
   - pip install astroid==1.1.0 --user `whoami`
   - pip install pylint==1.1.0 --user `whoami`

--- a/mx.sulong/suite.py
+++ b/mx.sulong/suite.py
@@ -9,6 +9,7 @@ suite = {
            "version" : "61191367671d802efa088b4b2c80f17bc3c53061",
            "urls" : [
                 {"url" : "https://github.com/graalvm/graal-core", "kind" : "git"},
+                {"url" : "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind" : "binary"},
             ]
         },
     ],


### PR DESCRIPTION
This change addresses #224 by not building the jvmci native from source but downloading the binary from https://curio.ssw.jku.at/nexus/content/repositories/snapshots to reduce the Travis gate time.