### PR TITLE
Support void main functions

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMMainFunctionReturnValueRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMMainFunctionReturnValueRootNode.java
@@ -83,4 +83,20 @@ public abstract class LLVMMainFunctionReturnValueRootNode extends RootNode {
 
     }
 
+    public static class LLVMMainFunctionReturnVoidRootNode extends LLVMMainFunctionReturnValueRootNode {
+
+        private static final int VOID_RET_VALUE = 0;
+
+        public LLVMMainFunctionReturnVoidRootNode(RootCallTarget rootCallTarget) {
+            super(rootCallTarget);
+        }
+
+        @Override
+        public Object execute(VirtualFrame frame) {
+            rootCallTarget.call();
+            return VOID_RET_VALUE;
+        }
+
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
@@ -270,6 +270,8 @@ public final class LLVMFunctionFactory {
                 return new LLVMMainFunctionReturnValueRootNode.LLVMMainFunctionReturnNumberRootNode(mainCallTarget);
             case I_VAR_BITWIDTH:
                 return new LLVMMainFunctionReturnValueRootNode.LLVMMainFunctionReturnIVarBitRootNode(mainCallTarget);
+            case VOID:
+                return new LLVMMainFunctionReturnValueRootNode.LLVMMainFunctionReturnVoidRootNode(mainCallTarget);
             default:
                 throw new AssertionError(returnType);
         }


### PR DESCRIPTION
Both Clang and GCC support void main functions, although such functions are undefined in ANSI C. This change returns 214 for main functions to imitate the behavior of Clang.