### PR TITLE
Remove the double-dispose check in the context

### DIFF
--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
@@ -132,8 +132,4 @@ public final class LLVMStack extends LLVMMemory {
         return LLVMAddress.fromLong(upperBounds);
     }
 
-    public boolean isFreed() {
-        return isFreed;
-    }
-
 }

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/LLVM.java
@@ -241,17 +241,13 @@ public class LLVM {
 
             @Override
             public void disposeContext(LLVMContext context) {
-                // the PolyglotEngine calls this method for every mime type supported by the
-                // language
-                if (!context.getStack().isFreed()) {
-                    for (RootCallTarget destructorFunction : context.getDestructorFunctions()) {
-                        destructorFunction.call(destructorFunction);
-                    }
-                    for (RootCallTarget destructor : context.getGlobalVarDeallocs()) {
-                        destructor.call();
-                    }
-                    context.getStack().free();
+                for (RootCallTarget destructorFunction : context.getDestructorFunctions()) {
+                    destructorFunction.call(destructorFunction);
                 }
+                for (RootCallTarget destructor : context.getGlobalVarDeallocs()) {
+                    destructor.call();
+                }
+                context.getStack().free();
             }
         };
     }


### PR DESCRIPTION
The double-dispose check was introduced since a bug in Truffle disposed the context once for every MIME type the language supported. This bug was fixed in the Truffle version 35c1a2c0ab4de828208bc057d1f45f2a03f50523.