### PR TITLE
Converting objects to native as they escape

### DIFF
--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -45,6 +45,11 @@ TODO
 
 `object()` sends `EXECUTE`
 
+A reference to a foreign object being converted to an integer (possibly to make
+a native call) sends `UNBOX` and treats the returned value as a native memory
+address. This behaviour is likely to change in the future, but currently
+enables foreign objects to convert to a native representation if possible.
+
 ## Intrinsic functions
 
 ### `string.h`


### PR DESCRIPTION
This is the basic implementation for #402, specialised just for the Ruby use case, which is at https://github.com/jruby/jruby/commit/c30e0ecc0b47f8027d350a3d7a4f7e0961e188c7.

We probably want to do this with something like the adapter that @mrigger already suggested, but I wanted to show the code that does enough to work.

I decided to repurpose the `UNBOX` message.

This lets us do:

```
$ JRUBY_TRUFFLE_NATIVE_OPENSSL=true GRAAL_HOME=$SULONG_HOME jt run --graal -e "require 'openssl'; p OpenSSL::Random.random_bytes(12).bytes"
[200, 158, 154, 243, 111, 122, 42, 200, 18, 94, 89, 124]
```

Where the `openssl` gem is using the native system `libssl.so` to actually generate the random bytes, and is writing into a raw Ruby `char*` string (it thinks), which Ruby then continues to use.

@mrigger @grimmerm @mickjordan 