### PR TITLE
Remove the global state in LLVMTypeHelper

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeFunctionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeFunctionVisitor.java
@@ -187,4 +187,5 @@ public class LLVMBitcodeFunctionVisitor implements FunctionVisitor {
     public LLVMOptimizationConfiguration getOptimizationConfiguration() {
         return module.getOptimizationConfiguration();
     }
+
 }

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeInstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeInstructionVisitor.java
@@ -725,7 +725,8 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
 
         Type type = store.getSource().getType();
 
-        LLVMNode node = LLVMMemoryReadWriteFactory.createStore(pointerNode, valueNode, LLVMBitcodeHelper.toBaseType(type).getType(), LLVMBitcodeHelper.getSize(type, store.getAlign()));
+        LLVMNode node = LLVMMemoryReadWriteFactory.createStore(pointerNode, valueNode, LLVMBitcodeHelper.toBaseType(type).getType(),
+                        LLVMBitcodeHelper.getSize(type, store.getAlign()));
 
         method.addInstruction(node);
     }

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
@@ -216,7 +216,8 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
                         store = LLVMMemI32CopyFactory.create(globalVarAddress, (LLVMAddressNode) constant, new LLVMI32LiteralNode(size), new LLVMI32LiteralNode(0), new LLVMI1LiteralNode(false));
                     } else {
                         Type t = global.getValue().getType();
-                        store = LLVMMemoryReadWriteFactory.createStore(globalVarAddress, constant, LLVMBitcodeHelper.toBaseType(t).getType(), LLVMBitcodeHelper.getSize(t, 0));
+                        store = LLVMMemoryReadWriteFactory.createStore(globalVarAddress, constant, LLVMBitcodeHelper.toBaseType(t).getType(),
+                                        LLVMBitcodeHelper.getSize(t, 0));
                     }
                     return store;
                 }
@@ -353,4 +354,5 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
     @Override
     public void visit(Type type) {
     }
+
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAggregateFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAggregateFactory.java
@@ -117,24 +117,24 @@ public final class LLVMAggregateFactory {
         int[] offsets = new int[types.length];
         LLVMStructWriteNode[] nodes = new LLVMStructWriteNode[types.length];
         int currentOffset = 0;
-        int structSize = LLVMTypeHelper.getByteSize(structType);
-        int structAlignment = LLVMTypeHelper.getAlignmentByte(structType);
+        int structSize = runtime.getTypeHelper().getByteSize(structType);
+        int structAlignment = runtime.getTypeHelper().getAlignmentByte(structType);
         LLVMExpressionNode alloc = runtime.allocateFunctionLifetime(structType, structSize, structAlignment);
         for (int i = 0; i < types.length; i++) {
             ResolvedType resolvedType = types[i];
             if (!packed) {
-                currentOffset += LLVMTypeHelper.computePaddingByte(currentOffset, resolvedType);
+                currentOffset += runtime.getTypeHelper().computePaddingByte(currentOffset, resolvedType);
             }
             offsets[i] = currentOffset;
-            int byteSize = LLVMTypeHelper.getByteSize(resolvedType);
-            nodes[i] = createStructWriteNode(constants[i], resolvedType);
+            int byteSize = runtime.getTypeHelper().getByteSize(resolvedType);
+            nodes[i] = createStructWriteNode(runtime, constants[i], resolvedType);
             currentOffset += byteSize;
         }
         return new StructLiteralNode(offsets, nodes, (LLVMAddressNode) alloc);
     }
 
