### PR TITLE
strlen and strcmp Truffle interop intrinsics

### DIFF
--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -45,6 +45,15 @@ TODO
 
 `object()` sends `EXECUTE`
 
+## intrinsic functions
+
+### `string.h`
+
+Strings are assumed to be non-null terminated.
+* `strlen`: Sends a `HAS_SIZE` followed by a `GET_SIZE`.
+* `strcmp`: Sends `READ`s for each character, casts them to `char` and
+compares them.
+
 ## Currently unsupported operations
 
 It is not possible to access members of objects from foreign languages or share

--- a/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
+++ b/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
@@ -67,7 +67,7 @@ public class NativeLookup {
 
     private final NodeFactoryFacade facade;
 
-    private static NativeFunctionInterface getNFI() {
+    public static NativeFunctionInterface getNFI() {
         CompilerAsserts.neverPartOfCompilation();
         if (nfi == null) {
             nfi = NativeFunctionInterfaceRuntime.getNativeFunctionInterface();

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
@@ -80,7 +80,7 @@ public class LLVMContext extends ExecutionContext {
 
     public NativeFunctionHandle getNativeHandle(LLVMFunctionDescriptor function, LLVMExpressionNode[] args) {
         LLVMFunctionDescriptor sameFunction = getFunctionDescriptor(function);
-        return nativeLookup.getNativeHandle(sameFunction, args);
+        return getNativeLookup().getNativeHandle(sameFunction, args);
     }
 
     /**
@@ -99,15 +99,15 @@ public class LLVMContext extends ExecutionContext {
     }
 
     public void addLibraryToNativeLookup(String library) {
-        nativeLookup.addLibraryToNativeLookup(library);
+        getNativeLookup().addLibraryToNativeLookup(library);
     }
 
     public long getNativeHandle(String functionName) {
-        return nativeLookup.getNativeHandle(functionName);
+        return getNativeLookup().getNativeHandle(functionName);
     }
 
     public Map<LLVMFunctionDescriptor, Integer> getNativeFunctionLookupStats() {
-        return nativeLookup.getNativeFunctionLookupStats();
+        return getNativeLookup().getNativeFunctionLookupStats();
     }
 
     public LLVMStack getStack() {
@@ -168,6 +168,10 @@ public class LLVMContext extends ExecutionContext {
 
     public boolean isParseOnly() {
         return parseOnly;
+    }
+
+    public NativeLookup getNativeLookup() {
+        return nativeLookup;
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMCallNode.java
@@ -95,22 +95,45 @@ public abstract class LLVMCallNode {
         return frame.getArguments().length - ARG_START_INDEX;
     }
 
-    protected static LLVMExpressionNode[] prepareForNative(LLVMExpressionNode[] originalArgs, LLVMContext context) {
+    /**
+     *
+     * @param originalArgs the original args to the native function
+     * @param context the context needed to retrieve a native function handle if one of the
+     *            arguments is a function literal node
+     * @return the converted arguments
+     * @throws LLVMUnsupportedException if one of the argument nodes is a Truffle function node that
+     *             would escape to the native side
+     */
+    public static LLVMExpressionNode[] convertToPrimitiveNodes(LLVMExpressionNode[] originalArgs, LLVMContext context) {
         CompilerAsserts.neverPartOfCompilation();
-        LLVMExpressionNode[] newNodes = new LLVMExpressionNode[originalArgs.length - LLVMCallNode.ARG_START_INDEX];
+        int realArgsLength = originalArgs.length - LLVMCallNode.ARG_START_INDEX;
+        LLVMExpressionNode[] newNodes = new LLVMExpressionNode[realArgsLength];
         for (int i = 0; i < newNodes.length; i++) {
-            newNodes[i] = getArgNode(originalArgs, i + LLVMCallNode.ARG_START_INDEX, context);
+            LLVMExpressionNode originalArg = originalArgs[i + LLVMCallNode.ARG_START_INDEX];
+            newNodes[i] = convertToPrimitiveNode(originalArg, context);
         }
         return newNodes;
     }
 
-    private static LLVMExpressionNode getArgNode(LLVMExpressionNode[] originalArgs, int i, LLVMContext context) {
-        if (originalArgs[i] instanceof LLVMAddressNode) {
-            return LLVMAddressToI64NodeGen.create((LLVMAddressNode) originalArgs[i]);
-        } else if (originalArgs[i] instanceof LLVM80BitFloatNode) {
+    /**
+     * Converts a Sulong Truffle node to a node that returns a primitive that can be used as an
+     * argument to Graal's NFI.
+     *
+     * @param originalArg an argument to the native function
+     * @param context the context needed to retrieve a native function handle if one of the
+     *            arguments is a function literal node
+     * @return the conversion node that wraps the originalArg or the originalArg node itself
+     * @throws LLVMUnsupportedException if one of the argument nodes is a Truffle function node that
+     *             would escape to the native side
+     */
+    public static LLVMExpressionNode convertToPrimitiveNode(LLVMExpressionNode originalArg, LLVMContext context) {
+        CompilerAsserts.neverPartOfCompilation();
+        if (originalArg instanceof LLVMAddressNode) {
+            return LLVMAddressToI64NodeGen.create((LLVMAddressNode) originalArg);
+        } else if (originalArg instanceof LLVM80BitFloatNode) {
             throw new AssertionError("foreign function interface does not support 80 bit floats yet");
-        } else if (originalArgs[i] instanceof LLVMFunctionNode) {
-            LLVMFunctionDescriptor function = ((LLVMFunctionLiteralNode) originalArgs[i]).executeFunction();
+        } else if (originalArg instanceof LLVMFunctionNode) {
+            LLVMFunctionDescriptor function = ((LLVMFunctionLiteralNode) originalArg).executeFunction();
             String functionName = function.getName();
             long getNativeSymbol = context.getNativeHandle(functionName);
             if (getNativeSymbol != 0) {
@@ -119,7 +142,7 @@ public abstract class LLVMCallNode {
                 throw new LLVMUnsupportedException(UnsupportedReason.FUNCTION_POINTER_ESCAPES_TO_NATIVE);
             }
         } else {
-            return originalArgs[i];
+            return originalArg;
         }
     }
 
@@ -169,7 +192,7 @@ public abstract class LLVMCallNode {
                 LLVMFunctionDescriptor llvmFunction = (LLVMFunctionDescriptor) function;
                 CallTarget callTarget = context.getFunction(llvmFunction);
                 if (callTarget == null) {
-                    NativeFunctionHandle nativeHandle = context.getNativeHandle(llvmFunction, prepareForNative(getArgs(), context));
+                    NativeFunctionHandle nativeHandle = context.getNativeHandle(llvmFunction, convertToPrimitiveNodes(getArgs(), context));
                     if (nativeHandle == null) {
                         throw new IllegalStateException("could not find function " + llvmFunction.getName());
                     }
@@ -213,7 +236,7 @@ public abstract class LLVMCallNode {
 
         public LLVMResolvedDirectNativeCallNode(@SuppressWarnings("unused") LLVMFunctionDescriptor function, NativeFunctionHandle nativeFunctionHandle, LLVMExpressionNode[] args,
                         LLVMContext context) {
-            super(prepareForNative(args, context));
+            super(convertToPrimitiveNodes(args, context));
             functionHandle = nativeFunctionHandle;
         }
 
@@ -289,6 +312,18 @@ public abstract class LLVMCallNode {
 
     }
 
+    public static Object[] convertToPrimitiveArgs(Object[] arguments) {
+        Object[] newArguments = new Object[arguments.length - LLVMCallNode.ARG_START_INDEX];
+        System.arraycopy(arguments, LLVMCallNode.ARG_START_INDEX, newArguments, 0, newArguments.length);
+        CompilerAsserts.compilationConstant(arguments.length);
+        for (int i = 0; i < newArguments.length; i++) {
+            if (newArguments[i] instanceof LLVMAddress) {
+                newArguments[i] = ((LLVMAddress) newArguments[i]).getVal();
+            }
+        }
+        return newArguments;
+    }
+
     public abstract static class LLVMFunctionCallChain extends Node {
 
         private final LLVMContext context;
@@ -324,7 +359,7 @@ public abstract class LLVMCallNode {
             if (CompilerDirectives.inInterpreter() && !printedNativePerformanceWarning) {
                 printIndirectNativeCallWarning(function);
             }
-            final NativeFunctionHandle nativeHandle = currentContext.getNativeHandle(function, prepareForNative(args, currentContext));
+            final NativeFunctionHandle nativeHandle = currentContext.getNativeHandle(function, convertToPrimitiveNodes(args, currentContext));
             if (nativeHandle == null) {
                 throw new IllegalStateException("could not find function " + function.getName());
             } else {
@@ -334,15 +369,7 @@ public abstract class LLVMCallNode {
                     @ExplodeLoop
                     public Object execute(VirtualFrame frame) {
                         Object[] arguments = frame.getArguments();
-                        Object[] newArguments = new Object[arguments.length - LLVMCallNode.ARG_START_INDEX];
-                        System.arraycopy(arguments, LLVMCallNode.ARG_START_INDEX, newArguments, 0, newArguments.length);
-                        CompilerAsserts.compilationConstant(arguments.length);
-                        for (int i = 0; i < newArguments.length; i++) {
-                            if (newArguments[i] instanceof LLVMAddress) {
-                                newArguments[i] = ((LLVMAddress) newArguments[i]).getVal();
-                            }
-                        }
-                        return nativeHandle.call(newArguments);
+                        return nativeHandle.call(convertToPrimitiveArgs(arguments));
                     }
                 });
             }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMTruffleOnlyIntrinsics.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMTruffleOnlyIntrinsics.java
@@ -112,7 +112,7 @@ public final class LLVMTruffleOnlyIntrinsics {
                 Object strlen;
                 try {
                     strlen = ForeignAccess.sendGetSize(foreignGetSize, frame, object);
-                    long size = (long) toLLVM.convert(frame, strlen, long.class);
+                    long size = toLLVM.convert(frame, strlen, long.class);
                     return size;
                 } catch (UnsupportedMessageException e) {
                     throw new AssertionError(e);
@@ -161,24 +161,24 @@ public final class LLVMTruffleOnlyIntrinsics {
         }
 
         private int execute(VirtualFrame frame, TruffleObject str1, TruffleObject str2) throws UnsupportedMessageException, UnknownIdentifierException {
-            long size1 = (long) toLLVMSize1.convert(frame, ForeignAccess.sendGetSize(getSize1, frame, str1), long.class);
-            long size2 = (long) toLLVMSize2.convert(frame, ForeignAccess.sendGetSize(getSize2, frame, str2), long.class);
+            long size1 = toLLVMSize1.convert(frame, ForeignAccess.sendGetSize(getSize1, frame, str1), long.class);
+            long size2 = toLLVMSize2.convert(frame, ForeignAccess.sendGetSize(getSize2, frame, str2), long.class);
             int i;
             for (i = 0; i < size1; i++) {
                 Object s1 = ForeignAccess.sendRead(readStr1, frame, str1, i);
-                char c1 = (char) toLLVM1.convert(frame, s1, char.class);
+                char c1 = toLLVM1.convert(frame, s1, char.class);
                 if (i >= size2) {
                     return c1;
                 }
                 Object s2 = ForeignAccess.sendRead(readStr2, frame, str2, i);
-                char c2 = (char) toLLVM2.convert(frame, s2, char.class);
+                char c2 = toLLVM2.convert(frame, s2, char.class);
                 if (c1 != c2) {
                     return c1 - c2;
                 }
             }
             if (i < size2) {
                 Object s2 = ForeignAccess.sendRead(readStr2, frame, str2, i);
-                char c2 = (char) toLLVM2.convert(frame, s2, char.class);
+                char c2 = toLLVM2.convert(frame, s2, char.class);
                 return -c2;
             } else {
                 return 0;

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMTruffleOnlyIntrinsics.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMTruffleOnlyIntrinsics.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.intrinsics.c;
+
+import com.oracle.nfi.api.NativeFunctionHandle;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.interop.ForeignAccess;
+import com.oracle.truffle.api.interop.Message;
+import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.llvm.nativeint.NativeLookup;
+import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.ToLLVMNode;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsic.LLVMI64Intrinsic;
+import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+
+public final class LLVMTruffleOnlyIntrinsics {
+
+    private LLVMTruffleOnlyIntrinsics() {
+    }
+
+    public abstract static class LLVMTruffleOnlyI64Intrinsic extends LLVMI64Intrinsic {
+
+        protected final NativeFunctionHandle handle;
+
+        public LLVMTruffleOnlyI64Intrinsic(LLVMFunctionDescriptor descriptor) {
+            handle = NativeLookup.getNFI().getFunctionHandle(descriptor.getName().substring(1), getReturnValueClass(), getParameterClasses());
+        }
+
+        protected abstract Class<?>[] getParameterClasses();
+
+        protected Class<?> getReturnValueClass() {
+            return long.class;
+        }
+    }
+
+    @NodeChild(type = LLVMExpressionNode.class)
+    public abstract static class LLVMStrlen extends LLVMTruffleOnlyI64Intrinsic {
+
+        public LLVMStrlen(LLVMFunctionDescriptor descriptor) {
+            super(descriptor);
+        }
+
+        @Override
+        protected Class<?>[] getParameterClasses() {
+            return new Class<?>[]{long.class};
+        }
+
+        @Specialization
+        public long executeIntrinsic(LLVMAddress string) {
+            return (long) handle.call(string.getVal());
+        }
+
+        @Child private Node foreignHasSize = Message.HAS_SIZE.createNode();
+        @Child private Node foreignGetSize = Message.GET_SIZE.createNode();
+        @Child private ToLLVMNode toLLVM = new ToLLVMNode();
+
+        @Specialization
+        public long executeIntrinsic(VirtualFrame frame, TruffleObject object) {
+            boolean hasSize = ForeignAccess.sendHasSize(foreignHasSize, frame, object);
+            if (hasSize) {
+                Object strlen;
+                try {
+                    strlen = ForeignAccess.sendGetSize(foreignGetSize, frame, object);
+                    long size = (long) toLLVM.convert(frame, strlen, long.class);
+                    return size;
+                } catch (UnsupportedMessageException e) {
+                    throw new AssertionError(e);
+                }
+            } else {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                throw new AssertionError(object);
+            }
+        }
+
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/ToLLVMNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/interop/ToLLVMNode.java
@@ -45,7 +45,7 @@ public final class ToLLVMNode extends Node {
     @Child private Node isBoxed = Message.IS_BOXED.createNode();
     @Child private Node unboxed = Message.UNBOX.createNode();
 
-    public Object convert(VirtualFrame frame, Object value, Class<?> type) {
+    public <T> T convert(VirtualFrame frame, Object value, Class<T> type) {
         Object convertedValue;
         if (value == null) {
             return null;
@@ -56,7 +56,9 @@ public final class ToLLVMNode extends Node {
             assert TruffleObject.class.isAssignableFrom(type);
             convertedValue = value;
         }
-        return convertedValue;
+        @SuppressWarnings("unchecked")
+        T convertedValue2 = (T) convertedValue;
+        return convertedValue2;
     }
 
     public Object convert(VirtualFrame frame, Object value, LLVMRuntimeType type) {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMDoubleLoadNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMDoubleLoadNode.java
@@ -50,13 +50,12 @@ import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 public abstract class LLVMDoubleLoadNode extends LLVMDoubleNode {
     @Child protected Node foreignRead = Message.READ.createNode();
     @Child protected ToLLVMNode toLLVM = new ToLLVMNode();
-    protected static final Class<?> type = double.class;
 
     protected double doForeignAccess(VirtualFrame frame, LLVMTruffleObject addr) {
         try {
             int index = (int) (addr.getOffset() / LLVMDoubleNode.BYTE_SIZE);
             Object value = ForeignAccess.sendRead(foreignRead, frame, addr.getObject(), index);
-            return (double) toLLVM.convert(frame, value, type);
+            return toLLVM.convert(frame, value, double.class);
         } catch (UnknownIdentifierException | UnsupportedMessageException e) {
             throw new IllegalStateException(e);
         }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMFloatLoadNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMFloatLoadNode.java
@@ -50,13 +50,12 @@ import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 public abstract class LLVMFloatLoadNode extends LLVMFloatNode {
     @Child protected Node foreignRead = Message.READ.createNode();
     @Child protected ToLLVMNode toLLVM = new ToLLVMNode();
-    protected static final Class<?> type = float.class;
 
     protected float doForeignAccess(VirtualFrame frame, LLVMTruffleObject addr) {
         try {
             int index = (int) (addr.getOffset() / LLVMFloatNode.BYTE_SIZE);
             Object value = ForeignAccess.sendRead(foreignRead, frame, addr.getObject(), index);
-            return (float) toLLVM.convert(frame, value, type);
+            return toLLVM.convert(frame, value, float.class);
         } catch (UnknownIdentifierException | UnsupportedMessageException e) {
             throw new IllegalStateException(e);
         }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMI16LoadNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMI16LoadNode.java
@@ -52,13 +52,12 @@ import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 public abstract class LLVMI16LoadNode extends LLVMI16Node {
     @Child protected Node foreignRead = Message.READ.createNode();
     @Child protected ToLLVMNode toLLVM = new ToLLVMNode();
-    protected static final Class<?> type = short.class;
 
     protected short doForeignAccess(VirtualFrame frame, LLVMTruffleObject addr) {
         try {
             int index = (int) (addr.getOffset() / LLVMI16Node.BYTE_SIZE);
             Object value = ForeignAccess.sendRead(foreignRead, frame, addr.getObject(), index);
-            return (short) toLLVM.convert(frame, value, type);
+            return toLLVM.convert(frame, value, short.class);
         } catch (UnknownIdentifierException | UnsupportedMessageException e) {
             throw new IllegalStateException(e);
         }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMI32LoadNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMI32LoadNode.java
@@ -50,13 +50,12 @@ import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 public abstract class LLVMI32LoadNode extends LLVMI32Node {
     @Child protected Node foreignRead = Message.READ.createNode();
     @Child protected ToLLVMNode toLLVM = new ToLLVMNode();
-    protected static final Class<?> type = int.class;
 
     protected int doForeignAccess(VirtualFrame frame, LLVMTruffleObject addr) {
         try {
             int index = (int) (addr.getOffset() / LLVMI32Node.BYTE_SIZE);
             Object value = ForeignAccess.sendRead(foreignRead, frame, addr.getObject(), index);
-            return (int) toLLVM.convert(frame, value, type);
+            return toLLVM.convert(frame, value, int.class);
         } catch (UnknownIdentifierException | UnsupportedMessageException e) {
             throw new IllegalStateException(e);
         }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMI64LoadNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMI64LoadNode.java
@@ -51,13 +51,12 @@ public abstract class LLVMI64LoadNode extends LLVMI64Node {
 
     @Child protected Node foreignRead = Message.READ.createNode();
     @Child protected ToLLVMNode toLLVM = new ToLLVMNode();
-    protected static final Class<?> type = long.class;
 
     protected long doForeignAccess(VirtualFrame frame, LLVMTruffleObject addr) {
         try {
             int index = (int) addr.getOffset() / LLVMI64Node.BYTE_SIZE;
             Object value = ForeignAccess.sendRead(foreignRead, frame, addr.getObject(), index);
-            return (long) toLLVM.convert(frame, value, type);
+            return toLLVM.convert(frame, value, long.class);
         } catch (UnknownIdentifierException | UnsupportedMessageException e) {
             throw new IllegalStateException(e);
         }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMI8LoadNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMI8LoadNode.java
@@ -50,13 +50,12 @@ import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 public abstract class LLVMI8LoadNode extends LLVMI8Node {
     @Child protected Node foreignRead = Message.READ.createNode();
     @Child protected ToLLVMNode toLLVM = new ToLLVMNode();
-    protected static final Class<?> type = byte.class;
 
     protected byte doForeignAccess(VirtualFrame frame, LLVMTruffleObject addr) {
         try {
             int index = (int) addr.getOffset();
             Object value = ForeignAccess.sendRead(foreignRead, frame, addr.getObject(), index);
-            return (byte) toLLVM.convert(frame, value, type);
+            return toLLVM.convert(frame, value, byte.class);
         } catch (UnknownIdentifierException | UnsupportedMessageException e) {
             throw new IllegalStateException(e);
         }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMAbortFactory;
-import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCIntrinsicsFactory.LLVMStrlenFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMAbsFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMCeilFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMExpFactory;
@@ -48,6 +47,8 @@ import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFacto
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMRintFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMSqrtFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMExitFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMTruffleOnlyIntrinsicsFactory.LLVMStrCmpFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMTruffleOnlyIntrinsicsFactory.LLVMStrlenFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMTruffleReadBytesFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleAddressToFunctionFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.LLVMTruffleBinaryFactory.LLVMTruffleHasSizeFactory;
@@ -230,6 +231,7 @@ public class LLVMRuntimeIntrinsicFactory {
         intrinsics.put("@exit", LLVMExitFactory.getInstance());
 
         intrinsics.put("@strlen", LLVMStrlenFactory.getInstance());
+        intrinsics.put("@strcmp", LLVMStrCmpFactory.getInstance());
     }
 
     /**

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMAbortFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCIntrinsicsFactory.LLVMStrlenFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMAbsFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMCeilFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMExpFactory;
@@ -227,6 +228,8 @@ public class LLVMRuntimeIntrinsicFactory {
         // C
         intrinsics.put("@abort", LLVMAbortFactory.getInstance());
         intrinsics.put("@exit", LLVMExitFactory.getInstance());
+
+        intrinsics.put("@strlen", LLVMStrlenFactory.getInstance());
     }
 
     /**

--- a/projects/com.oracle.truffle.llvm.test/interoptests/strcmp.c
+++ b/projects/com.oracle.truffle.llvm.test/interoptests/strcmp.c
@@ -1,0 +1,5 @@
+#include <string.h>
+
+int main() { return 0; }
+
+int func(const char *str1, const char *str2) { return strcmp(str1, str2); }

--- a/projects/com.oracle.truffle.llvm.test/interoptests/strlen.c
+++ b/projects/com.oracle.truffle.llvm.test/interoptests/strlen.c
@@ -1,0 +1,5 @@
+#include <string.h>
+
+int main() { return 0; }
+
+int func(const char *str) { return strlen(str); }

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/interop/LLVMInteropTest.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/interop/LLVMInteropTest.java
@@ -44,6 +44,7 @@ import com.oracle.truffle.api.interop.java.JavaInterop;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.vm.PolyglotEngine;
 import com.oracle.truffle.api.vm.PolyglotEngine.Builder;
+import com.oracle.truffle.api.vm.PolyglotEngine.Value;
 import com.oracle.truffle.llvm.test.LLVMPaths;
 import com.oracle.truffle.llvm.tools.Clang;
 import com.oracle.truffle.llvm.tools.Clang.ClangOptions;
@@ -534,6 +535,24 @@ public final class LLVMInteropTest {
             List<Integer> array = JavaInterop.asJavaObject(List.class, result);
             array.size(); // GET_SIZE is not supported
             Assert.fail("IllegalStateException expected");
+        } finally {
+            runner.dispose();
+        }
+    }
+
+    @Test
+    public void testStrlen() throws Exception {
+        Runner runner = new Runner("strlen");
+        try {
+            Value strlenFunction = runner.findGlobalSymbol("func");
+            Value nullString = strlenFunction.execute(JavaInterop.asTruffleObject(new char[]{}));
+            Value a = strlenFunction.execute(JavaInterop.asTruffleObject(new char[]{'a'}));
+            Value abcd = strlenFunction.execute(JavaInterop.asTruffleObject(new char[]{'a', 'b', 'c', 'd'}));
+            Value abcdWithTerminator = strlenFunction.execute(JavaInterop.asTruffleObject(new char[]{'a', 'b', 'c', 'd', '\0'}));
+            Assert.assertEquals(0, nullString.get());
+            Assert.assertEquals(1, a.get());
+            Assert.assertEquals(4, abcd.get());
+            Assert.assertEquals(5, abcdWithTerminator.get());
         } finally {
             runner.dispose();
         }

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/interop/LLVMInteropTest.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/interop/LLVMInteropTest.java
@@ -558,6 +558,34 @@ public final class LLVMInteropTest {
         }
     }
 
+    @Test
+    public void testStrcmp() throws Exception {
+        Runner runner = new Runner("strcmp");
+        try {
+            Value strlenFunction = runner.findGlobalSymbol("func");
+            Value test1 = strlenFunction.execute(JavaInterop.asTruffleObject(new char[]{}), JavaInterop.asTruffleObject(new char[]{}));
+            Value test2 = strlenFunction.execute(JavaInterop.asTruffleObject(new char[]{'a'}), JavaInterop.asTruffleObject(new char[]{}));
+            Value test3 = strlenFunction.execute(JavaInterop.asTruffleObject(new char[]{}), JavaInterop.asTruffleObject(new char[]{'a'}));
+            Value test4 = strlenFunction.execute(JavaInterop.asTruffleObject(new char[]{'a'}), JavaInterop.asTruffleObject(new char[]{'d'}));
+            Value test5 = strlenFunction.execute(JavaInterop.asTruffleObject(new char[]{'d'}), JavaInterop.asTruffleObject(new char[]{'a'}));
+            Value test6 = strlenFunction.execute(JavaInterop.asTruffleObject(new char[]{'d'}), JavaInterop.asTruffleObject(new char[]{'d'}));
+            Value test7 = strlenFunction.execute(JavaInterop.asTruffleObject(new char[]{'a', 'b', 'c'}), JavaInterop.asTruffleObject(new char[]{'a', 'b', 'c', 'd'}));
+            Value test8 = strlenFunction.execute(JavaInterop.asTruffleObject(new char[]{'a', 'b', 'c', 'd'}), JavaInterop.asTruffleObject(new char[]{'a', 'b', 'c'}));
+            Value test9 = strlenFunction.execute(JavaInterop.asTruffleObject(new char[]{'A', 'B', 'C', 'D'}), JavaInterop.asTruffleObject(new char[]{'a', 'b', 'c', 'd'}));
+            Assert.assertEquals(0, test1.get());
+            Assert.assertEquals(97, test2.get());
+            Assert.assertEquals(-97, test3.get());
+            Assert.assertEquals(-3, test4.get());
+            Assert.assertEquals(3, test5.get());
+            Assert.assertEquals(0, test6.get());
+            Assert.assertEquals(-100, test7.get());
+            Assert.assertEquals(100, test8.get());
+            Assert.assertEquals(-32, test9.get());
+        } finally {
+            runner.dispose();
+        }
+    }
+
     public static final class ClassA {
         public boolean valueBool = true;
         public byte valueB = 40;


### PR DESCRIPTION
This change adds intrinsics for `strcmp` and `strlen`. The intrinsics call glib functions if the arguments are LLVM IR objects, and call a Java implementation if the arguments are `TruffleObject`s. 