### PR TITLE
Add lifetime analysis tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ projects/com.intel.llvm.ireditor/build.properties
 projects/com.intel.llvm.ireditor/src_gen/**
 projects/com.intel.llvm.ireditor/xtend-gen/**
 projects/com.intel.llvm.ireditor/.launch/**
+projects/com.oracle.truffle.llvm.test/lifetime/**

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -141,6 +141,8 @@ def travis3(args=None):
         if t: runNWCCTestCases()
     with Task('TestGCCSuiteCompile', tasks) as t:
         if t: runCompileTestCases()
+    with Task('TestLifetime', tasks) as t:
+        if t: runLifetimeTestCases()
 
 def travisJRuby(args=None):
     """executes the JRuby Travis job (Javac build, JRuby test cases)"""
@@ -520,6 +522,11 @@ def runTypeTestCases(args=None):
     """runs the type test cases"""
     vmArgs, _ = truffle_extract_VM_args(args)
     return unittest(getCommonUnitTestOptions() + vmArgs + ['com.oracle.truffle.llvm.types.floating.test'])
+
+def runLifetimeTestCases(args=None):
+    """runs the lifetime analysis test cases"""
+    vmArgs, _ = truffle_extract_VM_args(args)
+    return unittest(getCommonUnitTestOptions() + vmArgs + ['com.oracle.truffle.llvm.test.TestLifetimeAnalysisGCC'])
 
 def runPolyglotTestCases(args=None):
     """runs the type test cases"""
@@ -943,6 +950,7 @@ mx.update_commands(_suite, {
     'su-tests-compile' : [runCompileTestCases, ''],
     'su-tests-jruby' : [runTestJRuby, ''],
     'su-tests-argon2' : [runTestArgon2, ''],
+    'su-tests-lifetime' : [runLifetimeTestCases, ''],
     'su-local-gate' : [localGate, ''],
     'su-clang' : [compileWithClang, ''],
     'su-clang++' : [compileWithClangPP, ''],

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -19,6 +19,7 @@ _root = join(_suite.dir, "projects/")
 _parserDir = join(_root, "com.intel.llvm.ireditor")
 _testDir = join(_root, "com.oracle.truffle.llvm.test/")
 _argon2Dir = join(_testDir, "argon2/phc-winner-argon2/")
+_lifetimeReferenceDir = join(_testDir, "lifetime/")
 _toolDir = join(_root, "com.oracle.truffle.llvm.tools/")
 _clangPath = _toolDir + 'tools/llvm/bin/clang'
 
@@ -431,6 +432,14 @@ def pullArgon2(args=None):
     tar(localPath, _argon2Dir, ['phc-winner-argon2-20160406/'], stripLevels=1)
     os.remove(localPath)
 
+def pullLifetime(args=None):
+    """downloads the lifetime reference outputs"""
+    mx.ensure_dir_exists(_lifetimeReferenceDir)
+    urls = ["https://lafo.ssw.uni-linz.ac.at/pub/sulong-deps/lifetime-analysis-ref.tar.gz"]
+    localPath = pullsuite(_lifetimeReferenceDir, urls)
+    tar(localPath, _lifetimeReferenceDir)
+    os.remove(localPath)
+
 def truffle_extract_VM_args(args, useDoubleDash=False):
     vmArgs, remainder = [], []
     if args is not None:
@@ -525,6 +534,7 @@ def runTypeTestCases(args=None):
 
 def runLifetimeTestCases(args=None):
     """runs the lifetime analysis test cases"""
+    ensureLifetimeReferenceExists()
     vmArgs, _ = truffle_extract_VM_args(args)
     return unittest(getCommonUnitTestOptions() + vmArgs + ['com.oracle.truffle.llvm.test.TestLifetimeAnalysisGCC'])
 
@@ -770,6 +780,11 @@ def ensureArgon2Exists():
     """downloads Argon2 if not downloaded yet"""
     if not os.path.exists(_argon2Dir):
         pullArgon2()
+
+def ensureLifetimeReferenceExists():
+    """downloads the lifetime analysis reference outputs if not downloaded yet"""
+    if not os.path.exists(_lifetimeReferenceDir):
+        pullLifetime()
 
 def suBench(args=None):
     """runs a given benchmark with Sulong"""

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMPhiVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMPhiVisitor.java
@@ -53,7 +53,7 @@ public final class LLVMPhiVisitor {
 
     private final Map<BasicBlock, List<Phi>> basicBlockReferences = new HashMap<>();
 
-    static class Phi {
+    public static class Phi {
 
         private final ValueRef valueRef;
         private final Type type;

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMReadVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMReadVisitor.java
@@ -249,7 +249,7 @@ public final class LLVMReadVisitor {
             LocalValueRef localValueRef = (LocalValueRef) valueRef;
             LocalValue localValue = localValueRef.getRef();
             String name = localValue.getName();
-            reads.add(frameDescriptor.findFrameSlot(name));
+            reads.add(frameDescriptor.findOrAddFrameSlot(name));
         } else {
             throw new AssertionError(valueRef);
         }

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -126,24 +126,25 @@ import com.oracle.truffle.llvm.nativeint.NativeLookup;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller;
+import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMAddressNuller;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMBooleanNuller;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMByteNuller;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMDoubleNuller;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMFloatNuller;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMIntNuller;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMLongNuller;
-import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller.LLVMAddressNuller;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMParserResult;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.LLVMType;
 import com.oracle.truffle.llvm.parser.NodeFactoryFacade;
-import com.oracle.truffle.llvm.parser.impl.LLVMLifeTimeAnalysisVisitor.LifeTimeAnalysisResult;
 import com.oracle.truffle.llvm.parser.impl.LLVMPhiVisitor.Phi;
 import com.oracle.truffle.llvm.parser.impl.layout.DataLayoutConverter;
 import com.oracle.truffle.llvm.parser.impl.layout.DataLayoutConverter.DataSpecConverter;
 import com.oracle.truffle.llvm.parser.impl.layout.DataLayoutParser;
 import com.oracle.truffle.llvm.parser.impl.layout.DataLayoutParser.DataTypeSpecification;
+import com.oracle.truffle.llvm.parser.impl.lifetime.LLVMLifeTimeAnalysisResult;
+import com.oracle.truffle.llvm.parser.impl.lifetime.LLVMLifeTimeAnalysisVisitor;
 import com.oracle.truffle.llvm.parser.instructions.LLVMArithmeticInstructionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
@@ -540,7 +541,7 @@ public final class LLVMVisitor implements LLVMParserRuntime {
         Map<BasicBlock, FrameSlot[]> deadSlotsAtBeginBlock;
         Map<BasicBlock, FrameSlot[]> deadSlotsAfterBlock;
         if (LLVMBaseOptionFacade.lifeTimeAnalysisEnabled()) {
-            LifeTimeAnalysisResult analysisResult = LLVMLifeTimeAnalysisVisitor.visit(def, frameDescriptor);
+            LLVMLifeTimeAnalysisResult analysisResult = LLVMLifeTimeAnalysisVisitor.visit(def, frameDescriptor);
             deadSlotsAtBeginBlock = analysisResult.getBeginDead();
             deadSlotsAfterBlock = analysisResult.getEndDead();
         } else {

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/lifetime/LLVMLifeTimeAnalysisResult.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/lifetime/LLVMLifeTimeAnalysisResult.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.parser.impl.lifetime;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.intel.llvm.ireditor.lLVM_IR.BasicBlock;
+import com.oracle.truffle.api.frame.FrameSlot;
+
+public abstract class LLVMLifeTimeAnalysisResult {
+
+    /**
+     * Gets the local variables which are dead at the beginning of a basic block.
+     *
+     * @return the basic blocks which are dead at the beginning of a basic block
+     */
+    public abstract Map<BasicBlock, FrameSlot[]> getBeginDead();
+
+    /**
+     * Gets the local variables which are dead at the end of a basic block.
+     *
+     * @return the basic blocks which are dead at the end of a basic block
+     */
+    public abstract Map<BasicBlock, FrameSlot[]> getEndDead();
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof LLVMLifeTimeAnalysisResult)) {
+            return false;
+        }
+        LLVMLifeTimeAnalysisResult other = (LLVMLifeTimeAnalysisResult) obj;
+        return equals(getBeginDead(), other.getBeginDead()) && equals(getEndDead(), other.getEndDead());
+    }
+
+    private static boolean equals(Map<BasicBlock, FrameSlot[]> map, Map<BasicBlock, FrameSlot[]> otherMap) {
+        if (map.size() != otherMap.size()) {
+            return false;
+        }
+        if (!getBasicBlockNames(map).equals(getBasicBlockNames(otherMap))) {
+            return false;
+        }
+        for (BasicBlock b : map.keySet()) {
+            FrameSlot[] frameSlots = map.get(b);
+            FrameSlot[] otherFrameSlots = otherMap.get(findBasicBlock(b.getName(), otherMap));
+            boolean equals = asStrings(frameSlots).equals(asStrings(otherFrameSlots));
+            if (!equals) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Set<String> asStrings(FrameSlot[] frameSlots) {
+        Set<String> frameSlotNames = new HashSet<>();
+        for (FrameSlot slot : frameSlots) {
+            frameSlotNames.add(slot.getIdentifier().toString());
+        }
+        return frameSlotNames;
+    }
+
+    private static BasicBlock findBasicBlock(String name, Map<BasicBlock, FrameSlot[]> map) {
+        for (BasicBlock b : map.keySet()) {
+            if (b.getName().equals(name)) {
+                return b;
+            }
+        }
+        throw new AssertionError(name);
+    }
+
+    private static Set<String> getBasicBlockNames(Map<BasicBlock, FrameSlot[]> blockSlotMap) {
+        Set<String> basicBlockNames = new HashSet<>();
+        for (BasicBlock b : blockSlotMap.keySet()) {
+            basicBlockNames.add(b.getName());
+        }
+        return basicBlockNames;
+    }
+
+    @Override
+    public int hashCode() {
+        return getBeginDead().hashCode() + 11 * getEndDead().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("begin dead [");
+        sb.append(frameSlotToString(getBeginDead()));
+        sb.append("], end dead [");
+        sb.append(frameSlotToString(getEndDead()));
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private static String frameSlotToString(Map<BasicBlock, FrameSlot[]> beginDead) {
+        StringBuilder sb = new StringBuilder();
+        for (BasicBlock bb : beginDead.keySet()) {
+            sb.append(bb.getName() + " (");
+            FrameSlot[] slots = beginDead.get(bb);
+            for (int i = 0; i < slots.length; i++) {
+                if (i != 0) {
+                    sb.append(", ");
+                }
+                sb.append(slots[i].getIdentifier());
+            }
+            sb.append(")");
+        }
+        return sb.toString();
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/lifetime/LLVMLifeTimeAnalysisVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/lifetime/LLVMLifeTimeAnalysisVisitor.java
@@ -27,7 +27,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.oracle.truffle.llvm.parser.impl;
+package com.oracle.truffle.llvm.parser.impl.lifetime;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,7 +59,9 @@ import com.intel.llvm.ireditor.lLVM_IR.impl.Instruction_brImpl;
 import com.intel.llvm.ireditor.lLVM_IR.impl.LocalValueRefImpl;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.llvm.parser.impl.LLVMPhiVisitor;
 import com.oracle.truffle.llvm.parser.impl.LLVMPhiVisitor.Phi;
+import com.oracle.truffle.llvm.parser.impl.LLVMReadVisitor;
 import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
 
 /**
@@ -82,17 +84,19 @@ public final class LLVMLifeTimeAnalysisVisitor {
         phiRefs = LLVMPhiVisitor.visit(function);
     }
 
-    public static class LifeTimeAnalysisResult {
+    static class LifeTimeAnalysisResultImpl implements LLVMLifeTimeAnalysisResult {
 
-        public LifeTimeAnalysisResult(Map<BasicBlock, FrameSlot[]> beginDead, Map<BasicBlock, FrameSlot[]> endDead) {
+        public LifeTimeAnalysisResultImpl(Map<BasicBlock, FrameSlot[]> beginDead, Map<BasicBlock, FrameSlot[]> endDead) {
             this.beginDead = beginDead;
             this.endDead = endDead;
         }
 
+        @Override
         public Map<BasicBlock, FrameSlot[]> getBeginDead() {
             return beginDead;
         }
 
+        @Override
         public Map<BasicBlock, FrameSlot[]> getEndDead() {
             return endDead;
         }
@@ -102,8 +106,8 @@ public final class LLVMLifeTimeAnalysisVisitor {
 
     }
 
-    public static LifeTimeAnalysisResult visit(FunctionDef function, FrameDescriptor frameDescriptor) {
-        LifeTimeAnalysisResult mapping = new LLVMLifeTimeAnalysisVisitor(function, frameDescriptor).visit();
+    public static LLVMLifeTimeAnalysisResult visit(FunctionDef function, FrameDescriptor frameDescriptor) {
+        LifeTimeAnalysisResultImpl mapping = new LLVMLifeTimeAnalysisVisitor(function, frameDescriptor).visit();
         if (LLVMBaseOptionFacade.printLifeTimeAnalysis()) {
             printAnalysisResults(function, mapping.getEndDead());
         }
@@ -161,7 +165,7 @@ public final class LLVMLifeTimeAnalysisVisitor {
 
     }
 
-    private LifeTimeAnalysisResult visit() {
+    private LifeTimeAnalysisResultImpl visit() {
         initializeInstructionReads();
         initializeInstructionInOuts();
         initializeVariableDefinitions();
@@ -173,7 +177,7 @@ public final class LLVMLifeTimeAnalysisVisitor {
             Set<FrameSlot> bbBegin = bbBeginKills.get(block);
             beginKills.put(block, bbBegin.toArray(new FrameSlot[bbBegin.size()]));
         }
-        return new LifeTimeAnalysisResult(beginKills, endKills);
+        return new LifeTimeAnalysisResultImpl(beginKills, endKills);
     }
 
     private Map<Instruction, List<FrameSlot>> instructionReads = new HashMap<>();

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/lifetime/LLVMLifeTimeAnalysisVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/lifetime/LLVMLifeTimeAnalysisVisitor.java
@@ -59,6 +59,7 @@ import com.intel.llvm.ireditor.lLVM_IR.impl.Instruction_brImpl;
 import com.intel.llvm.ireditor.lLVM_IR.impl.LocalValueRefImpl;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.llvm.parser.impl.LLVMParserAsserts;
 import com.oracle.truffle.llvm.parser.impl.LLVMPhiVisitor;
 import com.oracle.truffle.llvm.parser.impl.LLVMPhiVisitor.Phi;
 import com.oracle.truffle.llvm.parser.impl.LLVMReadVisitor;
@@ -84,9 +85,9 @@ public final class LLVMLifeTimeAnalysisVisitor {
         phiRefs = LLVMPhiVisitor.visit(function);
     }
 
-    static class LifeTimeAnalysisResultImpl implements LLVMLifeTimeAnalysisResult {
+    static class LifeTimeAnalysisResultImpl extends LLVMLifeTimeAnalysisResult {
 
-        public LifeTimeAnalysisResultImpl(Map<BasicBlock, FrameSlot[]> beginDead, Map<BasicBlock, FrameSlot[]> endDead) {
+        LifeTimeAnalysisResultImpl(Map<BasicBlock, FrameSlot[]> beginDead, Map<BasicBlock, FrameSlot[]> endDead) {
             this.beginDead = beginDead;
             this.endDead = endDead;
         }
@@ -107,6 +108,7 @@ public final class LLVMLifeTimeAnalysisVisitor {
     }
 
     public static LLVMLifeTimeAnalysisResult visit(FunctionDef function, FrameDescriptor frameDescriptor) {
+        LLVMParserAsserts.assertNoNullElement(frameDescriptor.getSlots());
         LifeTimeAnalysisResultImpl mapping = new LLVMLifeTimeAnalysisVisitor(function, frameDescriptor).visit();
         if (LLVMBaseOptionFacade.printLifeTimeAnalysis()) {
             printAnalysisResults(function, mapping.getEndDead());
@@ -263,7 +265,8 @@ public final class LLVMLifeTimeAnalysisVisitor {
             while (it.hasNext()) {
                 blockKills.addAll(bbEndKills.get(it.next()));
             }
-            convertedMap.put(bb, blockKills.toArray(new FrameSlot[blockKills.size()]));
+            FrameSlot[] blockKillArr = blockKills.toArray(new FrameSlot[blockKills.size()]);
+            convertedMap.put(bb, blockKillArr);
         }
         return convertedMap;
     }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/options/LLVMBaseOption.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/options/LLVMBaseOption.java
@@ -57,6 +57,12 @@ public enum LLVMBaseOption implements LLVMOption {
                     false,
                     LLVMOptions::parseBoolean,
                     PropertyCategory.TESTS),
+    LIFETIME_TEST_GENERATE_REFERENCE_OUTPUT(
+                    "LifetimeTestsGenerateReferenceOutput",
+                    "Generate the reference output file for the lifetime test cases based on the current version of the lifetime analysis.",
+                    false,
+                    LLVMOptions::parseBoolean,
+                    PropertyCategory.TESTS),
     TEST_DISCOVERY_PATH(
                     "TestDiscoveryPath",
                     "Looks for newly supported test cases in the specified path. E.g., when executing the GCC test cases you can use /gcc.c-torture/execute to discover newly working torture test cases.",

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/options/LLVMBaseOptionFacade.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/options/LLVMBaseOptionFacade.java
@@ -101,6 +101,10 @@ public final class LLVMBaseOptionFacade {
         return LLVMOptions.getParsedProperty(LLVMBaseOption.REMOTE_TEST_CASES_AS_LOCAL);
     }
 
+    public static boolean generateLifetimeReferenceOutput() {
+        return LLVMOptions.getParsedProperty(LLVMBaseOption.LIFETIME_TEST_GENERATE_REFERENCE_OUTPUT);
+    }
+
     public static boolean printPerformanceWarnings() {
         return LLVMOptions.getParsedProperty(LLVMBaseOption.PRINT_PERFORMANCE_WARNINGS);
     }

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/LLVMPaths.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/LLVMPaths.java
@@ -47,6 +47,7 @@ public final class LLVMPaths {
     static final File PROJECT_ROOT = new File(LLVMBaseOptionFacade.getProjectRoot() + File.separator + LLVMPaths.class.getPackage().getName());
 
     public static final File LOCAL_TESTS = new File(PROJECT_ROOT, "tests/");
+    static final File LIFETIME_ANALYSIS_REFERENCE_FILES = new File(PROJECT_ROOT, "lifetime/");
     static final File EXTERNAL_TEST_SUITES = new File(PROJECT_ROOT, "suites/");
     static final File EXTERNAL_TEST_SUITES_EXECUTION_CONFIG = new File(PROJECT_ROOT, "suites-configs/");
     static final File EXTERNAL_TEST_SUITES_COMPILE_CONFIG = new File(PROJECT_ROOT, "suites-configs-compile/");

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestLifetimeAnalysisGCC.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestLifetimeAnalysisGCC.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.emf.common.notify.Adapter;
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EOperation;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.intel.llvm.ireditor.lLVM_IR.BasicBlock;
+import com.intel.llvm.ireditor.lLVM_IR.FunctionDef;
+import com.intel.llvm.ireditor.lLVM_IR.Instruction;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.llvm.parser.impl.LLVMWriteVisitor;
+import com.oracle.truffle.llvm.parser.impl.lifetime.LLVMLifeTimeAnalysisResult;
+import com.oracle.truffle.llvm.parser.impl.lifetime.LLVMLifeTimeAnalysisVisitor;
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
+import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
+import com.oracle.truffle.llvm.test.FunctionVisitorIterator.LLVMFunctionVisitor;
+
+@RunWith(Parameterized.class)
+public class TestLifetimeAnalysisGCC extends TestSuiteBase {
+
+    private static final String FUNCTION_INDENT = "";
+    private static final String BEGIN_DEAD_END_INDENT = "\t";
+    private static final String BASIC_BLOCK_INDENT = "\t\t";
+    private static final String VARIABLE_INDENT = "\t\t\t";
+
+    private static final String BEGIN_DEAD = BEGIN_DEAD_END_INDENT + "begin dead:";
+    private static final String END_DEAD = BEGIN_DEAD_END_INDENT + "end dead:";
+
+    private TestCaseFiles tuple;
+    private File referenceOutputFile;
+    private final PrintStream printStream;
+    private BufferedReader referenceFileReader;
+    private Map<String, LLVMLifeTimeAnalysisResult> referenceResults;
+
+    public TestLifetimeAnalysisGCC(TestCaseFiles tuple) throws IOException {
+        this.tuple = tuple;
+        setUpReferenceFilePath(tuple);
+        if (LLVMBaseOptionFacade.generateLifetimeReferenceOutput()) {
+            referenceOutputFile.getParentFile().mkdirs();
+            printStream = new PrintStream(referenceOutputFile);
+        } else {
+            printStream = null;
+            FileInputStream fis = new FileInputStream(referenceOutputFile);
+            referenceFileReader = new BufferedReader(new InputStreamReader(fis));
+            referenceResults = parseReferenceResults();
+        }
+    }
+
+    private void setUpReferenceFilePath(TestCaseFiles tuple) {
+        String referenceFileRelative = tuple.getOriginalFile().getAbsolutePath().substring(LLVMPaths.GCC_TEST_SUITE.getAbsolutePath().length() + 1) + ".lifetime";
+        referenceOutputFile = new File(LLVMPaths.LIFETIME_ANALYSIS_REFERENCE_FILES, referenceFileRelative);
+    }
+
+    @Parameterized.Parameters
+    public static List<TestCaseFiles[]> getTestFiles() throws IOException {
+        File configFile = LLVMPaths.GCC_TEST_SUITE_CONFIG;
+        File testSuite = LLVMPaths.GCC_TEST_SUITE;
+        List<TestCaseFiles[]> files = getTestCasesFromConfigFile(configFile, testSuite, new TestCaseGeneratorImpl(false));
+        return files;
+    }
+
+    private enum ParseState {
+        LOOKING_FOR_FUNCTION,
+        LOOKING_FOR_BEGIN_DEAD,
+        LOOKING_FOR_BLOCK_OR_END_DEAD,
+        LOOKING_FOR_BLOCK_OR_END,
+        LOOKING_FOR_VARIABLE_BEGIN,
+        LOOKING_FOR_VARIABLE_END;
+    }
+
+    @Test
+    public void test() throws Throwable {
+        try {
+            LLVMLogger.info("original file: " + tuple.getOriginalFile());
+
+            FunctionVisitorIterator.visitFunctions(new LLVMFunctionVisitor() {
+
+                @Override
+                public void visit(FunctionDef def) {
+                    Set<String> writes = LLVMWriteVisitor.visit(def);
+                    FrameDescriptor frameDescriptor = new FrameDescriptor();
+                    for (String variableName : writes) {
+                        frameDescriptor.findOrAddFrameSlot(variableName);
+                    }
+                    LLVMLifeTimeAnalysisResult analysisResult = LLVMLifeTimeAnalysisVisitor.visit(def,
+                                    frameDescriptor);
+                    String functionName = def.getHeader().getName();
+                    if (LLVMBaseOptionFacade.generateLifetimeReferenceOutput()) {
+                        printStringln(functionName);
+                        printStringln(BEGIN_DEAD);
+                        Map<BasicBlock, FrameSlot[]> beginDead = analysisResult.getBeginDead();
+                        printBasicBlockVariables(beginDead);
+                        printStringln(END_DEAD);
+                        Map<BasicBlock, FrameSlot[]> endDead = analysisResult.getEndDead();
+                        printBasicBlockVariables(endDead);
+                    } else {
+                        LLVMLifeTimeAnalysisResult expected = referenceResults.get(functionName);
+                        Assert.assertEquals(functionName, expected, analysisResult);
+                    }
+                }
+
+            }, tuple.getBitCodeFile());
+        } catch (Throwable e) {
+            recordError(tuple, e);
+            throw e;
+        }
+    }
+
+    private static BasicBlock createBasicBlock(String name) {
+        return new BasicBlock() {
+
+            @Override
+            public void eSetDeliver(boolean arg0) {
+            }
+
+            @Override
+            public void eNotify(Notification arg0) {
+            }
+
+            @Override
+            public boolean eDeliver() {
+                return false;
+            }
+
+            @Override
+            public EList<Adapter> eAdapters() {
+                return null;
+            }
+
+            @Override
+            public void eUnset(EStructuralFeature arg0) {
+            }
+
+            @Override
+            public void eSet(EStructuralFeature arg0, Object arg1) {
+            }
+
+            @Override
+            public Resource eResource() {
+                return null;
+            }
+
+            @Override
+            public boolean eIsSet(EStructuralFeature arg0) {
+                return false;
+            }
+
+            @Override
+            public boolean eIsProxy() {
+                return false;
+            }
+
+            @Override
+            public Object eInvoke(EOperation arg0, EList<?> arg1) throws InvocationTargetException {
+                return null;
+            }
+
+            @Override
+            public Object eGet(EStructuralFeature arg0, boolean arg1) {
+                return null;
+            }
+
+            @Override
+            public Object eGet(EStructuralFeature arg0) {
+                return null;
+            }
+
+            @Override
+            public EList<EObject> eCrossReferences() {
+                return null;
+            }
+
+            @Override
+            public EList<EObject> eContents() {
+                return null;
+            }
+
+            @Override
+            public EReference eContainmentFeature() {
+                return null;
+            }
+
+            @Override
+            public EStructuralFeature eContainingFeature() {
+                return null;
+            }
+
+            @Override
+            public EObject eContainer() {
+                return null;
+            }
+
+            @Override
+            public EClass eClass() {
+                return null;
+            }
+
+            @Override
+            public TreeIterator<EObject> eAllContents() {
+                return null;
+            }
+
+            @Override
+            public void setName(String arg0) {
+            }
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public EList<Instruction> getInstructions() {
+                return null;
+            }
+        };
+    }
+
+    private Map<String, LLVMLifeTimeAnalysisResult> parseReferenceResults() throws IOException {
+        ParseState state = ParseState.LOOKING_FOR_FUNCTION;
+        boolean deadAtBeginning = true;
+        String block = null;
+        FrameDescriptor descr = new FrameDescriptor();
+        Map<BasicBlock, FrameSlot[]> beginDead = new HashMap<>();
+        Map<BasicBlock, FrameSlot[]> endDead = new HashMap<>();
+        Map<String, LLVMLifeTimeAnalysisResult> results = new HashMap<>();
+        String functionName = null;
+        Set<FrameSlot> slots = new HashSet<>();
+        while (referenceFileReader.ready()) {
+            String line = referenceFileReader.readLine();
+            switch (state) {
+                case LOOKING_FOR_FUNCTION:
+                    if (line.startsWith(FUNCTION_INDENT)) {
+                        state = ParseState.LOOKING_FOR_BEGIN_DEAD;
+                        functionName = line;
+                    } else {
+                        throw new AssertionError(line);
+                    }
+                    break;
+                case LOOKING_FOR_BEGIN_DEAD:
+                    if (line.equals(BEGIN_DEAD)) {
+                        state = ParseState.LOOKING_FOR_BLOCK_OR_END_DEAD;
+                        deadAtBeginning = true;
+                    } else {
+                        throw new AssertionError(line);
+                    }
+                    break;
+                case LOOKING_FOR_BLOCK_OR_END_DEAD:
+                    if (line.equals(END_DEAD)) {
+                        deadAtBeginning = false;
+                        state = ParseState.LOOKING_FOR_BLOCK_OR_END;
+                    } else if (line.startsWith(BASIC_BLOCK_INDENT)) {
+                        block = line.substring(BASIC_BLOCK_INDENT.length());
+                        state = ParseState.LOOKING_FOR_VARIABLE_BEGIN;
+                    } else {
+                        throw new AssertionError(line);
+                    }
+                    break;
+                case LOOKING_FOR_VARIABLE_BEGIN:
+                    if (line.startsWith(VARIABLE_INDENT)) {
+                        String variableName = line.substring(VARIABLE_INDENT.length());
+                        slots.add(descr.findOrAddFrameSlot(variableName));
+                    } else if (line.startsWith(BASIC_BLOCK_INDENT)) {
+                        finishEntry(deadAtBeginning, block, beginDead, endDead, slots);
+                        block = line.substring(BASIC_BLOCK_INDENT.length());
+                        state = ParseState.LOOKING_FOR_VARIABLE_BEGIN;
+                    } else if (line.startsWith(END_DEAD)) {
+                        finishEntry(deadAtBeginning, block, beginDead, endDead, slots);
+                        deadAtBeginning = false;
+                        state = ParseState.LOOKING_FOR_BLOCK_OR_END;
+                    } else {
+                        throw new AssertionError(line);
+                    }
+                    break;
+                case LOOKING_FOR_BLOCK_OR_END:
+                    if (line.startsWith(BASIC_BLOCK_INDENT)) {
+                        block = line.substring(BASIC_BLOCK_INDENT.length());
+                        state = ParseState.LOOKING_FOR_VARIABLE_END;
+                    } else if (line.startsWith(FUNCTION_INDENT)) {
+                        finishEntry(deadAtBeginning, block, beginDead, endDead, slots);
+                        results.put(functionName, result(beginDead, endDead));
+                        beginDead = new HashMap<>();
+                        endDead = new HashMap<>();
+                    } else {
+                        throw new AssertionError(line);
+                    }
+                    break;
+                case LOOKING_FOR_VARIABLE_END:
+                    if (line.startsWith(VARIABLE_INDENT)) {
+                        String variableName = line.substring(VARIABLE_INDENT.length());
+                        slots.add(descr.findOrAddFrameSlot(variableName));
+                    } else if (line.startsWith(BASIC_BLOCK_INDENT)) {
+                        finishEntry(deadAtBeginning, block, beginDead, endDead, slots);
+                        block = line.substring(BASIC_BLOCK_INDENT.length());
+                        state = ParseState.LOOKING_FOR_VARIABLE_END;
+                    } else if (line.startsWith(FUNCTION_INDENT)) {
+                        finishEntry(deadAtBeginning, block, beginDead, endDead, slots);
+                        results.put(functionName, result(beginDead, endDead));
+                        functionName = line;
+                        beginDead = new HashMap<>();
+                        endDead = new HashMap<>();
+                        state = ParseState.LOOKING_FOR_BEGIN_DEAD;
+                    } else {
+                        throw new AssertionError(line);
+                    }
+                    break;
+                default:
+                    throw new AssertionError();
+            }
+        }
+        finishEntry(deadAtBeginning, block, beginDead, endDead, slots);
+        results.put(functionName, result(beginDead, endDead));
+        return results;
+    }
+
+    private static LLVMLifeTimeAnalysisResult result(Map<BasicBlock, FrameSlot[]> beginDead, Map<BasicBlock, FrameSlot[]> endDead) {
+        return new LLVMLifeTimeAnalysisResult() {
+
+            @Override
+            public Map<BasicBlock, FrameSlot[]> getEndDead() {
+                return endDead;
+            }
+
+            @Override
+            public Map<BasicBlock, FrameSlot[]> getBeginDead() {
+                return beginDead;
+            }
+        };
+    }
+
+    private static void finishEntry(boolean deadAtBeginning, String block, Map<BasicBlock, FrameSlot[]> beginDead, Map<BasicBlock, FrameSlot[]> endDead, Set<FrameSlot> slots) {
+        if (deadAtBeginning) {
+            beginDead.put(createBasicBlock(block), slots.toArray(new FrameSlot[slots.size()]));
+        } else {
+            endDead.put(createBasicBlock(block), slots.toArray(new FrameSlot[slots.size()]));
+        }
+        slots.clear();
+    }
+
+    private void printBasicBlockVariables(Map<BasicBlock, FrameSlot[]> beginDead) {
+        for (BasicBlock b : beginDead.keySet()) {
+            printString(BASIC_BLOCK_INDENT + b.getName());
+            for (FrameSlot slot : beginDead.get(b)) {
+                if (slot != null) {
+                    printString(VARIABLE_INDENT + slot.getIdentifier());
+                }
+            }
+        }
+    }
+
+    void printStringln(String s) {
+        printStream.println(s);
+    }
+
+    void printString(String s) {
+        printStream.println(s);
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestSuiteBase.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestSuiteBase.java
@@ -153,6 +153,16 @@ public abstract class TestSuiteBase {
 
     public static class TestCaseGeneratorImpl implements TestCaseGenerator {
 
+        private boolean withOptimizations;
+
+        public TestCaseGeneratorImpl(boolean withOptimizations) {
+            this.withOptimizations = withOptimizations;
+        }
+
+        public TestCaseGeneratorImpl() {
+            withOptimizations = true;
+        }
+
         @Override
         public TestCaseFiles getBitCodeTestCaseFiles(SpecificationEntry bitCodeFile) {
             return TestCaseFiles.createFromBitCodeFile(bitCodeFile.getFile(), bitCodeFile.getFlags());
@@ -177,8 +187,10 @@ public abstract class TestSuiteBase {
                     try {
                         TestCaseFiles compiledFiles = TestHelper.compileToLLVMIRWithClang(toBeCompiledFile, dest, toBeCompiled.getFlags(), builder);
                         files.add(compiledFiles);
-                        TestCaseFiles optimized = getOptimizedTestCase(compiledFiles);
-                        files.add(optimized);
+                        if (withOptimizations) {
+                            TestCaseFiles optimized = getOptimizedTestCase(compiledFiles);
+                            files.add(optimized);
+                        }
                     } catch (Exception e) {
                         return Collections.emptyList();
                     }


### PR DESCRIPTION
This change adds lifetime test cases and auto-generated reference output. Having lifetime test cases prevents performance regressions, especially when we switch to the binary LLVM IR parser.