### PR TITLE
Replace Unsafe and Java implementations for C stdlib calls with native calls

### DIFF
--- a/mx.sulong/suite.py
+++ b/mx.sulong/suite.py
@@ -257,6 +257,7 @@ suite = {
       "dependencies" : [
         "com.oracle.truffle.llvm.runtime",
         "truffle:TRUFFLE_API",
+        "graal-core:GRAAL_TRUFFLE_HOTSPOT",
       ],
       "checkstyle" : "com.oracle.truffle.llvm.nodes",
       "javaCompliance" : "1.8",

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/LLVMMemMove.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/LLVMMemMove.java
@@ -48,9 +48,10 @@ public abstract class LLVMMemMove {
                     @NodeChild(type = LLVMI32Node.class, value = "align"), @NodeChild(type = LLVMI1Node.class, value = "isVolatile")})
     public abstract static class LLVMMemMoveI64 extends LLVMNode {
 
+        @SuppressWarnings("unused")
         @Specialization
         public void executeVoid(LLVMAddress dest, LLVMAddress source, long length, int align, boolean isVolatile) {
-            LLVMHeap.memMove(dest, source, length, align, isVolatile);
+            LLVMHeap.memMove(dest, source, length);
         }
 
     }

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
@@ -67,7 +67,7 @@ public final class LLVMHeap extends LLVMMemory {
         long targetAddress = extractAddrNullPointerAllowed(target);
         long sourceAddress = extractAddrNullPointerAllowed(source);
         assert length == 0 || targetAddress != 0 && sourceAddress != 0;
-        UNSAFE.copyMemory(sourceAddress, targetAddress, length);
+        memCopyHandle.call(targetAddress, sourceAddress, length);
     }
 
     public static void memCopy(LLVMAddress target, LLVMAddress source, long length, @SuppressWarnings("unused") int align, @SuppressWarnings("unused") boolean isVolatile) {
@@ -85,10 +85,12 @@ public final class LLVMHeap extends LLVMMemory {
 
     private static final NativeFunctionHandle memMoveHandle;
     private static final NativeFunctionHandle memSetHandle;
+    private static final NativeFunctionHandle memCopyHandle;
 
     static {
         final NativeFunctionInterface nfi = NativeFunctionInterfaceRuntime.getNativeFunctionInterface();
         memMoveHandle = nfi.getFunctionHandle("memmove", void.class, long.class, long.class, long.class);
+        memCopyHandle = nfi.getFunctionHandle("memcpy", void.class, long.class, long.class, long.class);
         memSetHandle = nfi.getFunctionHandle("memset", void.class, long.class, int.class, long.class);
     }
 

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
@@ -49,18 +49,18 @@ public final class LLVMHeap extends LLVMMemory {
     }
 
     public static LLVMAddress allocateMemory(long size) {
-        long allocateMemory = UNSAFE.allocateMemory(size);
+        long allocateMemory = (long) mallocHandle.call(size);
         return LLVMAddress.fromLong(allocateMemory);
     }
 
     public static LLVMAddress allocateZeroedMemory(long l) {
-        long allocateMemory = UNSAFE.allocateMemory(l);
+        long allocateMemory = allocateMemory(l).getVal();
         UNSAFE.setMemory(allocateMemory, l, (byte) 0);
         return LLVMAddress.fromLong(allocateMemory);
     }
 
     public static void freeMemory(LLVMAddress addr) {
-        UNSAFE.freeMemory(extractAddrNullPointerAllowed(addr));
+        freeHandle.call(addr.getVal());
     }
 
     public static void memCopy(LLVMAddress target, LLVMAddress source, long length) {
@@ -86,12 +86,16 @@ public final class LLVMHeap extends LLVMMemory {
     private static final NativeFunctionHandle memMoveHandle;
     private static final NativeFunctionHandle memSetHandle;
     private static final NativeFunctionHandle memCopyHandle;
+    private static final NativeFunctionHandle freeHandle;
+    private static final NativeFunctionHandle mallocHandle;
 
     static {
         final NativeFunctionInterface nfi = NativeFunctionInterfaceRuntime.getNativeFunctionInterface();
         memMoveHandle = nfi.getFunctionHandle("memmove", void.class, long.class, long.class, long.class);
         memCopyHandle = nfi.getFunctionHandle("memcpy", void.class, long.class, long.class, long.class);
         memSetHandle = nfi.getFunctionHandle("memset", void.class, long.class, int.class, long.class);
+        freeHandle = nfi.getFunctionHandle("free", void.class, long.class);
+        mallocHandle = nfi.getFunctionHandle("malloc", long.class, long.class);
     }
 
     public static void memMove(LLVMAddress dest, LLVMAddress source, long length) {

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMHeap.java
@@ -74,9 +74,9 @@ public final class LLVMHeap extends LLVMMemory {
         memCopy(target, source, length);
     }
 
-    public static void memSet(LLVMAddress target, byte value, long length) {
+    public static void memSet(LLVMAddress target, int value, long length) {
         long targetAddress = LLVMMemory.extractAddr(target);
-        UNSAFE.setMemory(targetAddress, length, value);
+        memSetHandle.call(targetAddress, value, length);
     }
 
     public static void memSet(LLVMAddress target, byte value, long length, @SuppressWarnings("unused") int align, @SuppressWarnings("unused") boolean isVolatile) {
@@ -84,10 +84,12 @@ public final class LLVMHeap extends LLVMMemory {
     }
 
     private static final NativeFunctionHandle memMoveHandle;
+    private static final NativeFunctionHandle memSetHandle;
 
     static {
         final NativeFunctionInterface nfi = NativeFunctionInterfaceRuntime.getNativeFunctionInterface();
-        memMoveHandle = nfi.getFunctionHandle("memcpy", void.class, long.class, long.class, long.class);
+        memMoveHandle = nfi.getFunctionHandle("memmove", void.class, long.class, long.class, long.class);
+        memSetHandle = nfi.getFunctionHandle("memset", void.class, long.class, int.class, long.class);
     }
 
     public static void memMove(LLVMAddress dest, LLVMAddress source, long length) {


### PR DESCRIPTION
The naive implementation is around 50 times slower.