### PR TITLE
Set heap size for junit tests

### DIFF
--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -580,7 +580,7 @@ def getSearchPathOption(lib_args=None):
     return '-Dsulong.DynamicNativeLibraryPath=' + ':'.join(lib_names)
 
 def getCommonUnitTestOptions():
-    return getCommonOptions() + ['-Xss56m', getLLVMRootOption(), '-ea', '-esa']
+    return getCommonOptions() + ['-Xss56m', '-Xms2g', '-Xmx2g', getLLVMRootOption(), '-ea', '-esa']
 
 # PE does not work yet for all test cases
 def compilationSucceedsOption():


### PR DESCRIPTION
Right now, there is no heap size specified for the JUnit tests. Therefore, the JVM selects a heap size depending on the system's RAM size, but on systems with 4GB of RAM, this default is too small for the GCC JUnit test suite.

This change sets a fixed JVM heap size (2GB), such that it is independent of the system's RAM size.