### PR TITLE
Add a signal (dummy) implementation

### DIFF
--- a/mx.sulong/libs/signal.c
+++ b/mx.sulong/libs/signal.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+void (*signal(int sig, void (*func)(int)))(int) {
+  fprintf(stderr, "Sulong does not support signals, registering a signal handler over "
+                  "the signal function has no effect!\n");
+  return func;
+}

--- a/projects/com.oracle.truffle.llvm.test/suites-configs/gcc/gcc.dg/unsorted/working.include
+++ b/projects/com.oracle.truffle.llvm.test/suites-configs/gcc/gcc.dg/unsorted/working.include
@@ -561,8 +561,4 @@ gcc.dg/torture/stackalign/pr16660-2.c
 gcc.dg/torture/stackalign/global-1.c
 gcc.dg/torture/stackalign/alloca-1.c
 gcc.dg/autopar/pr39500-2.c
-gcc.dg/vect/vec-scal-opt2.c
-gcc.dg/vect/vec-scal-opt.c
-gcc.dg/vect/vec-scal-opt1.c
-gcc.dg/ipa/pure-const-2.c
 gcc.dg/ipa/inlinehint-3.c

--- a/projects/com.oracle.truffle.llvm.test/tests/c/stdlib/signal.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/stdlib/signal.c
@@ -1,0 +1,8 @@
+#include <signal.h>
+
+void sig_handler(int signo) {}
+
+int main(void) {
+  signal(SIGINT, sig_handler);
+  return 0;
+}


### PR DESCRIPTION
This change adds a dummy implementation for the C standard library `signal` function. The motivation for this change is the same as for #250.