### PR TITLE
Revert "Remove branch profiling for switch"

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/control/LLVMSwitchNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/control/LLVMSwitchNode.java
@@ -30,8 +30,10 @@
 package com.oracle.truffle.llvm.nodes.impl.control;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.api.profiles.ConditionProfile;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMTerminatorNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
@@ -65,12 +67,21 @@ public abstract class LLVMSwitchNode extends LLVMTerminatorNode {
         }
     }
 
-    public static class LLVMI8SwitchNode extends LLVMSwitchNode {
+    protected ConditionProfile[] createProfiles(int length) {
+        CompilerAsserts.neverPartOfCompilation();
+        ConditionProfile[] profiles = new ConditionProfile[length];
+        for (int i = 0; i < profiles.length; i++) {
+            profiles[i] = ConditionProfile.createCountingProfile();
+        }
+        return profiles;
+    }
+
+    public abstract static class LLVMI8SwitchBaseNode extends LLVMSwitchNode {
 
         @Child private LLVMI8Node cond;
         @Children private final LLVMI8Node[] cases;
 
-        public LLVMI8SwitchNode(LLVMI8Node cond, LLVMI8Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+        public LLVMI8SwitchBaseNode(LLVMI8Node cond, LLVMI8Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
             super(defaultLabel, successors, phiWriteNodes);
             this.cond = cond;
             this.cases = cases;
@@ -82,7 +93,7 @@ public abstract class LLVMSwitchNode extends LLVMTerminatorNode {
             int val = cond.executeI8(frame);
             for (int i = 0; i < cases.length; i++) {
                 int caseValue = cases[i].executeI8(frame);
-                if (val == caseValue) {
+                if (profile(i, val == caseValue)) {
                     executePhiWrites(frame);
                     return i + CASE_LABEL_START_INDEX;
                 }
@@ -91,14 +102,45 @@ public abstract class LLVMSwitchNode extends LLVMTerminatorNode {
             return DEFAULT_LABEL_INDEX;
         }
 
+        abstract boolean profile(int i, boolean value);
+
     }
 
-    public static class LLVMI32SwitchNode extends LLVMSwitchNode {
+    public static class LLVMI8SwitchNode extends LLVMI8SwitchBaseNode {
+
+        public LLVMI8SwitchNode(LLVMI8Node cond, LLVMI8Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+            super(cond, cases, successors, defaultLabel, phiWriteNodes);
+        }
+
+        @Override
+        boolean profile(int i, boolean value) {
+            return value;
+        }
+
+    }
+
+    public static class LLVMI8ProfilingSwitchNode extends LLVMI8SwitchBaseNode {
+
+        @CompilationFinal private final ConditionProfile[] profiles;
+
+        public LLVMI8ProfilingSwitchNode(LLVMI8Node cond, LLVMI8Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+            super(cond, cases, successors, defaultLabel, phiWriteNodes);
+            profiles = createProfiles(cases.length);
+        }
+
+        @Override
+        boolean profile(int i, boolean value) {
+            return profiles[i].profile(value);
+        }
+
+    }
+
+    public abstract static class LLVMI32SwitchBaseNode extends LLVMSwitchNode {
 
         @Child private LLVMI32Node cond;
         @Children private final LLVMI32Node[] cases;
 
-        public LLVMI32SwitchNode(LLVMI32Node cond, LLVMI32Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+        public LLVMI32SwitchBaseNode(LLVMI32Node cond, LLVMI32Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
             super(defaultLabel, successors, phiWriteNodes);
             this.cond = cond;
             this.cases = cases;
@@ -110,7 +152,7 @@ public abstract class LLVMSwitchNode extends LLVMTerminatorNode {
             int val = cond.executeI32(frame);
             for (int i = 0; i < cases.length; i++) {
                 int caseValue = cases[i].executeI32(frame);
-                if (val == caseValue) {
+                if (profile(i, val == caseValue)) {
                     executePhiWrites(frame);
                     return i + CASE_LABEL_START_INDEX;
                 }
@@ -119,14 +161,48 @@ public abstract class LLVMSwitchNode extends LLVMTerminatorNode {
             return DEFAULT_LABEL_INDEX;
         }
 
+        abstract boolean profile(int i, boolean value);
+
     }
 
-    public static class LLVMI64SwitchNode extends LLVMSwitchNode {
+    public static class LLVMI32ProfilingSwitchNode extends LLVMI32SwitchBaseNode {
+
+        @CompilationFinal private final ConditionProfile[] profiles;
+
+        public LLVMI32ProfilingSwitchNode(LLVMI32Node cond, LLVMI32Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+            super(cond, cases, successors, defaultLabel, phiWriteNodes);
+            profiles = createProfiles(cases.length);
+        }
+
+        @Override
+        boolean profile(int i, boolean value) {
+            return profiles[i].profile(value);
+        }
+
+    }
+
+    public static class LLVMI32SwitchNode extends LLVMI32SwitchBaseNode {
+
+        @CompilationFinal private ConditionProfile[] profiles;
+
+        public LLVMI32SwitchNode(LLVMI32Node cond, LLVMI32Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+            super(cond, cases, successors, defaultLabel, phiWriteNodes);
+            profiles = createProfiles(cases.length);
+        }
+
+        @Override
+        boolean profile(int i, boolean value) {
+            return value;
+        }
+
+    }
+
+    public abstract static class LLVMI64SwitchBaseNode extends LLVMSwitchNode {
 
         @Child private LLVMI64Node cond;
         @Children private final LLVMI64Node[] cases;
 
-        public LLVMI64SwitchNode(LLVMI64Node cond, LLVMI64Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+        public LLVMI64SwitchBaseNode(LLVMI64Node cond, LLVMI64Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
             super(defaultLabel, successors, phiWriteNodes);
             this.cond = cond;
             this.cases = cases;
@@ -138,13 +214,44 @@ public abstract class LLVMSwitchNode extends LLVMTerminatorNode {
             long val = cond.executeI64(frame);
             for (int i = 0; i < cases.length; i++) {
                 long caseValue = cases[i].executeI64(frame);
-                if (val == caseValue) {
+                if (profile(i, val == caseValue)) {
                     executePhiWrites(frame);
                     return i + CASE_LABEL_START_INDEX;
                 }
             }
             executePhiWrites(frame);
             return DEFAULT_LABEL_INDEX;
+        }
+
+        abstract boolean profile(int i, boolean value);
+
+    }
+
+    public static class LLVMI64ProfilingSwitchNode extends LLVMI64SwitchBaseNode {
+
+        @CompilationFinal private final ConditionProfile[] profiles;
+
+        public LLVMI64ProfilingSwitchNode(LLVMI64Node cond, LLVMI64Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+            super(cond, cases, successors, defaultLabel, phiWriteNodes);
+            profiles = createProfiles(cases.length);
+        }
+
+        @Override
+        boolean profile(int i, boolean value) {
+            return profiles[i].profile(value);
+        }
+
+    }
+
+    public static class LLVMI64SwitchNode extends LLVMI64SwitchBaseNode {
+
+        public LLVMI64SwitchNode(LLVMI64Node cond, LLVMI64Node[] cases, int[] successors, int defaultLabel, LLVMNode[] phiWriteNodes) {
+            super(cond, cases, successors, defaultLabel, phiWriteNodes);
+        }
+
+        @Override
+        boolean profile(int i, boolean value) {
+            return value;
         }
 
     }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMSwitchFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMSwitchFactory.java
@@ -37,10 +37,14 @@ import com.oracle.truffle.llvm.nodes.impl.base.LLVMTerminatorNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI8Node;
+import com.oracle.truffle.llvm.nodes.impl.control.LLVMSwitchNode.LLVMI32ProfilingSwitchNode;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMSwitchNode.LLVMI32SwitchNode;
+import com.oracle.truffle.llvm.nodes.impl.control.LLVMSwitchNode.LLVMI64ProfilingSwitchNode;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMSwitchNode.LLVMI64SwitchNode;
+import com.oracle.truffle.llvm.nodes.impl.control.LLVMSwitchNode.LLVMI8ProfilingSwitchNode;
 import com.oracle.truffle.llvm.nodes.impl.control.LLVMSwitchNode.LLVMI8SwitchNode;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
+import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
 
 public class LLVMSwitchFactory {
 
@@ -49,13 +53,25 @@ public class LLVMSwitchFactory {
         switch (llvmType) {
             case I8:
                 LLVMI8Node[] i8Cases = Arrays.copyOf(cases, cases.length, LLVMI8Node[].class);
-                return new LLVMI8SwitchNode((LLVMI8Node) cond, i8Cases, otherLabels, defaultLabel, phiWriteNodes);
+                if (LLVMBaseOptionFacade.injectBranchProbabilities()) {
+                    return new LLVMI8ProfilingSwitchNode((LLVMI8Node) cond, i8Cases, otherLabels, defaultLabel, phiWriteNodes);
+                } else {
+                    return new LLVMI8SwitchNode((LLVMI8Node) cond, i8Cases, otherLabels, defaultLabel, phiWriteNodes);
+                }
             case I32:
                 LLVMI32Node[] i32Cases = Arrays.copyOf(cases, cases.length, LLVMI32Node[].class);
-                return new LLVMI32SwitchNode((LLVMI32Node) cond, i32Cases, otherLabels, defaultLabel, phiWriteNodes);
+                if (LLVMBaseOptionFacade.injectBranchProbabilities()) {
+                    return new LLVMI32ProfilingSwitchNode((LLVMI32Node) cond, i32Cases, otherLabels, defaultLabel, phiWriteNodes);
+                } else {
+                    return new LLVMI32SwitchNode((LLVMI32Node) cond, i32Cases, otherLabels, defaultLabel, phiWriteNodes);
+                }
             case I64:
                 LLVMI64Node[] i64Cases = Arrays.copyOf(cases, cases.length, LLVMI64Node[].class);
-                return new LLVMI64SwitchNode((LLVMI64Node) cond, i64Cases, otherLabels, defaultLabel, phiWriteNodes);
+                if (LLVMBaseOptionFacade.injectBranchProbabilities()) {
+                    return new LLVMI64ProfilingSwitchNode((LLVMI64Node) cond, i64Cases, otherLabels, defaultLabel, phiWriteNodes);
+                } else {
+                    return new LLVMI64SwitchNode((LLVMI64Node) cond, i64Cases, otherLabels, defaultLabel, phiWriteNodes);
+                }
             default:
                 throw new AssertionError(llvmType);
         }


### PR DESCRIPTION
This reverts commit 98d8c1ea6834edfdd3c549eb02bcca10f328f883.

Graal does not use the injected successor branch probabilities for switches. Hence, this change reintroduced the switch case branch probabilities. See https://github.com/graalvm/sulong/issues/238 for more details.

Conflicts:
	projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMOptions.java