### PR TITLE
Cache tool and suite directories in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+cache:
+  directories:
+  - projects/com.oracle.truffle.llvm.test/suites
+  - projects/com.oracle.truffle.llvm.tools/tools
 sudo: required
 language: java
 python:


### PR DESCRIPTION
Use the new (non container-based) Travis cache infrastructure to cache the downloaded test suites, Dragonegg, and LLVM binaries.