### PR TITLE
Flexible select installed LLVM or GCC binaries or download them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libxml2-dev
   - sudo apt-get install -y libssl-dev
-  - if ["$CLANG" == "3.3"]; then sudo apt-get install llvm-3.3 -y; fi
 install:
   - export MX_BINARY_SUITES="jvmci"
   - gem install mdl
@@ -47,21 +46,21 @@ branches:
   only:
     - master
 env:  
-  - TEST_COMMAND='mx su-clangformatcheck' CLANG='3.3'
-  - TEST_COMMAND='mx eclipseformat --primary' CLANG='3.3'
-  - TEST_COMMAND='mx su-mdlcheck' CLANG='3.3'
-  - TEST_COMMAND='mx su-gitlogcheck' CLANG='3.3'
-  - TEST_COMMAND='mx pylint' CLANG='3.3'
-  - TEST_COMMAND='mx checkstyle' CLANG='3.3'
-  - TEST_COMMAND='mx checkoverlap' CLANG='3.3'
-  - TEST_COMMAND='mx canonicalizeprojects' CLANG='3.3'
-  - TEST_COMMAND='mx su-httpcheck' CLANG='3.3'
-  - TEST_COMMAND='mx su-travis1' CLANG='3.3'
-  - TEST_COMMAND='mx su-travis2' CLANG='3.3'
-  - TEST_COMMAND='mx su-travis3' CLANG='3.3'
-  - TEST_COMMAND='mx su-travis-sulong' CLANG='3.3'
-  - TEST_COMMAND='mx su-travis-sulong' CLANG='download'
-  - TEST_COMMAND='mx su-travis-jruby' LIBXML_LIB_HOME=/usr/lib/x86_64-linux-gnu OPENSSL_LIB_HOME=/usr/lib/x86_64-linux-gnu CLANG='3.3'
-  - TEST_COMMAND='mx su-travis-argon2' CLANG='3.3'
+  - TEST_COMMAND='mx su-clangformatcheck' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx eclipseformat --primary' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx su-mdlcheck' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx su-gitlogcheck' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx pylint' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx checkstyle' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx checkoverlap' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx canonicalizeprojects' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx su-httpcheck' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx su-travis1' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx su-travis2' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx su-travis3' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx su-travis-sulong' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx su-travis-sulong' CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx su-travis-jruby' LIBXML_LIB_HOME=/usr/lib/x86_64-linux-gnu OPENSSL_LIB_HOME=/usr/lib/x86_64-linux-gnu CLANG='suite version (3.2)'
+  - TEST_COMMAND='mx su-travis-argon2' CLANG='suite version (3.2)'
 after_failure:
   - find . -iname "*.log" -print0 | xargs -0 cat

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ addons:
     - g++-4.6
     - gfortran-4.6
     - libgmp3-dev
-    - llvm-3.3
     - clang-format-3.4
     - gobjc++-4.6
     - gcc-4.6-plugin-dev
@@ -25,6 +24,7 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libxml2-dev
   - sudo apt-get install -y libssl-dev
+  - if ["$CLANG" == "3.3"]; then sudo apt-get install llvm-3.3 -y; fi
 install:
   - export MX_BINARY_SUITES="jvmci"
   - gem install mdl
@@ -46,22 +46,22 @@ script:
 branches:
   only:
     - master
