### PR TITLE
Add exp and pow intrinsics for the C standard library functions

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMCMathsIntrinsics.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMCMathsIntrinsics.java
@@ -30,6 +30,7 @@
 package com.oracle.truffle.llvm.nodes.impl.intrinsics.c;
 
 import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.llvm.nodes.impl.base.floating.LLVMDoubleNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
@@ -119,6 +120,26 @@ public abstract class LLVMCMathsIntrinsics {
         @Specialization
         public double executeIntrinsic(double value) {
             return Math.abs(value);
+        }
+
+    }
+
+    @NodeChild(type = LLVMDoubleNode.class)
+    public abstract static class LLVMExp extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double value) {
+            return Math.exp(value);
+        }
+
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMDoubleNode.class), @NodeChild(type = LLVMDoubleNode.class)})
+    public abstract static class LLVMPow extends LLVMDoubleIntrinsic {
+
+        @Specialization
+        public double executeIntrinsic(double a, double b) {
+            return Math.pow(a, b);
         }
 
     }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
@@ -38,11 +38,13 @@ import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMAbortFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMAbsFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMCeilFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMExpFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMFAbsFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMFloorFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMLAbsFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMLog10Factory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMLogFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMPowFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMRintFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMSqrtFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMExitFactory;
@@ -219,6 +221,8 @@ public class LLVMRuntimeIntrinsicFactory {
         intrinsics.put("@abs", LLVMAbsFactory.getInstance());
         intrinsics.put("@labs", LLVMLAbsFactory.getInstance());
         intrinsics.put("@fabs", LLVMFAbsFactory.getInstance());
+        intrinsics.put("@pow", LLVMPowFactory.getInstance());
+        intrinsics.put("@exp", LLVMExpFactory.getInstance());
     }
 
 }


### PR DESCRIPTION
Some measurements on microbenchmarks that call the functions with different values in a loop:

pow:
    native call: 585
    intrinsification before Intel PR: 2007
    intrinsification after Intel PR: 162

exp:
    native call: 160
    intrinsification before Intel PR: 160
    intrinsification after Intel PR: 56