### PR TITLE
Provide substitutions for C's log and log10 functions

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMCMathsIntrinsics.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMCMathsIntrinsics.java
@@ -49,4 +49,24 @@ public abstract class LLVMCMathsIntrinsics {
 
     }
 
+    @NodeChild(type = LLVMDoubleNode.class)
+    public abstract static class LLVMLog extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double value) {
+            return Math.log(value);
+        }
+
+    }
+
+    @NodeChild(type = LLVMDoubleNode.class)
+    public abstract static class LLVMLog10 extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double value) {
+            return Math.log10(value);
+        }
+
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
@@ -37,6 +37,8 @@ import com.oracle.graal.replacements.amd64.AMD64MathSubstitutions;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMAbortFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMLog10Factory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMLogFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMSqrtFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMExitFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMTruffleReadBytesFactory;
@@ -203,6 +205,8 @@ public class LLVMRuntimeIntrinsicFactory {
      */
     private static void intrinsifyCFunctions(Map<String, NodeFactory<? extends LLVMNode>> intrinsics) {
         intrinsics.put("@sqrt", LLVMSqrtFactory.getInstance());
+        intrinsics.put("@log", LLVMLogFactory.getInstance());
+        intrinsics.put("@log10", LLVMLog10Factory.getInstance());
     }
 
 }


### PR DESCRIPTION
The Java `Math.log` and `Math.log10` were intrinsified in Graal with `933145c57eb275f6b05a0c4d2341ec85d6536600`. See https://github.com/graalvm/graal-core/pull/187