### PR TITLE
Use the MessageResolution DSL for LLVMFunctionDescriptor

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.oracle.nfi.api.NativeFunctionHandle;
-import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.ExecutionContext;
 import com.oracle.truffle.api.RootCallTarget;
@@ -66,7 +65,6 @@ public class LLVMContext extends ExecutionContext {
     public LLVMContext(NodeFactoryFacade facade, LLVMOptimizationConfiguration optimizationConfig) {
         nativeLookup = new NativeLookup(facade);
         this.registry = new LLVMFunctionRegistry(optimizationConfig, facade);
-        setLastContext(this);
     }
 
     public RootCallTarget getFunction(LLVMFunctionDescriptor function) {
@@ -124,22 +122,6 @@ public class LLVMContext extends ExecutionContext {
 
     public Source getSourceFile() {
         return sourceFile;
-    }
-
-    // TODO No static access to this class from LLVMFunction at the moment
-
-    private static LLVMContext lastContext;
-
-    public static CallTarget getCallTarget(LLVMFunctionDescriptor function) {
-        return lastContext.registry.lookup(function);
-    }
-
-    private static void setLastContext(LLVMContext context) {
-        lastContext = context;
-    }
-
-    public static LLVMStack getStaticStack() {
-        return lastContext.stack;
     }
 
     public void registerStaticDestructor(RootCallTarget staticDestructor) {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMForeignCallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMForeignCallNode.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.intrinsics.interop;
+
+import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.IndirectCallNode;
+import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
+import com.oracle.truffle.llvm.types.memory.LLVMStack;
+
+@NodeChildren({@NodeChild("receiver"), @NodeChild("arguments")})
+public abstract class LLVMForeignCallNode extends LLVMExpressionNode {
+
+    private final LLVMContext context;
+    private final LLVMStack stack;
+
+    protected LLVMForeignCallNode(LLVMContext context) {
+        this.context = context;
+        this.stack = context.getStack();
+    }
+
+    public abstract Object executeCall(VirtualFrame frame, LLVMFunctionDescriptor function, Object[] arguments);
+
+    @SuppressWarnings("unused")
+    @Specialization(guards = "function.getFunctionIndex() == functionIndex")
+    public Object callDirect(VirtualFrame frame, LLVMFunctionDescriptor function, Object[] arguments,
+                    @Cached("function.getFunctionIndex()") int functionIndex,
+                    @Cached("create(getCallTarget(function))") DirectCallNode callNode) {
+        assert function.getReturnType() != LLVMRuntimeType.STRUCT;
+        return callNode.call(frame, packArguments(arguments));
+    }
+
+    @Specialization
+    public Object callIndirect(VirtualFrame frame, LLVMFunctionDescriptor function, Object[] arguments,
+                    @Cached("create()") IndirectCallNode callNode) {
+        assert function.getReturnType() != LLVMRuntimeType.STRUCT;
+        return callNode.call(frame, getCallTarget(function), packArguments(arguments));
+    }
+
+    protected CallTarget getCallTarget(LLVMFunctionDescriptor function) {
+        return context.getFunction(function);
+    }
+
+    private Object[] packArguments(Object[] arguments) {
+        final Object[] packedArguments = new Object[1 + arguments.length];
+        packedArguments[0] = stack.getUpperBounds();
+        System.arraycopy(arguments, 0, packedArguments, 1, arguments.length);
+        return packedArguments;
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMFunctionMessageResolution.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMFunctionMessageResolution.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.intrinsics.interop;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.interop.MessageResolution;
+import com.oracle.truffle.api.interop.Resolve;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+
+@MessageResolution(receiverType = LLVMFunctionDescriptor.class, language = LLVMLanguage.class)
+public class LLVMFunctionMessageResolution {
+
+    @Resolve(message = "IS_EXECUTABLE")
+    public abstract static class ForeignIsExecutableNode extends Node {
+
+        @SuppressWarnings("unused")
+        protected Object access(VirtualFrame frame, LLVMFunctionDescriptor object) {
+            return true;
+        }
+
+    }
+
+    @Resolve(message = "EXECUTE")
+    public abstract static class ForeignExecuteNode extends Node {
+
+        @Child private Node findContextNode;
+        @Child private LLVMForeignCallNode executeNode;
+
+        protected Object access(VirtualFrame frame, LLVMFunctionDescriptor object, Object[] arguments) {
+            return getHelperNode().executeCall(frame, object, arguments);
+        }
+
+        private LLVMForeignCallNode getHelperNode() {
+            if (executeNode == null) {
+                CompilerDirectives.transferToInterpreter();
+                findContextNode = insert(LLVMLanguage.INSTANCE.createFindContextNode0());
+                LLVMContext context = LLVMLanguage.INSTANCE.findContext0(findContextNode);
+                executeNode = insert(LLVMForeignCallNodeGen.create(context, null, null));
+            }
+
+            return executeNode;
+        }
+
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMFunctionMessageResolutionAccessor.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMFunctionMessageResolutionAccessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.intrinsics.interop;
+
+import com.oracle.truffle.api.interop.ForeignAccess;
+
+public class LLVMFunctionMessageResolutionAccessor {
+
+    public static final ForeignAccess ACCESS = LLVMFunctionMessageResolutionForeign.ACCESS;
+
+}

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -250,7 +250,7 @@ public final class LLVMVisitor implements LLVMParserRuntime {
         deallocations = globalDeallocations.toArray(new LLVMNode[globalDeallocations.size()]);
         RootCallTarget staticDestructorsTarget = Truffle.getRuntime().createCallTarget(factoryFacade.createStaticInitsRootNode(deallocations));
         if (mainFunction == null) {
-            return new ParserResult(Truffle.getRuntime().createCallTarget(RootNode.createConstantNode(null)), staticInitsTarget, staticDestructorsTarget, parsedFunctions);
+            return new ParserResult(null, staticInitsTarget, staticDestructorsTarget, parsedFunctions);
         }
         RootCallTarget mainCallTarget = parsedFunctions.get(mainFunction);
         RootNode globalFunction = factoryFacade.createGlobalRootNode(mainCallTarget, mainArgs, sourceFile, mainFunction.getParameterTypes());

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
@@ -29,22 +29,10 @@
  */
 package com.oracle.truffle.llvm.types;
 
-import java.lang.reflect.Method;
-import java.util.List;
-
-import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerAsserts;
-import com.oracle.truffle.api.Truffle;
-import com.oracle.truffle.api.TruffleLanguage;
-import com.oracle.truffle.api.frame.FrameDescriptor;
-import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.interop.ForeignAccess;
-import com.oracle.truffle.api.interop.ForeignAccess.Factory10;
-import com.oracle.truffle.api.interop.Message;
 import com.oracle.truffle.api.interop.TruffleObject;
-import com.oracle.truffle.api.nodes.IndirectCallNode;
-import com.oracle.truffle.api.nodes.RootNode;
-import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
 public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<LLVMFunctionDescriptor> {
 
@@ -148,128 +136,23 @@ public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<L
         }
     }
 
-    @Override
-    public ForeignAccess getForeignAccess() {
-        return ForeignAccess.create(LLVMFunctionDescriptor.class, new Factory10() {
-
-            @Override
-            public CallTarget accessIsNull() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public CallTarget accessIsExecutable() {
-                return Truffle.getRuntime().createCallTarget(RootNode.createConstantNode(true));
-            }
-
-            @Override
-            public CallTarget accessIsBoxed() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public CallTarget accessHasSize() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public CallTarget accessGetSize() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public CallTarget accessUnbox() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public CallTarget accessRead() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public CallTarget accessWrite() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public CallTarget accessExecute(int argumentsLength) {
-                return Truffle.getRuntime().createCallTarget(new ForeignCallNode());
-            }
-
-            @Override
-            public CallTarget accessInvoke(int argumentsLength) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public CallTarget accessNew(int argumentsLength) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public CallTarget accessMessage(Message unknown) {
-                throw new UnsupportedOperationException();
-            }
-
-        });
+    public static boolean isInstance(TruffleObject object) {
+        return object instanceof LLVMFunctionDescriptor;
     }
 
-    private static class ForeignCallNode extends RootNode {
+    @CompilationFinal private static ForeignAccess ACCESS;
 
-        private final LLVMStack stack;
-
-        @Child private IndirectCallNode callNode;
-
-        protected ForeignCallNode() {
-            super(getLLVMLanguage(), null, new FrameDescriptor());
-            stack = getLLVMStack();
-            callNode = Truffle.getRuntime().createIndirectCallNode();
-        }
-
-        @Override
-        public Object execute(VirtualFrame frame) {
-            final LLVMFunctionDescriptor function = (LLVMFunctionDescriptor) ForeignAccess.getReceiver(frame);
-            assert function.getReturnType() != LLVMRuntimeType.STRUCT;
-            final CallTarget callTarget = getCallTarget(function);
-            final List<Object> arguments = ForeignAccess.getArguments(frame);
-            final Object[] packedArguments = new Object[1 + arguments.size()];
-            packedArguments[0] = stack.getUpperBounds();
-            System.arraycopy(arguments.toArray(), 0, packedArguments, 1, arguments.size());
-            return callNode.call(frame, callTarget, packedArguments);
-        }
-
-        // TODO No static access to these classes at the moment
-
-        @SuppressWarnings("unchecked")
-        private static Class<? extends TruffleLanguage<?>> getLLVMLanguage() {
+    @Override
+    public ForeignAccess getForeignAccess() {
+        if (ACCESS == null) {
             try {
-                return (Class<? extends TruffleLanguage<?>>) Class.forName("com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage");
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        private static LLVMStack getLLVMStack() {
-            try {
-                final Class<?> contextClass = Class.forName("com.oracle.truffle.llvm.nodes.impl.base.LLVMContext");
-                final Method getStaticStackMethod = contextClass.getMethod("getStaticStack");
-                return (LLVMStack) getStaticStackMethod.invoke(null);
+                Class<?> accessor = Class.forName("com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMFunctionMessageResolutionAccessor");
+                ACCESS = (ForeignAccess) accessor.getField("ACCESS").get(null);
             } catch (Exception e) {
-                throw new RuntimeException(e);
+                throw new AssertionError(e);
             }
         }
-
-        private static CallTarget getCallTarget(LLVMFunctionDescriptor function) {
-            try {
-                final Class<?> contextClass = Class.forName("com.oracle.truffle.llvm.nodes.impl.base.LLVMContext");
-                final Method getCallTargetMethod = contextClass.getMethod("getCallTarget", LLVMFunctionDescriptor.class);
-                return (CallTarget) getCallTargetMethod.invoke(null, function);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-
+        return ACCESS;
     }
 
 }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -34,8 +34,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
@@ -91,7 +89,6 @@ public class LLVM {
                     mainFunction = parserResult.getMainFunction();
                     handleParserResult(context, parserResult);
                 } else if (code.getMimeType().equals(LLVMLanguage.SULONG_LIBRARY_MIME_TYPE)) {
-                    final List<CallTarget> mainFunctions = new ArrayList<>();
                     final SulongLibrary library = new SulongLibrary(new File(code.getPath()));
 
                     try {
@@ -105,17 +102,15 @@ public class LLVM {
                                 throw new UncheckedIOException(e);
                             }
                             handleParserResult(context, parserResult);
-                            mainFunctions.add(parserResult.getMainFunction());
+                            if (parserResult.getMainFunction() != null) {
+                                throw new IllegalArgumentException("main function in library");
+                            }
                         });
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);
                     }
 
-                    if (mainFunctions.size() != 1) {
-                        throw new UnsupportedOperationException();
-                    }
-
-                    mainFunction = mainFunctions.get(0);
+                    mainFunction = Truffle.getRuntime().createCallTarget(RootNode.createConstantNode(null));
                 } else {
                     throw new IllegalArgumentException("undeclared mime type");
                 }


### PR DESCRIPTION
* This allows EXECUTE messages to compile.
* Still slightly hacky in LLVMFunctionDescriptor, one possible fix would be to move LLVMFunctionDescriptor behind a facade entirely.
* Interop EXECUTE is still slow due to native to Java String and byte-by-byte comparisons (Could we detect if it's a literal by seeing it's in read-only memory or so and then just compare pointers adresses?).