### PR TITLE
Mark a GCC test case with undefined return value with the UNDEFINED_R…

### DIFF
--- a/projects/com.oracle.truffle.llvm.test/suites-configs/gcc/gcc.dg/unsorted/working.include
+++ b/projects/com.oracle.truffle.llvm.test/suites-configs/gcc/gcc.dg/unsorted/working.include
@@ -560,5 +560,5 @@ gcc.dg/torture/stackalign/pr16660-3.c
 gcc.dg/torture/stackalign/pr16660-2.c
 gcc.dg/torture/stackalign/global-1.c
 gcc.dg/torture/stackalign/alloca-1.c
-gcc.dg/autopar/pr39500-2.c
+gcc.dg/autopar/pr39500-2.c UNDEFINED_RETURN_CODE
 gcc.dg/ipa/inlinehint-3.c


### PR DESCRIPTION
…ETURN_CODE flag

Solves https://github.com/graalvm/sulong/issues/423.