### PR TITLE
Set an explicit MIME type for IR files loaded from a Sulong library.

### DIFF
--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/SulongLibrary.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/SulongLibrary.java
@@ -38,7 +38,6 @@ import java.util.function.Consumer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import com.oracle.truffle.api.source.MissingMIMETypeException;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
 
@@ -86,11 +85,7 @@ public class SulongLibrary {
                         }
                     }
                 } else {
-                    try {
-                        handleSource.accept(Source.newBuilder(string).name(file.getPath() + "@" + zipEntry.getName()).build());
-                    } catch (MissingMIMETypeException e) {
-                        throw new AssertionError(e);
-                    }
+                    handleSource.accept(Source.newBuilder(string).name(file.getPath() + "@" + zipEntry.getName()).mimeType(LLVMLanguage.LLVM_IR_MIME_TYPE).build());
                 }
                 zipEntry = zipStream.getNextEntry();
             }


### PR DESCRIPTION
It's a shame - this problem would have been caught by the JRuby test if we didn't have to disable it!