-    private static LLVMStructWriteNode createStructWriteNode(LLVMExpressionNode parsedConstant, ResolvedType resolvedType) {
-        int byteSize = LLVMTypeHelper.getByteSize(resolvedType);
+    private static LLVMStructWriteNode createStructWriteNode(LLVMParserRuntime runtime, LLVMExpressionNode parsedConstant, ResolvedType resolvedType) {
+        int byteSize = runtime.getTypeHelper().getByteSize(resolvedType);
         LLVMBaseType llvmType = LLVMTypeHelper.getLLVMType(resolvedType).getType();
         switch (llvmType) {
             case I1:

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
@@ -154,7 +154,7 @@ public final class LLVMFunctionFactory {
                     return LLVMFunctionRetNodeGen.create((LLVMFunctionNode) retValue, retSlot);
                 case STRUCT:
                     ResolvedStructType structType = (ResolvedStructType) resolvedType;
-                    int size = LLVMTypeHelper.getByteSize(structType);
+                    int size = runtime.getTypeHelper().getByteSize(structType);
                     return LLVMStructRetNodeGen.create((LLVMAddressNode) retValue, retSlot, size);
                 default:
                     throw new AssertionError(type);

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
@@ -122,7 +122,7 @@ public final class LLVMLiteralFactory {
         }
         switch (type) {
             case I_VAR_BITWIDTH:
-                int byteSize = LLVMTypeHelper.getByteSize(resolvedType);
+                int byteSize = runtime.getTypeHelper().getByteSize(resolvedType);
                 byte[] loadedBytes = new byte[byteSize];
                 Arrays.fill(loadedBytes, (byte) -1);
                 return new LLVMIVarBitLiteralNode(LLVMIVarBit.create(byteSize * Byte.SIZE, loadedBytes));
@@ -377,10 +377,10 @@ public final class LLVMLiteralFactory {
         int nrElements = arrayValues.size();
         ResolvedType elementType = arrayType.getContainedType(-1);
         LLVMBaseType llvmElementType = LLVMTypeHelper.getLLVMType(elementType).getType();
-        int baseTypeSize = LLVMTypeHelper.getByteSize(elementType);
+        int baseTypeSize = runtime.getTypeHelper().getByteSize(elementType);
         int size = nrElements * baseTypeSize;
-        LLVMAddressNode arrayAlloc = (LLVMAddressNode) runtime.allocateFunctionLifetime(arrayType, size, LLVMTypeHelper.getAlignmentByte(arrayType));
-        int byteLength = LLVMTypeHelper.getByteSize(elementType);
+        LLVMAddressNode arrayAlloc = (LLVMAddressNode) runtime.allocateFunctionLifetime(arrayType, size, runtime.getTypeHelper().getAlignmentByte(arrayType));
+        int byteLength = runtime.getTypeHelper().getByteSize(elementType);
         if (size == 0) {
             throw new AssertionError(llvmElementType + " has size of 0!");
         }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMMemoryReadWriteFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMMemoryReadWriteFactory.java
@@ -192,8 +192,8 @@ public final class LLVMMemoryReadWriteFactory {
         }
     }
 
-    public static LLVMNode createStore(LLVMAddressNode pointerNode, LLVMExpressionNode valueNode, ResolvedType type) {
-        return createStore(pointerNode, valueNode, LLVMTypeHelper.getLLVMType(type).getType(), LLVMTypeHelper.getByteSize(type));
+    public static LLVMNode createStore(LLVMParserRuntime runtime, LLVMAddressNode pointerNode, LLVMExpressionNode valueNode, ResolvedType type) {
+        return createStore(pointerNode, valueNode, LLVMTypeHelper.getLLVMType(type).getType(), runtime.getTypeHelper().getByteSize(type));
     }
 
     public static LLVMNode createStore(LLVMAddressNode pointerNode, LLVMExpressionNode valueNode, LLVMBaseType type, int size) {

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -93,7 +93,6 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
-import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
@@ -109,7 +108,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     protected LLVMParserRuntime runtime;
 
     public NodeFactoryFacadeImpl(LLVMParserRuntime runtime) {
-        this.runtime = runtime;
+        setUpFacade(runtime);
     }
 
     @Override
@@ -139,7 +138,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
 
     @Override
     public LLVMNode createStore(LLVMExpressionNode pointerNode, LLVMExpressionNode valueNode, ResolvedType type) {
-        return LLVMMemoryReadWriteFactory.createStore((LLVMAddressNode) pointerNode, valueNode, type);
+        return LLVMMemoryReadWriteFactory.createStore(runtime, (LLVMAddressNode) pointerNode, valueNode, type);
     }
 
     @Override
@@ -413,7 +412,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     public Object allocateGlobalVariable(GlobalVariable globalVariable) {
         if (runtime.isGlobalVariableDefined(globalVariable.getName())) {
             ResolvedType resolvedType = runtime.resolve(globalVariable.getType());
-            int byteSize = LLVMTypeHelper.getByteSize(resolvedType);
+            int byteSize = runtime.getTypeHelper().getByteSize(resolvedType);
             LLVMAddress allocation = LLVMHeap.allocateMemory(byteSize);
             LLVMAddressNode addressLiteralNode = (LLVMAddressNode) createLiteral(allocation, LLVMBaseType.ADDRESS);
             runtime.addDestructor(LLVMFreeFactory.create(addressLiteralNode));

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParserRuntime.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParserRuntime.java
@@ -37,6 +37,7 @@ import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
+import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
 import com.oracle.truffle.llvm.runtime.LLVMOptimizationConfiguration;
 
 public interface LLVMParserRuntime {
@@ -93,5 +94,7 @@ public interface LLVMParserRuntime {
     boolean isGlobalVariableDefined(String globalVarName);
 
     long getNativeHandle(String name);
+
+    LLVMTypeHelper getTypeHelper();
 
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/util/LLVMTypeHelper.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/util/LLVMTypeHelper.java
@@ -54,9 +54,13 @@ import com.oracle.truffle.llvm.types.memory.LLVMHeap;
 
 public class LLVMTypeHelper {
 
-    private static LLVMParserRuntime runtime;
+    private final LLVMParserRuntime runtime;
 
-    public static int getByteSize(ResolvedType type) {
+    public LLVMTypeHelper(LLVMParserRuntime runtime) {
+        this.runtime = runtime;
+    }
+
+    public int getByteSize(ResolvedType type) {
         int bits = type.getBits().intValue();
         if (type instanceof ResolvedIntegerType || type instanceof ResolvedFloatingType) {
             return Math.max(1, bits / Byte.SIZE);
@@ -87,7 +91,7 @@ public class LLVMTypeHelper {
         }
     }
 
-    public static int getStructureSizeByte(StructureConstant structure, TypeResolver typeResolver) {
+    public int getStructureSizeByte(StructureConstant structure, TypeResolver typeResolver) {
         int sumByte = 0;
         int largestAlignment = 0;
         for (TypedConstant constant : structure.getList().getTypedConstants()) {
@@ -107,7 +111,7 @@ public class LLVMTypeHelper {
         return totalSizeByte;
     }
 
-    private static int getStructSizeByte(ResolvedStructType type) {
+    private int getStructSizeByte(ResolvedStructType type) {
         int sumByte = 0;
         for (ResolvedType field : type.getFieldTypes()) {
             if (!type.isPacked()) {
@@ -133,7 +137,7 @@ public class LLVMTypeHelper {
         return padding;
     }
 
-    private static int largestAlignmentByte(ResolvedStructType structType) {
+    private int largestAlignmentByte(ResolvedStructType structType) {
         int largestAlignment = 0;
         for (ResolvedType field : structType.getFieldTypes()) {
             int alignment = getAlignmentByte(field);
@@ -217,7 +221,7 @@ public class LLVMTypeHelper {
         }
     }// Checkstyle: resume magic number name check
 
-    public static int goIntoTypeGetLengthByte(ResolvedType currentType, int index) {
+    public int goIntoTypeGetLengthByte(ResolvedType currentType, int index) {
         if (currentType == null) {
             return 0; // TODO: better throw an exception
         } else if (currentType instanceof ResolvedPointerType) {
@@ -235,7 +239,7 @@ public class LLVMTypeHelper {
                     sum += computePaddingByte(sum, containedType);
                 }
             }
-            if (!isPackedStructType(currentType) && LLVMTypeHelper.getStructSizeByte((ResolvedStructType) currentType) > sum) {
+            if (!isPackedStructType(currentType) && getStructSizeByte((ResolvedStructType) currentType) > sum) {
                 sum += computePaddingByte(sum, currentType.getContainedType(index));
             }
             return sum;
@@ -260,7 +264,7 @@ public class LLVMTypeHelper {
         return ((ResolvedStructType) currentType).isPacked();
     }
 
-    public static int computePaddingByte(int currentOffset, ResolvedType type) {
+    public int computePaddingByte(int currentOffset, ResolvedType type) {
         int alignmentByte = getAlignmentByte(type);
         if (alignmentByte == 0) {
             return 0;
@@ -273,11 +277,7 @@ public class LLVMTypeHelper {
         int getBitAlignment(LLVMBaseType type);
     }
 
-    public static void setParserRuntime(LLVMParserRuntime runtime) {
-        LLVMTypeHelper.runtime = runtime;
-    }
-
-    public static int getAlignmentByte(ResolvedType field) {
+    public int getAlignmentByte(ResolvedType field) {
         if (field instanceof ResolvedNamedType) {
             return getAlignmentByte(((ResolvedNamedType) field).getReferredType());
         } else if (field instanceof ResolvedStructType) {


### PR DESCRIPTION
`LLVMTypeHelper` has global state that is set to the IR file which happened to be parsed last. If you only parse bitcode files I'm not sure it's ever set.

We really need to start eliminating these static variables.