### PR TITLE
Increment the total execution count before the basic block execution …

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMBasicBlockNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMBasicBlockNode.java
@@ -119,8 +119,8 @@ public class LLVMBasicBlockNode extends LLVMNode {
 
     private void incrementCountAtIndex(int successorIndex) {
         if (totalExecutionCount != Long.MAX_VALUE) {
-            successorCount[successorIndex]++;
             totalExecutionCount++;
+            successorCount[successorIndex]++;
         }
     }
 


### PR DESCRIPTION
…count

This prevents a seldom occuring assertion error that is triggered by injecting a branch probability over 1.0.