### PR TITLE
Add gcc-bc test suite for BitCode parser

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -67,6 +67,7 @@ are remote test cases.
 | test suite | type   | config | description                              |
 |------------|--------|--------|------------------------------------------|
 | llvm       | remote | yes    | LLVM's test suite                        |
+| llvm-bc    | remote | yes    | LLVM's test suite for BitCode parser     |
 | interop    | local  | no     | Truffle interoperability test suite      |
 | polyglot   | local  | no     | Minimal Polyglot engine test             |
 | tck        | local  | no     | Test suite to certify Truffle compliance |
@@ -75,6 +76,7 @@ are remote test cases.
 | asm        | local  | no     | Inline assembler tests                   |
 | sulong     | local  | no     | Sulong's own primary test suite          |
 | gcc        | local  | yes    | GCC's test suite                         |
+| gcc-bc     | local  | yes    | GCC's test suite for BitCode parser      |
 | main-arg   | local  | no     | Tests arguments to the main function     |
 | bench      | local  | no     | Language Benchmark game benchmarks       |
 | compile    | local  | yes    | GCC's compile-only test cases            |


### PR DESCRIPTION
- Adding a 'gcc-bc' test suite for BitCode parser, equivalent to the 'gcc' test suite for .ll files.
- Actual code change is quite little, most of the files conating list of files to be tested.
- Separate test suite required causing duplication of files listing names of files to be executed/tested because not all the files running with .ll parser runs with BitCode parser.
- Adding a new mx target 'su-travis4' to run tests on BitCode parser. This addition would increase the overall regression tests time.
- Generation of .bc files from FORTRAN files is done in 2 stages (.f90 -> .ll -> .bc) as a quick fix. Please suggest if it can be more elegant.
