### PR TITLE
Give a proper error when trying to store a Truffle object in a native address

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/LLVMStoreNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/LLVMStoreNode.java
@@ -29,6 +29,7 @@
  */
 package com.oracle.truffle.llvm.nodes.impl.memory;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.NodeField;
@@ -208,6 +209,13 @@ public abstract class LLVMStoreNode extends LLVMNode {
         @Specialization
         public void execute(LLVMAddress address, LLVMAddress value) {
             LLVMMemory.putAddress(address, value);
+        }
+
+        @SuppressWarnings("unused")
+        @Specialization
+        public void execute(LLVMAddress address, TruffleObject value) {
+            CompilerDirectives.bailout("unsupported operation");
+            throw new UnsupportedOperationException("Sulong can't store a Truffle object in a native memory address");
         }
 
     }


### PR DESCRIPTION
We can give good error messages like this - with specialisations just for the error cases