### PR TITLE
Fix the linking of external variables

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
@@ -63,6 +63,7 @@ public class LLVMContext extends ExecutionContext {
     private Source mainSourceFile;
 
     private boolean parseOnly;
+    private List<String> resolvedVariables;
 
     public LLVMContext(NodeFactoryFacade facade, LLVMOptimizationConfiguration optimizationConfig) {
         nativeLookup = new NativeLookup(facade);
@@ -172,6 +173,14 @@ public class LLVMContext extends ExecutionContext {
 
     public NativeLookup getNativeLookup() {
         return nativeLookup;
+    }
+
+    public List<String> getResolvedVariableNames() {
+        return resolvedVariables;
+    }
+
+    public void setResolvedVariableNames(List<String> resolvedVariables) {
+        this.resolvedVariables = resolvedVariables;
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMGlobalVariableVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMGlobalVariableVisitor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.parser.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+
+import com.intel.llvm.ireditor.lLVM_IR.GlobalVariable;
+import com.intel.llvm.ireditor.lLVM_IR.Model;
+
+public class LLVMGlobalVariableVisitor {
+
+    public class LLVMGlobalVariableResult {
+
+        private final List<String> resolvedVariables;
+        private final List<String> externalVariables;
+
+        public LLVMGlobalVariableResult(List<String> resolvedVariables, List<String> externalVariables) {
+            this.resolvedVariables = resolvedVariables;
+            this.externalVariables = externalVariables;
+        }
+
+        public List<String> getResolvedVariables() {
+            return resolvedVariables;
+        }
+
+        public List<String> getExternalVariables() {
+            return externalVariables;
+        }
+
+    }
+
+    public LLVMGlobalVariableResult getMain(Model model) {
+        List<String> resolvedVariables = new ArrayList<>();
+        List<String> externalVariables = new ArrayList<>();
+        List<EObject> objects = model.eContents();
+        for (EObject object : objects) {
+            if (object instanceof GlobalVariable) {
+                GlobalVariable globalVar = (GlobalVariable) object;
+                if (globalVar.getLinkage() != null && globalVar.getLinkage().equals("external")) {
+                    externalVariables.add(globalVar.getName());
+                } else {
+                    resolvedVariables.add(globalVar.getName());
+                }
+            }
+        }
+        return new LLVMGlobalVariableResult(resolvedVariables, externalVariables);
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -387,9 +387,15 @@ public final class LLVMVisitor implements LLVMParserRuntime {
     }
 
     private void allocateGlobals(List<EObject> objects) {
+        boolean correctLinking = LLVMBaseOptionFacade.enableCorrectExternalVariableLinking();
         for (EObject object : objects) {
             if (object instanceof GlobalVariable) {
-                findOrAllocateGlobal((GlobalVariable) object);
+                GlobalVariable globalVar = (GlobalVariable) object;
+                boolean hasExternalLinkage = "external".equals(globalVar.getLinkage());
+                if (!correctLinking && !hasExternalLinkage) {
+                    resolvedVariableNames.add(globalVar.getName());
+                }
+                findOrAllocateGlobal(globalVar);
             }
         }
     }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParserRuntime.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParserRuntime.java
@@ -81,4 +81,17 @@ public interface LLVMParserRuntime {
      * @param destructorNode
      */
     void addDestructor(LLVMNode destructorNode);
+
+    /**
+     * Returns whether a global variable is defined (as a non <code>extern</code>) in one of the
+     * bitcode files.
+     *
+     * @param globalVarName the global variable name
+     * @return <code>true</code> whether the global variable is defined, <code>false </code>
+     *         otherwise
+     */
+    boolean isGlobalVariableDefined(String globalVarName);
+
+    long getNativeHandle(String name);
+
 }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/options/LLVMBaseOption.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/options/LLVMBaseOption.java
@@ -78,6 +78,12 @@ public enum LLVMBaseOption implements LLVMOption {
                     null,
                     LLVMOptions::parseDynamicLibraryPath,
                     PropertyCategory.GENERAL),
+    CORRECT_EXTERNAL_VAR_LINKING(
+                    "CorrectExternalVariableLinking",
+                    "Enables the correct linking of external variables, so that external variables defined in other bitcode files are found, instead of attempting to use the Graal NFI to resolve them",
+                    false,
+                    LLVMOptions::parseBoolean,
+                    PropertyCategory.GENERAL),
     DYN_BITCODE_LIBRARIES(
                     "DynamicBitcodeLibraries",
                     "The paths to shared bitcode libraries delimited by " + LLVMOptions.getPathDelimiter(),

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/options/LLVMBaseOptionFacade.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/options/LLVMBaseOptionFacade.java
@@ -145,4 +145,8 @@ public final class LLVMBaseOptionFacade {
         return LLVMOptions.getParsedProperty(LLVMBaseOption.NODE_CONFIGURATION);
     }
 
+    public static boolean enableCorrectExternalVariableLinking() {
+        return LLVMOptions.getParsedProperty(LLVMBaseOption.CORRECT_EXTERNAL_VAR_LINKING);
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -199,16 +199,20 @@ public class LLVM {
             }
 
             private List<String> getAllResolvedGlobalVariables(Source code) throws IOException {
-                List<String> resolvedGlobalVariables = new ArrayList<>();
-                visitBitcodeLibraries(source -> {
-                    try {
-                        addResolvedGlobalVariables(resolvedGlobalVariables, source);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-                addResolvedGlobalVariables(resolvedGlobalVariables, code);
-                return resolvedGlobalVariables;
+                if (LLVMBaseOptionFacade.enableCorrectExternalVariableLinking()) {
+                    List<String> resolvedGlobalVariables = new ArrayList<>();
+                    visitBitcodeLibraries(source -> {
+                        try {
+                            addResolvedGlobalVariables(resolvedGlobalVariables, source);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                    addResolvedGlobalVariables(resolvedGlobalVariables, code);
+                    return resolvedGlobalVariables;
+                } else {
+                    return new ArrayList<>();
+                }
             }
 
             private void addResolvedGlobalVariables(List<String> resolvedGlobalVariables, Source source) throws IOException {


### PR DESCRIPTION
Previously, Sulong always used the Graal NFI to link global `extern` variables.
This does not work when another bitcode file defines a `extern` variable, or when we want to intrinsify such a variable.
With this change, we traverse the bitcode libraries and remember defined variables.
When allocating global variables, we can decide based on the defined variables to use the Graal NFI for variables not in this list.
This change addresses #380 but is disabled by default due to the run-time overhead caused by the textual parser.