### PR TITLE
Fix the LLVMAddress arg conversion in indirect calls with native functions

### DIFF
--- a/projects/com.oracle.truffle.llvm.test/tests/c/native-call-arg-conv-363.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/native-call-arg-conv-363.c
@@ -1,0 +1,8 @@
+#include <string.h>
+
+int main(void) {
+  char test[512];
+  static void *(*const volatile memset_v)(void *, int, size_t) = &memset;
+  memset_v(test, 0, 512);
+  return 0;
+}


### PR DESCRIPTION
Fixes https://github.com/graalvm/sulong/issues/363.