### PR TITLE
Add truffle_read_n_string and fix truffle_read_n_bytes interop intrinsic

### DIFF
--- a/include/truffle.h
+++ b/include/truffle.h
@@ -127,6 +127,7 @@ void truffle_write_idx_b(void *object, int idx, bool value);
 
 // Strings
 void *truffle_read_string(const char *string);
+void *truffle_read_n_string(const char *string, int n);
 void *truffle_read_bytes(const char *bytes);
 void *truffle_read_n_bytes(const char *bytes, int n);
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMTruffleReadNBytes.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMTruffleReadNBytes.java
@@ -32,13 +32,13 @@ package com.oracle.truffle.llvm.nodes.impl.intrinsics.interop;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
+import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsic.LLVMAddressIntrinsic;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 
-@NodeChildren({@NodeChild(type = LLVMAddressNode.class), @NodeChild(type = LLVMI32Node.class)})
+@NodeChildren({@NodeChild(type = LLVMExpressionNode.class), @NodeChild(type = LLVMI32Node.class)})
 public abstract class LLVMTruffleReadNBytes extends LLVMAddressIntrinsic {
     @Specialization
     public Object executeIntrinsic(LLVMAddress value, int n) {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMTruffleReadNString.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/LLVMTruffleReadNString.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.intrinsics.interop;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsic.LLVMAddressIntrinsic;
+import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.memory.LLVMMemory;
+
+@NodeChildren({@NodeChild(type = LLVMExpressionNode.class), @NodeChild(type = LLVMI32Node.class)})
+public abstract class LLVMTruffleReadNString extends LLVMAddressIntrinsic {
+    @Specialization
+    @TruffleBoundary
+    public Object executeIntrinsic(LLVMAddress value, int n) {
+        LLVMAddress adr = value;
+        int count = n < 0 ? 0 : n;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < count; i++) {
+            sb.append((char) Byte.toUnsignedInt(LLVMMemory.getI8(adr)));
+            adr = adr.increment(Byte.BYTES);
+        }
+        return sb.toString();
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
@@ -84,6 +84,7 @@ import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleReadFact
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleReadFactory.LLVMTruffleReadIdxPFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleReadFactory.LLVMTruffleReadLFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleReadFactory.LLVMTruffleReadPFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleReadNBytesFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleReadNStringFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleReadStringFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleUnboxFactory.LLVMTruffleUnboxBFactory;
@@ -194,7 +195,7 @@ public class LLVMRuntimeIntrinsicFactory {
         intrinsics.put("@truffle_read_string", LLVMTruffleReadStringFactory.getInstance());
         intrinsics.put("@truffle_read_n_string", LLVMTruffleReadNStringFactory.getInstance());
         intrinsics.put("@truffle_read_bytes", LLVMTruffleReadBytesFactory.getInstance());
-        intrinsics.put("@truffle_read_n_bytes", LLVMTruffleReadBytesFactory.getInstance());
+        intrinsics.put("@truffle_read_n_bytes", LLVMTruffleReadNBytesFactory.getInstance());
 
         intrinsics.put("@truffle_is_truffle_object", LLVMTruffleIsTruffleObjectFactory.getInstance());
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
@@ -84,6 +84,7 @@ import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleReadFact
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleReadFactory.LLVMTruffleReadIdxPFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleReadFactory.LLVMTruffleReadLFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleReadFactory.LLVMTruffleReadPFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleReadNStringFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleReadStringFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleUnboxFactory.LLVMTruffleUnboxBFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleUnboxFactory.LLVMTruffleUnboxCFactory;
@@ -191,6 +192,7 @@ public class LLVMRuntimeIntrinsicFactory {
         intrinsics.put("@truffle_get_size", LLVMTruffleGetSizeFactory.getInstance());
 
         intrinsics.put("@truffle_read_string", LLVMTruffleReadStringFactory.getInstance());
+        intrinsics.put("@truffle_read_n_string", LLVMTruffleReadNStringFactory.getInstance());
         intrinsics.put("@truffle_read_bytes", LLVMTruffleReadBytesFactory.getInstance());
         intrinsics.put("@truffle_read_n_bytes", LLVMTruffleReadBytesFactory.getInstance());
 

--- a/projects/com.oracle.truffle.llvm.test/interoptests/interop028.c
+++ b/projects/com.oracle.truffle.llvm.test/interoptests/interop028.c
@@ -1,0 +1,6 @@
+#include <truffle.h>
+
+int main() {
+  truffle_execute(truffle_import("foo"), truffle_read_n_string("foo\x00 bar\x80 bla", 10));
+  return 72;
+}

--- a/projects/com.oracle.truffle.llvm.test/interoptests/interop029.c
+++ b/projects/com.oracle.truffle.llvm.test/interoptests/interop029.c
@@ -1,0 +1,6 @@
+#include <truffle.h>
+
+int main() {
+  truffle_execute(truffle_import("foo"), truffle_read_n_bytes("foo\x00 bar\x80 bla", 10));
+  return 36;
+}

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/interop/LLVMInteropTest.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/interop/LLVMInteropTest.java
@@ -338,6 +338,15 @@ public final class LLVMInteropTest {
         Assert.assertEquals("foo\u0000 bar\u0080 ", result[0]);
     }
 
+    @Test
+    public void test029() {
+        Runner runner = new Runner("interop029");
+        final Object[] result = new Object[]{null};
+        runner.export(JavaInterop.asTruffleFunction(FuncEInterface.class, x -> result[0] = x), "foo");
+        Assert.assertEquals(36, runner.run());
+        Assert.assertArrayEquals(new byte[]{102, 111, 111, 0, 32, 98, 97, 114, -128, 32}, (byte[]) result[0]);
+    }
+
     public static final class ClassA {
         public boolean valueBool = true;
         public byte valueB = 40;

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/interop/LLVMInteropTest.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/interop/LLVMInteropTest.java
@@ -329,6 +329,15 @@ public final class LLVMInteropTest {
                         result[0]);
     }
 
+    @Test
+    public void test028() {
+        Runner runner = new Runner("interop028");
+        final Object[] result = new Object[]{null};
+        runner.export(JavaInterop.asTruffleFunction(FuncEInterface.class, x -> result[0] = x), "foo");
+        Assert.assertEquals(72, runner.run());
+        Assert.assertEquals("foo\u0000 bar\u0080 ", result[0]);
+    }
+
     public static final class ClassA {
         public boolean valueBool = true;
         public byte valueB = 40;


### PR DESCRIPTION
`truffle_read_n_string` is necessary for Ruby's `rb_str_new` function that allows specifying a length.