### PR TITLE
Allow .su files to include a list of libraries to load

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
@@ -96,6 +96,10 @@ public class LLVMContext extends ExecutionContext {
         return completeFunctionDescriptors[validFunctionIndex];
     }
 
+    public void addLibraryToNativeLookup(String library) {
+        nativeLookup.addLibraryToNativeLookup(library);
+    }
+
     public long getNativeHandle(String functionName) {
         return nativeLookup.getNativeHandle(functionName);
     }

--- a/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/Linker.java
+++ b/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/Linker.java
@@ -57,27 +57,30 @@ public class Linker {
             while (n < args.length) {
                 final String arg = args[n];
 
-                switch (arg) {
-                    case "-h":
-                    case "-help":
-                    case "--help":
-                    case "/?":
-                    case "/help":
-                        help();
-                        break;
+                if (arg.length() > 0 && arg.charAt(0) == '-') {
+                    switch (arg) {
+                        case "-h":
+                        case "-help":
+                        case "--help":
+                        case "/?":
+                        case "/help":
+                            help();
+                            break;
 
-                    case "-o":
-                        if (n + 1 >= args.length) {
-                            throw new Exception("-o needs to be followed by a file name");
-                        }
+                        case "-o":
+                            if (n + 1 >= args.length) {
+                                throw new Exception("-o needs to be followed by a file name");
+                            }
 
-                        outputFileName = args[n + 1];
-                        n++;
-                        break;
+                            outputFileName = args[n + 1];
+                            n++;
+                            break;
 
-                    default:
-                        bitcodeFileNames.add(arg);
-                        break;
+                        default:
+                            throw new Exception("Unknown argument " + arg);
+                    }
+                } else {
+                    bitcodeFileNames.add(arg);
                 }
 
                 n++;


### PR DESCRIPTION
I did the minimum fix tix up `NativeLookup` to do what I needed here. I can go back and tidy it up later, but it's still got lots of static stuff. I wanted to keep the diff minimal here rather than tidying that up at the same time.

Enables JRuby to build and run C extensions that depend on external libraries like `libxml2` and `libssl`.

https://github.com/jruby/jruby/commit/cc7a72ffc78b04add5bfd2ce314bbe211feb065b