### PR TITLE
Add pthread stub with pthread_create, pthread_join and pthread_exit

### DIFF
--- a/mx.sulong/libs/pthread.c
+++ b/mx.sulong/libs/pthread.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include "pthread.h"
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine) (void *), void *arg) {
+  static int warn = 1;
+  if (warn) {
+    fprintf(stderr, "Sulong does not support threads yet, using pthread stub!\n");
+    warn = 0;
+  }
+  start_routine(arg);
+  return 0;
+}
+
+void pthread_exit(void *retval) {
+}
+
+int pthread_join(pthread_t thread, void **retval) {
+  return 0;
+}

--- a/mx.sulong/libs/pthread.h
+++ b/mx.sulong/libs/pthread.h
@@ -1,0 +1,15 @@
+#ifndef _PTHREAD_H
+#define _PTHREAD_H
+
+#ifndef NULL
+#define NULL 0
+#endif
+
+typedef long pthread_t;
+typedef void pthread_attr_t;
+
+extern int pthread_create (pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine) (void *), void *arg);
+extern void pthread_exit (void *retval);
+extern int pthread_join (pthread_t thread, void **retval);
+
+#endif


### PR DESCRIPTION
pthread_create synchronously executes the start_routine function
pthread_exit is a no-op
pthread_join is a no-op

This stub allows running Argon2: https://github.com/P-H-C/phc-winner-argon2