### PR TITLE
Allow boolean objects to be converted to an integer

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI32Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI32Node.java
@@ -107,6 +107,11 @@ public abstract class LLVMToI32Node extends LLVMI32Node {
     public abstract static class LLVMAddressToI32Node extends LLVMToI32Node {
 
         @Specialization
+        public int executeI32(boolean from) {
+            return from ? 1 : 0;
+        }
+
+        @Specialization
         public int executeI32(LLVMAddress from) {
             return (int) from.getVal();
         }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI64Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI64Node.java
@@ -181,6 +181,11 @@ public abstract class LLVMToI64Node extends LLVMI64Node {
     public abstract static class LLVMAddressToI64Node extends LLVMToI64Node {
 
         @Specialization
+        public long executeI64(boolean from) {
+            return from ? 1 : 0;
+        }
+
+        @Specialization
         public long executeI64(LLVMAddress from) {
             return from.getVal();
         }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI8Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/cast/LLVMToI8Node.java
@@ -132,6 +132,11 @@ public abstract class LLVMToI8Node extends LLVMI8Node {
     public abstract static class LLVMAddressToI8Node extends LLVMToI8Node {
 
         @Specialization
+        public byte executeI8(boolean from) {
+            return (byte) (from ? 1 : 0);
+        }
+
+        @Specialization
         public byte executeI8(LLVMAddress from) {
             return (byte) from.getVal();
         }


### PR DESCRIPTION
Arrises when we have a Java `Boolean`, which we are treating as a Ruby `VALUE` (`void *`). This is converted to an integer in a Ruby extension. I think it makes sense to allow this Java type be converted to a raw pointer and then integer value, even though we don't want to do it with arbitrary managed objects.