### PR TITLE
Fix Argon2 pthread stub for OSX

### DIFF
--- a/projects/com.oracle.truffle.llvm.test/argon2/pthread-stub/pthread.h
+++ b/projects/com.oracle.truffle.llvm.test/argon2/pthread-stub/pthread.h
@@ -1,8 +1,12 @@
 #ifndef _BITS_PTHREADTYPES_H
 #define _BITS_PTHREADTYPES_H
 
+#ifndef _PTHREAD_T
 typedef unsigned long pthread_t;
+#endif
+#ifndef _PTHREAD_ATTR_T
 typedef void pthread_attr_t;
+#endif
 
 #endif
 


### PR DESCRIPTION
Compilation issue on OSX:
```
$ mx -v su-tests-argon2
[...]
In file included from src/core.c:30:
In file included from src/thread.h:18:
../pthread-stub/pthread.h:5:14: error: typedef redefinition with different types ('void' vs '__darwin_pthread_attr_t' (aka 'struct _opaque_pthread_attr_t'))
typedef void pthread_attr_t;
             ^
/usr/include/sys/_pthread/_pthread_attr_t.h:30:33: note: previous definition is here
typedef __darwin_pthread_attr_t pthread_attr_t;
```
Unfortunately, I don't have OSX available, so please test the fix and report back any further errors.