-env:
-  - TEST_COMMAND='mx su-clangformatcheck'
-  - TEST_COMMAND='mx eclipseformat --primary'
-  - TEST_COMMAND='mx su-mdlcheck'
-  - TEST_COMMAND='mx su-gitlogcheck'
-  - TEST_COMMAND='mx pylint'
-  - TEST_COMMAND='mx checkstyle'
-  - TEST_COMMAND='mx checkoverlap'
-  - TEST_COMMAND='mx canonicalizeprojects'
-  - TEST_COMMAND='mx su-httpcheck'
-  - TEST_COMMAND='mx su-travis1'
-  - TEST_COMMAND='mx su-travis2'
-  - TEST_COMMAND='mx su-travis3'
-  - TEST_COMMAND='mx su-travis-sulong'
-  - TEST_COMMAND='mx su-travis-jruby' LIBXML_LIB_HOME=/usr/lib/x86_64-linux-gnu OPENSSL_LIB_HOME=/usr/lib/x86_64-linux-gnu
-  - TEST_COMMAND='mx su-travis-argon2'
-
+env:  
+  - TEST_COMMAND='mx su-clangformatcheck' CLANG='3.3'
+  - TEST_COMMAND='mx eclipseformat --primary' CLANG='3.3'
+  - TEST_COMMAND='mx su-mdlcheck' CLANG='3.3'
+  - TEST_COMMAND='mx su-gitlogcheck' CLANG='3.3'
+  - TEST_COMMAND='mx pylint' CLANG='3.3'
+  - TEST_COMMAND='mx checkstyle' CLANG='3.3'
+  - TEST_COMMAND='mx checkoverlap' CLANG='3.3'
+  - TEST_COMMAND='mx canonicalizeprojects' CLANG='3.3'
+  - TEST_COMMAND='mx su-httpcheck' CLANG='3.3'
+  - TEST_COMMAND='mx su-travis1' CLANG='3.3'
+  - TEST_COMMAND='mx su-travis2' CLANG='3.3'
+  - TEST_COMMAND='mx su-travis3' CLANG='3.3'
+  - TEST_COMMAND='mx su-travis-sulong' CLANG='3.3'
+  - TEST_COMMAND='mx su-travis-sulong' CLANG='download'
+  - TEST_COMMAND='mx su-travis-jruby' LIBXML_LIB_HOME=/usr/lib/x86_64-linux-gnu OPENSSL_LIB_HOME=/usr/lib/x86_64-linux-gnu CLANG='3.3'
+  - TEST_COMMAND='mx su-travis-argon2' CLANG='3.3'
 after_failure:
   - find . -iname "*.log" -print0 | xargs -0 cat

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -88,7 +88,7 @@ supportedLLVMVersions = [
 
 # the clang-format versions that can be used for formatting the test case C and C++ files
 clangFormatVersions = [
-	'3.4'
+    '3.4'
 ]
 
 # the basic LLVM dependencies for running the test cases and executing the mx commands
@@ -789,7 +789,10 @@ def getLLVMVersion(llvmProgram):
         # on my machine, opt returns a non-zero opcode even on success
         versionString = e.output
     printLLVMVersion = re.search(r'LLVM( version)? (\d\.\d)', versionString)
-    return printLLVMVersion.group(2)
+    if printLLVMVersion is None:
+        exit("could not find the LLVM version string in " + str(versionString))
+    else:
+        return printLLVMVersion.group(2)
 
 def findInstalledProgram(llvmProgram, supportedVersions=None):
     """tries to find a supported version of a program by checking for the argument string (e.g., clang) and appending version numbers (e.g., clang-3.4) as specified by the postfixes (or supportedLLVMVersions by default)"""

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -819,9 +819,18 @@ def findLLVMProgram(llvmProgram):
     if installedProgram is None:
         ensureLLVMBinariesExist()
         programPath = _toolDir + 'tools/llvm/bin/' + llvmProgram
+        if not os.path.exists(programPath):
+            exit(llvmProgram + ' is not a supported LLVM program!')
         return programPath
     else:
         return installedProgram
+
+def getLLVMProgramPath(args=None):
+    """gets a path with a supported version of the specified LLVM program (e.g. clang)"""
+    if args is None or len(args) != 1:
+        exit("please supply one LLVM program to be located!")
+    else:
+        print findLLVMProgram(args[0])
 
 def compileWithClang(args=None):
     """runs Clang"""
@@ -1100,5 +1109,6 @@ mx.update_commands(_suite, {
     'su-gitlogcheck' : [logCheck, ''],
     'su-mdlcheck' : [mdlCheck, ''],
     'su-clangformatcheck' : [clangformatcheck, ''],
-    'su-httpcheck' : [checkNoHttp, '']
+    'su-httpcheck' : [checkNoHttp, ''],
+    'su-get-llvm-program' : [getLLVMProgramPath, '']
 })

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -373,7 +373,9 @@ def pullInstallDragonEgg(args=None):
     os.environ['GCC'] = getGCC()
     os.environ['CXX'] = getGPP()
     os.environ['CC'] = getGCC()
-    os.environ['LLVM_CONFIG'] = findLLVMProgram('llvm-config')
+    pullLLVMBinaries()
+    os.environ['LLVM_CONFIG'] = _toolDir + 'tools/llvm/bin/llvm-config'
+    print os.environ['LLVM_CONFIG']
     compileCommand = ['make']
     return mx.run(compileCommand, cwd=_toolDir + 'tools/dragonegg/dragonegg-3.2.src')
 

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -788,11 +788,11 @@ def getLLVMVersion(llvmProgram):
     except subprocess.CalledProcessError as e:
         # on my machine, opt returns a non-zero opcode even on success
         versionString = e.output
-    printLLVMVersion = re.search(r'LLVM( version)? (\d\.\d)', versionString)
+    printLLVMVersion = re.search(r'(clang |LLVM )?(version )?(3\.\d)', versionString, re.IGNORECASE)
     if printLLVMVersion is None:
         exit("could not find the LLVM version string in " + str(versionString))
     else:
-        return printLLVMVersion.group(2)
+        return printLLVMVersion.group(3)
 
 def findInstalledProgram(llvmProgram, supportedVersions=None):
     """tries to find a supported version of a program by checking for the argument string (e.g., clang) and appending version numbers (e.g., clang-3.4) as specified by the postfixes (or supportedLLVMVersions by default)"""

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -90,7 +90,7 @@ mdlCheckExcludeDirectories = [
 # the LLVM versions supported by the current bitcode parser that bases on the textual format
 # sorted by priority in descending order (highest priority on top)
 supportedLLVMVersions = [
-    '3.2'
+    '3.2',
 ]
 
 # the clang-format versions that can be used for formatting the test case C and C++ files

--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -837,7 +837,8 @@ def findLLVMProgram(llvmProgram):
     """tries to find a supported version of an installed LLVM program; if the program is not found it downloads the LLVM binaries and checks there"""
     installedProgram = findInstalledLLVMProgram(llvmProgram)
     if installedProgram is None:
-        ensureLLVMBinariesExist()
+        if not os.path.exists(_clangPath):
+            pullLLVMBinaries()
         programPath = _toolDir + 'tools/llvm/bin/' + llvmProgram
         if not os.path.exists(programPath):
             exit(llvmProgram + ' is not a supported LLVM program!')

--- a/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/GCC.java
+++ b/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/GCC.java
@@ -36,11 +36,15 @@ import com.oracle.truffle.llvm.tools.util.ProcessUtil;
 
 public final class GCC extends CompilerBase {
 
+    private static final File GPP_PATH = Mx.executeGetGCCProgramPath("g++");
+    private static final File GFORTRAN_PATH = Mx.executeGetGCCProgramPath("gfortran");
+    private static final File GCC_PATH = Mx.executeGetGCCProgramPath("gcc");
+
     private GCC() {
     }
 
     public static void compileObjectToMachineCode(File objectFile, File executable) {
-        String linkCommand = Mx.executeGetGCCProgramPath("gcc") + " " + objectFile.getAbsolutePath() + " -o " + executable.getAbsolutePath() + " -lm -lgfortran -lgmp";
+        String linkCommand = GCC_PATH + " " + objectFile.getAbsolutePath() + " -o " + executable.getAbsolutePath() + " -lm -lgfortran -lgmp";
         ProcessUtil.executeNativeCommandZeroReturn(linkCommand);
         executable.setExecutable(true);
     }
@@ -48,11 +52,11 @@ public final class GCC extends CompilerBase {
     public static void compileToLLVMIR(File toBeCompiled, File destinationFile) {
         String tool;
         if (ProgrammingLanguage.C.isFile(toBeCompiled)) {
-            tool = Mx.executeGetGCCProgramPath("gcc") + " -std=gnu99";
+            tool = GCC_PATH + " -std=gnu99";
         } else if (ProgrammingLanguage.FORTRAN.isFile(toBeCompiled)) {
-            tool = Mx.executeGetGCCProgramPath("gfortran").toString();
+            tool = GFORTRAN_PATH.toString();
         } else if (ProgrammingLanguage.C_PLUS_PLUS.isFile(toBeCompiled)) {
-            tool = Mx.executeGetGCCProgramPath("g++").toString();
+            tool = GPP_PATH.toString();
         } else {
             throw new AssertionError(toBeCompiled);
         }

--- a/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/GCC.java
+++ b/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/GCC.java
@@ -40,7 +40,7 @@ public final class GCC extends CompilerBase {
     }
 
     public static void compileObjectToMachineCode(File objectFile, File executable) {
-        String linkCommand = "gcc-4.6 " + objectFile.getAbsolutePath() + " -o " + executable.getAbsolutePath() + " -lm -lgfortran -lgmp";
+        String linkCommand = Mx.executeGetGCCProgramPath("gcc") + " " + objectFile.getAbsolutePath() + " -o " + executable.getAbsolutePath() + " -lm -lgfortran -lgmp";
         ProcessUtil.executeNativeCommandZeroReturn(linkCommand);
         executable.setExecutable(true);
     }
@@ -48,11 +48,11 @@ public final class GCC extends CompilerBase {
     public static void compileToLLVMIR(File toBeCompiled, File destinationFile) {
         String tool;
         if (ProgrammingLanguage.C.isFile(toBeCompiled)) {
-            tool = "gcc-4.6 -std=gnu99";
+            tool = Mx.executeGetGCCProgramPath("gcc") + " -std=gnu99";
         } else if (ProgrammingLanguage.FORTRAN.isFile(toBeCompiled)) {
-            tool = "gfortran-4.6";
+            tool = Mx.executeGetGCCProgramPath("gfortran").toString();
         } else if (ProgrammingLanguage.C_PLUS_PLUS.isFile(toBeCompiled)) {
-            tool = "g++-4.6";
+            tool = Mx.executeGetGCCProgramPath("g++").toString();
         } else {
             throw new AssertionError(toBeCompiled);
         }

--- a/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/LLVMToolPaths.java
+++ b/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/LLVMToolPaths.java
@@ -32,7 +32,6 @@ package com.oracle.truffle.llvm.tools;
 import java.io.File;
 
 import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
-import com.oracle.truffle.llvm.tools.util.ProcessUtil.ProcessResult;
 
 public class LLVMToolPaths {
 
@@ -48,13 +47,7 @@ public class LLVMToolPaths {
     public static final File LLVM_DRAGONEGG = new File(TOOLS_ROOT, "/dragonegg/dragonegg-3.2.src/dragonegg.so");
 
     public static File getLLVMProgram(String program) {
-        ProcessResult result = Mx.execute("su-get-llvm " + program);
-        String output = result.getStdInput();
-        File llvmPath = new File(output);
-        if (!llvmPath.canExecute()) {
-            throw new AssertionError(output + " is not an executable program!");
-        }
-        return llvmPath;
+        return Mx.executeGetLLVMProgramPath(program);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/Mx.java
+++ b/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/Mx.java
@@ -29,6 +29,8 @@
  */
 package com.oracle.truffle.llvm.tools;
 
+import java.io.File;
+
 import com.oracle.truffle.llvm.tools.util.ProcessUtil;
 import com.oracle.truffle.llvm.tools.util.ProcessUtil.ProcessResult;
 
@@ -40,6 +42,27 @@ public final class Mx {
     public static ProcessResult execute(String string) {
         String command = "mx " + string;
         return ProcessUtil.executeNativeCommandZeroReturn(command);
+    }
+
+    public static File executeGetLLVMProgramPath(String program) {
+        ProcessResult result = Mx.execute("su-get-llvm " + program);
+        File llvmPath = getProgramPathFromStdout(result);
+        return llvmPath;
+    }
+
+    public static File executeGetGCCProgramPath(String program) {
+        ProcessResult result = Mx.execute("su-get-gcc " + program);
+        File llvmPath = getProgramPathFromStdout(result);
+        return llvmPath;
+    }
+
+    private static File getProgramPathFromStdout(ProcessResult result) {
+        String output = result.getStdInput();
+        File llvmPath = new File(output);
+        if (!llvmPath.canExecute()) {
+            throw new AssertionError(output + " is not an executable program!");
+        }
+        return llvmPath;
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/Mx.java
+++ b/projects/com.oracle.truffle.llvm.tools/src/com/oracle/truffle/llvm/tools/Mx.java
@@ -29,32 +29,17 @@
  */
 package com.oracle.truffle.llvm.tools;
 
-import java.io.File;
-
-import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
+import com.oracle.truffle.llvm.tools.util.ProcessUtil;
 import com.oracle.truffle.llvm.tools.util.ProcessUtil.ProcessResult;
 
-public class LLVMToolPaths {
+public final class Mx {
 
-    static final File PROJECT_ROOT = new File(LLVMBaseOptionFacade.getProjectRoot() + File.separator + LLVMToolPaths.class.getPackage().getName());
-    public static final File TOOLS_ROOT = new File(PROJECT_ROOT, "tools");
-    public static final File LLVM_ROOT = new File(TOOLS_ROOT, "llvm/bin");
+    private Mx() {
+    }
 
-    public static final File LLVM_ASSEMBLER = getLLVMProgram("llvm-as");
-    public static final File LLVM_COMPILER = getLLVMProgram("llc");
-    public static final File LLVM_CLANG = getLLVMProgram("clang");
-    public static final File LLVM_CLANGPlusPlus = getLLVMProgram("clang++");
-    public static final File LLVM_OPT = getLLVMProgram("opt");
-    public static final File LLVM_DRAGONEGG = new File(TOOLS_ROOT, "/dragonegg/dragonegg-3.2.src/dragonegg.so");
-
-    public static File getLLVMProgram(String program) {
-        ProcessResult result = Mx.execute("su-get-llvm " + program);
-        String output = result.getStdInput();
-        File llvmPath = new File(output);
-        if (!llvmPath.canExecute()) {
-            throw new AssertionError(output + " is not an executable program!");
-        }
-        return llvmPath;
+    public static ProcessResult execute(String string) {
+        String command = "mx " + string;
+        return ProcessUtil.executeNativeCommandZeroReturn(command);
     }
 
 }


### PR DESCRIPTION
With this change, mx dynamically selects supported and installed versions of GCC and LLVM tools, or downloads them when necessary. Also, with this change the test suites start to use mx to get the paths to these tools. 