### PR TITLE
Set dead `Object` frame slots to a `LLVMAddress(0)` object instead of `null`

### DIFF
--- a/mx.sulong/suite.py
+++ b/mx.sulong/suite.py
@@ -294,6 +294,7 @@ suite = {
       "sourceDirs" : ["src"],
       "dependencies" : [
         "truffle:TRUFFLE_API",
+        "com.oracle.truffle.llvm.types"
       ],
       "checkstyle" : "com.oracle.truffle.llvm.nodes",
       "javaCompliance" : "1.8",

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMFunctionStartNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMFunctionStartNode.java
@@ -87,7 +87,7 @@ public class LLVMFunctionStartNode extends RootNode {
                     initNullers.add(new LLVMStackFrameNuller.LLVMDoubleNuller(slot));
                     break;
                 case Object:
-                    initNullers.add(new LLVMStackFrameNuller.LLVMObjectNuller(slot));
+                    initNullers.add(new LLVMStackFrameNuller.LLVMAddressNuller(slot));
                     break;
                 case Illegal:
                     break;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/base/LLVMStackFrameNuller.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/base/LLVMStackFrameNuller.java
@@ -31,12 +31,13 @@ package com.oracle.truffle.llvm.nodes.base;
 
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.types.LLVMAddress;
 
 public abstract class LLVMStackFrameNuller {
 
     private final FrameSlot frameSlot;
 
-    LLVMStackFrameNuller(FrameSlot slot) {
+    public LLVMStackFrameNuller(FrameSlot slot) {
         this.frameSlot = slot;
     }
 
@@ -44,7 +45,7 @@ public abstract class LLVMStackFrameNuller {
         nullify(frame, frameSlot);
     }
 
-    abstract void nullify(VirtualFrame frame, FrameSlot slot);
+    public abstract void nullify(VirtualFrame frame, FrameSlot slot);
 
     public static final class LLVMBooleanNuller extends LLVMStackFrameNuller {
 
@@ -53,7 +54,7 @@ public abstract class LLVMStackFrameNuller {
         }
 
         @Override
-        void nullify(VirtualFrame frame, FrameSlot slot) {
+        public void nullify(VirtualFrame frame, FrameSlot slot) {
             frame.setBoolean(slot, false);
         }
 
@@ -66,7 +67,7 @@ public abstract class LLVMStackFrameNuller {
         }
 
         @Override
-        void nullify(VirtualFrame frame, FrameSlot slot) {
+        public void nullify(VirtualFrame frame, FrameSlot slot) {
             frame.setByte(slot, (byte) 0);
         }
 
@@ -79,7 +80,7 @@ public abstract class LLVMStackFrameNuller {
         }
 
         @Override
-        void nullify(VirtualFrame frame, FrameSlot slot) {
+        public void nullify(VirtualFrame frame, FrameSlot slot) {
             frame.setInt(slot, 0);
         }
 
@@ -92,7 +93,7 @@ public abstract class LLVMStackFrameNuller {
         }
 
         @Override
-        void nullify(VirtualFrame frame, FrameSlot slot) {
+        public void nullify(VirtualFrame frame, FrameSlot slot) {
             frame.setLong(slot, 0);
         }
 
@@ -105,7 +106,7 @@ public abstract class LLVMStackFrameNuller {
         }
 
         @Override
-        void nullify(VirtualFrame frame, FrameSlot slot) {
+        public void nullify(VirtualFrame frame, FrameSlot slot) {
             frame.setFloat(slot, 0);
         }
 
@@ -118,21 +119,21 @@ public abstract class LLVMStackFrameNuller {
         }
 
         @Override
-        void nullify(VirtualFrame frame, FrameSlot slot) {
+        public void nullify(VirtualFrame frame, FrameSlot slot) {
             frame.setDouble(slot, 0);
         }
 
     }
 
-    public static final class LLVMObjectNuller extends LLVMStackFrameNuller {
+    public static final class LLVMAddressNuller extends LLVMStackFrameNuller {
 
-        public LLVMObjectNuller(FrameSlot slot) {
+        public LLVMAddressNuller(FrameSlot slot) {
             super(slot);
         }
 
         @Override
-        void nullify(VirtualFrame frame, FrameSlot slot) {
-            frame.setObject(slot, null);
+        public void nullify(VirtualFrame frame, FrameSlot slot) {
+            frame.setObject(slot, LLVMAddress.fromLong(0));
         }
 
     }

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeFunctionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeFunctionVisitor.java
@@ -43,7 +43,7 @@ import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMDoubleNuller;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMFloatNuller;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMIntNuller;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMLongNuller;
-import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMObjectNuller;
+import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMAddressNuller;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMBasicBlockNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMTerminatorNode;
@@ -173,7 +173,7 @@ public class LLVMBitcodeFunctionVisitor implements FunctionVisitor {
                     nodes[i++] = new LLVMDoubleNuller(slot);
                     break;
                 case Object:
-                    nodes[i++] = new LLVMObjectNuller(slot);
+                    nodes[i++] = new LLVMAddressNuller(slot);
                     break;
                 case Illegal:
                     throw new AssertionError("illegal");

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -132,7 +132,7 @@ import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMDoubleNuller;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMFloatNuller;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMIntNuller;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMLongNuller;
-import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMObjectNuller;
+import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMAddressNuller;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMParserResult;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
@@ -570,7 +570,14 @@ public final class LLVMVisitor implements LLVMParserRuntime {
             case Double:
                 return new LLVMDoubleNuller(slot);
             case Object:
-                return new LLVMObjectNuller(slot);
+                /**
+                 * It would be cleaner do not distinct between the frame slot kinds but the variable
+                 * type. We cannot simply set the object to null, since phis that have null and
+                 * other Object's inside escape and are allocated. We set a null address here, since
+                 * other Sulong data types that use Object are implement inefficiently anyway. In
+                 * the long term, they should have their own stack nuller.
+                 */
+                return new LLVMAddressNuller(slot);
             case Illegal:
                 throw new AssertionError("illegal");
             default:


### PR DESCRIPTION
Setting the object to `null` will create phi nodes in Graal that have `null` and other `LLVMAddress` objects as input, which escape and are allocated.