### PR TITLE
Allow interop writes to take any Object as value

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMTruffleWrite.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMTruffleWrite.java
@@ -82,12 +82,12 @@ public final class LLVMTruffleWrite {
         @Child private Node foreignWrite = Message.WRITE.createNode();
 
         @Specialization
-        public void executeIntrinsic(VirtualFrame frame, LLVMTruffleObject value, LLVMAddress id, LLVMAddress v) {
+        public void executeIntrinsic(VirtualFrame frame, LLVMTruffleObject value, LLVMAddress id, Object v) {
             doWrite(frame, foreignWrite, value, id, v);
         }
 
         @Specialization
-        public void executeIntrinsic(VirtualFrame frame, TruffleObject value, LLVMAddress id, LLVMAddress v) {
+        public void executeIntrinsic(VirtualFrame frame, TruffleObject value, LLVMAddress id, Object v) {
             executeIntrinsic(frame, new LLVMTruffleObject(value), id, v);
         }
     }
@@ -195,12 +195,12 @@ public final class LLVMTruffleWrite {
         @Child private Node foreignWrite = Message.WRITE.createNode();
 
         @Specialization
-        public void executeIntrinsic(VirtualFrame frame, LLVMTruffleObject value, int id, LLVMAddress v) {
+        public void executeIntrinsic(VirtualFrame frame, LLVMTruffleObject value, int id, Object v) {
             doWriteIdx(frame, foreignWrite, value, id, v);
         }
 
         @Specialization
-        public void executeIntrinsic(VirtualFrame frame, TruffleObject value, int id, LLVMAddress v) {
+        public void executeIntrinsic(VirtualFrame frame, TruffleObject value, int id, Object v) {
             executeIntrinsic(frame, new LLVMTruffleObject(value), id, v);
         }
     }


### PR DESCRIPTION
It seems `LLVMAddress` is a typo here.
The `P` suffix in the node names means pointer I guess, but they should probably accept any value anyway since it's going to foreign objects.