### PR TITLE
Add inital debugging implementation (get name of struct element)

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
@@ -104,6 +104,8 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
 
         LLVMLabelList labels = LLVMLabelList.generate(model);
 
+        LLVMMetadata.generate(model);
+
         LLVMBitcodeVisitor module = new LLVMBitcodeVisitor(context, lifetimes, labels, phis, ((ModelModule) model.createModule()).getTargetDataLayout());
 
         model.accept(module);

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMMetadata.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMMetadata.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.parser.bc.impl;
+
+import uk.ac.man.cs.llvm.ir.model.FunctionDeclaration;
+import uk.ac.man.cs.llvm.ir.model.FunctionDefinition;
+import uk.ac.man.cs.llvm.ir.model.FunctionVisitor;
+import uk.ac.man.cs.llvm.ir.model.GlobalAlias;
+import uk.ac.man.cs.llvm.ir.model.GlobalConstant;
+import uk.ac.man.cs.llvm.ir.model.GlobalVariable;
+import uk.ac.man.cs.llvm.ir.model.InstructionBlock;
+import uk.ac.man.cs.llvm.ir.model.InstructionVisitor;
+import uk.ac.man.cs.llvm.ir.model.MetadataBlock;
+import uk.ac.man.cs.llvm.ir.model.MetadataReferenceType;
+import uk.ac.man.cs.llvm.ir.model.Model;
+import uk.ac.man.cs.llvm.ir.model.ModelVisitor;
+import uk.ac.man.cs.llvm.ir.model.Symbol;
+import uk.ac.man.cs.llvm.ir.model.constants.MetadataConstant;
+import uk.ac.man.cs.llvm.ir.model.elements.AllocateInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.BinaryOperationInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.BranchInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.CallInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.CastInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.CompareInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.ConditionalBranchInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.ExtractElementInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.ExtractValueInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.GetElementPointerInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.IndirectBranchInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.InsertElementInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.InsertValueInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.LoadInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.PhiInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.ReturnInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.SelectInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.ShuffleVectorInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.StoreInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.SwitchInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.SwitchOldInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.UnreachableInstruction;
+import uk.ac.man.cs.llvm.ir.model.elements.VoidCallInstruction;
+import uk.ac.man.cs.llvm.ir.model.metadata.MetadataLocalVariable;
+import uk.ac.man.cs.llvm.ir.types.Type;
+
+/**
+ * Parse all those "@llvm.dbg.declare" call instructions and add the fitting Metadata reference to
+ * the referenced instruction to allow parsing of those data later one.
+ */
+public final class LLVMMetadata implements ModelVisitor {
+
+    public static LLVMMetadata generate(Model model) {
+        LLVMMetadata visitor = new LLVMMetadata(model.createModule().getMetadata());
+
+        model.accept(visitor);
+
+        return visitor;
+    }
+
+    private final MetadataBlock metadata;
+
+    private LLVMMetadata(MetadataBlock metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public void visit(GlobalAlias alias) {
+    }
+
+    @Override
+    public void visit(GlobalConstant constant) {
+    }
+
+    @Override
+    public void visit(GlobalVariable variable) {
+    }
+
+    @Override
+    public void visit(FunctionDeclaration function) {
+    }
+
+    @Override
+    public void visit(FunctionDefinition function) {
+        LLVMMetadataFunctionVisitor visitor = new LLVMMetadataFunctionVisitor(metadata);
+
+        function.accept(visitor);
+    }
+
+    @Override
+    public void visit(Type type) {
+    }
+
+    private static final class LLVMMetadataFunctionVisitor implements FunctionVisitor, InstructionVisitor {
+        private InstructionBlock currentBlock = null;
+
+        private final MetadataBlock metadata;
+
+        private LLVMMetadataFunctionVisitor(MetadataBlock metadata) {
+            this.metadata = metadata;
+        }
+
+        @Override
+        public void visit(InstructionBlock block) {
+            this.currentBlock = block;
+            block.accept(this);
+        }
+
+        @Override
+        public void visit(AllocateInstruction allocate) {
+        }
+
+        /*
+         * TODO: symbols seems to be misalign by 6 (probably because of the KIND Metadata nodes)
+         *
+         * I don't know why, but adding the metadata kinds to the symbols table creates currently
+         * more problems than it would probably solve. Either we miss some symbols in the symbol
+         * table and there is currently a workaround for the specific location calculation, or this
+         * misalign has some other causes.
+         */
+        private static final int SYMBOL_MISALIGN = -6;
+
+        @Override
+        public void visit(VoidCallInstruction call) {
+            Symbol callTarget = call.getCallTarget();
+
+            if (callTarget instanceof FunctionDeclaration) {
+                if (((FunctionDeclaration) (callTarget)).getName().equals("@llvm.dbg.declare")) {
+
+                    int symbolId = (int) ((MetadataConstant) call.getArgument(0)).getValue() + SYMBOL_MISALIGN;
+                    long metadataId = ((MetadataConstant) call.getArgument(1)).getValue();
+
+                    Symbol referencedSymbol = currentBlock.getFunctionSymbols().getSymbol(symbolId);
+
+                    // TODO: use visitor pattern
+                    // TODO: parse global variables
+                    if (referencedSymbol instanceof AllocateInstruction) {
+                        Type symType = ((AllocateInstruction) referencedSymbol).getPointeeType();
+                        if (symType instanceof MetadataReferenceType) {
+                            MetadataReferenceType metadataRefType = (MetadataReferenceType) symType;
+
+                            // TODO: other variables than localVar should be possible here
+                            MetadataLocalVariable localVar = (MetadataLocalVariable) metadata.getReference(metadataId).get();
+                            metadataRefType.setValidatedMetadataReference(localVar.getType());
+                        }
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void visit(BinaryOperationInstruction operation) {
+        }
+
+        @Override
+        public void visit(BranchInstruction branch) {
+        }
+
+        @Override
+        public void visit(CallInstruction call) {
+        }
+
+        @Override
+        public void visit(CastInstruction cast) {
+        }
+
+        @Override
+        public void visit(CompareInstruction operation) {
+        }
+
+        @Override
+        public void visit(ConditionalBranchInstruction branch) {
+        }
+
+        @Override
+        public void visit(ExtractElementInstruction extract) {
+        }
+
+        @Override
+        public void visit(ExtractValueInstruction extract) {
+        }
+
+        @Override
+        public void visit(GetElementPointerInstruction gep) {
+        }
+
+        @Override
+        public void visit(IndirectBranchInstruction branch) {
+        }
+
+        @Override
+        public void visit(InsertElementInstruction insert) {
+        }
+
+        @Override
+        public void visit(InsertValueInstruction insert) {
+        }
+
+        @Override
+        public void visit(LoadInstruction load) {
+        }
+
+        @Override
+        public void visit(PhiInstruction phi) {
+        }
+
+        @Override
+        public void visit(ReturnInstruction ret) {
+        }
+
+        @Override
+        public void visit(SelectInstruction select) {
+        }
+
+        @Override
+        public void visit(ShuffleVectorInstruction shuffle) {
+        }
+
+        @Override
+        public void visit(StoreInstruction store) {
+        }
+
+        @Override
+        public void visit(SwitchInstruction select) {
+        }
+
+        @Override
+        public void visit(SwitchOldInstruction select) {
+        }
+
+        @Override
+        public void visit(UnreachableInstruction unreachable) {
+        }
+    }
+}

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMMetadata.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMMetadata.java
@@ -219,17 +219,19 @@ public final class LLVMMetadata implements ModelVisitor {
             if (t1 instanceof StructureType) {
                 StructureType thisStruct = (StructureType) t1;
                 // TODO: should always be this type?
-                MetadataCompositeType metaStruct = (MetadataCompositeType) thisStruct.getMetadataReference().get();
-                thisStruct.setName(((MetadataString) metaStruct.getName().get()).getString());
+                if (thisStruct.getMetadataReference().isPresent()) {
+                    MetadataCompositeType metaStruct = (MetadataCompositeType) thisStruct.getMetadataReference().get();
+                    thisStruct.setName(((MetadataString) metaStruct.getName().get()).getString());
 
-                MetadataNode elements = (MetadataNode) metaStruct.getMemberDescriptors().get();
+                    MetadataNode elements = (MetadataNode) metaStruct.getMemberDescriptors().get();
 
-                Symbol idx = gep.getIndices().get(1);
-                int parsedIndex = idx instanceof IntegerConstant ? (int) ((IntegerConstant) (idx)).getValue() : 0;
-                MetadataReference element = elements.get(parsedIndex);
+                    Symbol idx = gep.getIndices().get(1);
+                    int parsedIndex = idx instanceof IntegerConstant ? (int) ((IntegerConstant) (idx)).getValue() : 0;
+                    MetadataReference element = elements.get(parsedIndex);
 
-                MetadataDerivedType derivedType = (MetadataDerivedType) element.get();
-                gep.setReferenceName(((MetadataString) derivedType.getName().get()).getString());
+                    MetadataDerivedType derivedType = (MetadataDerivedType) element.get();
+                    gep.setReferenceName(((MetadataString) derivedType.getName().get()).getString());
+                }
             }
         }
 

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMMetadata.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMMetadata.java
@@ -85,17 +85,14 @@ import uk.ac.man.cs.llvm.ir.types.Type;
 public final class LLVMMetadata implements ModelVisitor {
 
     public static LLVMMetadata generate(Model model) {
-        LLVMMetadata visitor = new LLVMMetadata(model.createModule().getMetadata());
+        LLVMMetadata visitor = new LLVMMetadata();
 
         model.accept(visitor);
 
         return visitor;
     }
 
-    private final MetadataBlock metadata;
-
-    private LLVMMetadata(MetadataBlock metadata) {
-        this.metadata = metadata;
+    private LLVMMetadata() {
     }
 
     @Override
@@ -116,7 +113,7 @@ public final class LLVMMetadata implements ModelVisitor {
 
     @Override
     public void visit(FunctionDefinition function) {
-        LLVMMetadataFunctionVisitor visitor = new LLVMMetadataFunctionVisitor(metadata);
+        LLVMMetadataFunctionVisitor visitor = new LLVMMetadataFunctionVisitor(function.getMetadata());
 
         function.accept(visitor);
     }
@@ -147,12 +144,11 @@ public final class LLVMMetadata implements ModelVisitor {
         /*
          * TODO: metadata seems to be misalign by 8
          *
-         * I don't know why, but there is a little misalign between calculted and real metadata id.
+         * I don't know why, but there is a little misalign between calculated and real metadata id.
          * This has to be solved in the future!
          *
-         * Possible issues could probably arrive when there are changes in the number of MDKinds or
-         * when using multiple functions (because it look like we should create an copy of Metadata
-         * for every function block)
+         * Possible issues could probably arrive when there are changes in the number of MDKinds.
+         * This has to be evaluated in the future
          */
         private static final int SYMBOL_MISALIGN = 8;
 

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/ModuleGenerator.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/ModuleGenerator.java
@@ -29,6 +29,7 @@
  */
 package uk.ac.man.cs.llvm.ir;
 
+import uk.ac.man.cs.llvm.ir.model.MetadataBlock;
 import uk.ac.man.cs.llvm.ir.module.TargetDataLayout;
 import uk.ac.man.cs.llvm.ir.types.FunctionType;
 import uk.ac.man.cs.llvm.ir.types.Type;
@@ -48,4 +49,6 @@ public interface ModuleGenerator extends SymbolGenerator {
     void exitModule();
 
     FunctionGenerator generateFunction();
+
+    MetadataBlock getMetadata();
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/ModuleGenerator.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/ModuleGenerator.java
@@ -29,7 +29,6 @@
  */
 package uk.ac.man.cs.llvm.ir;
 
-import uk.ac.man.cs.llvm.ir.model.MetadataBlock;
 import uk.ac.man.cs.llvm.ir.module.TargetDataLayout;
 import uk.ac.man.cs.llvm.ir.types.FunctionType;
 import uk.ac.man.cs.llvm.ir.types.Type;
@@ -49,6 +48,4 @@ public interface ModuleGenerator extends SymbolGenerator {
     void exitModule();
 
     FunctionGenerator generateFunction();
-
-    MetadataBlock getMetadata();
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/SymbolGenerator.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/SymbolGenerator.java
@@ -29,6 +29,8 @@
  */
 package uk.ac.man.cs.llvm.ir;
 
+import uk.ac.man.cs.llvm.ir.model.MetadataBlock;
+
 public interface SymbolGenerator extends ConstantGenerator {
 
     void nameBlock(int index, String name);
@@ -36,4 +38,6 @@ public interface SymbolGenerator extends ConstantGenerator {
     void nameEntry(int index, String name);
 
     void nameFunction(int index, int offset, String name);
+
+    MetadataBlock getMetadata();
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/FunctionDefinition.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/FunctionDefinition.java
@@ -68,8 +68,11 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
 
     private String name = ValueSymbol.UNKNOWN;
 
-    public FunctionDefinition(FunctionType type) {
+    private final MetadataBlock metadata;
+
+    public FunctionDefinition(FunctionType type, MetadataBlock metadata) {
         super(type.getReturnType(), type.getArgumentTypes(), type.isVarArg());
+        this.metadata = metadata;
     }
 
     public void accept(FunctionVisitor visitor) {
@@ -240,6 +243,11 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
     @Override
     public void createUndefined(Type type) {
         symbols.addSymbol(new UndefinedConstant(type));
+    }
+
+    @Override
+    public MetadataBlock getMetadata() {
+        return metadata;
     }
 
     @Override

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/FunctionDefinition.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/FunctionDefinition.java
@@ -68,7 +68,7 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
 
     private String name = ValueSymbol.UNKNOWN;
 
-    private final MetadataBlock metadata;
+    private MetadataBlock metadata;
 
     public FunctionDefinition(FunctionType type, MetadataBlock metadata) {
         super(type.getReturnType(), type.getArgumentTypes(), type.isVarArg());
@@ -83,6 +83,9 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
 
     @Override
     public void allocateBlocks(int count) {
+        // we don't want do add function specific metadata to the global scope
+        metadata = new MetadataBlock(metadata);
+
         blocks = new InstructionBlock[count];
         for (int i = 0; i < count; i++) {
             blocks[i] = new InstructionBlock(this, i);

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/InstructionBlock.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/InstructionBlock.java
@@ -229,6 +229,10 @@ public final class InstructionBlock implements InstructionGenerator, ValueSymbol
         return instructions.get(index);
     }
 
+    public Symbols getFunctionSymbols() {
+        return function.getSymbols();
+    }
+
     public int getInstructionCount() {
         return instructions.size();
     }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/MetadataBlock.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/MetadataBlock.java
@@ -76,6 +76,10 @@ public class MetadataBlock {
         return getReference((int) index);
     }
 
+    public int getCurrentIndex() {
+        return startIndex + metadata.size();
+    }
+
     public MetadataReference getReference(Type t) {
         if (t instanceof MetadataConstantType) {
             int index = (int) ((MetadataConstantType) t).getValue();

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/MetadataBlock.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/MetadataBlock.java
@@ -40,9 +40,18 @@ import uk.ac.man.cs.llvm.ir.types.Type;
 
 public class MetadataBlock {
 
-    protected final List<MetadataBaseNode> metadata = new ArrayList<>();
+    protected final List<MetadataBaseNode> metadata;
 
     protected int startIndex = 0;
+
+    public MetadataBlock() {
+        metadata = new ArrayList<>();
+    }
+
+    public MetadataBlock(MetadataBlock orig) {
+        this.metadata = new ArrayList<>(orig.metadata);
+        this.startIndex = orig.startIndex;
+    }
 
     public void setStartIndex(int index) {
         startIndex = index;
@@ -104,6 +113,11 @@ public class MetadataBlock {
         MetadataBaseNode get();
 
         int getIndex();
+    }
+
+    @Override
+    public String toString() {
+        return "MetadataBlock [startIndex=" + startIndex + ", metadata=" + metadata + "]";
     }
 
     public static final VoidReference voidRef = new VoidReference();

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/MetadataBlock.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/MetadataBlock.java
@@ -158,8 +158,42 @@ public class MetadataBlock {
         }
 
         @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + getOuterType().hashCode();
+            result = prime * result + index;
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Reference other = (Reference) obj;
+            if (!getOuterType().equals(other.getOuterType())) {
+                return false;
+            }
+            if (index != other.index) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
         public String toString() {
             return "!" + index;
+        }
+
+        private MetadataBlock getOuterType() {
+            return MetadataBlock.this;
         }
     }
 

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/MetadataReferenceType.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/MetadataReferenceType.java
@@ -27,13 +27,35 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package uk.ac.man.cs.llvm.ir.types;
+package uk.ac.man.cs.llvm.ir.model;
 
-import uk.ac.man.cs.llvm.ir.model.MetadataReferenceType;
+import uk.ac.man.cs.llvm.ir.model.MetadataBlock.MetadataReference;
 
-public interface AggregateType extends Type, MetadataReferenceType {
+public interface MetadataReferenceType {
+    MetadataReference getMetadataReference();
 
-    int getElementCount();
+    void setMetadataReference(MetadataReference metadata);
 
-    Type getElementType(int index);
+    /**
+     * Checks if a MetadataReference was already set, and if yes checks if it equals with the new
+     * one.
+     *
+     * When this check fails it gives an AssertionError, otherwise it behaves like
+     * setMetadataReference. This is required to spot contradictory type definitions (which
+     * shouldn't happen)
+     *
+     * @param metadata MetadataReference where this type was defined
+     *
+     * @throws AssertionError("contradictory type informations given")
+     */
+    default void setValidatedMetadataReference(MetadataReference metadata) {
+        // the only valid writing would happen when the reference was empty before
+        if (getMetadataReference() == MetadataBlock.voidRef) {
+            setMetadataReference(metadata);
+        }
+
+        if (!getMetadataReference().equals(metadata)) {
+            throw new AssertionError("contradictory type informations given");
+        }
+    }
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/ModelModule.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/ModelModule.java
@@ -67,6 +67,8 @@ public final class ModelModule implements ModuleGenerator {
 
     private final Symbols symbols = new Symbols();
 
+    private final MetadataBlock metadata = new MetadataBlock();
+
     private int currentFunction = -1;
 
     private TargetDataLayout targetDataLayout = null;
@@ -224,6 +226,11 @@ public final class ModelModule implements ModuleGenerator {
             }
         }
         throw new RuntimeException("Trying to generate undefined function");
+    }
+
+    @Override
+    public MetadataBlock getMetadata() {
+        return metadata;
     }
 
     @Override

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/ModelModule.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/ModelModule.java
@@ -175,7 +175,7 @@ public final class ModelModule implements ModuleGenerator {
             symbols.addSymbol(function);
             declares.add(function);
         } else {
-            FunctionDefinition method = new FunctionDefinition(type);
+            FunctionDefinition method = new FunctionDefinition(type, metadata);
             symbols.addSymbol(method);
             defines.add(method);
         }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/elements/GetElementPointerInstruction.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/elements/GetElementPointerInstruction.java
@@ -48,6 +48,8 @@ public final class GetElementPointerInstruction extends ValueInstruction {
 
     private final boolean isInbounds;
 
+    private String referenceName = null;
+
     private GetElementPointerInstruction(Type type, boolean isInbounds) {
         super(type);
         this.indices = new ArrayList<>();
@@ -80,6 +82,14 @@ public final class GetElementPointerInstruction extends ValueInstruction {
 
     public Symbol getBasePointer() {
         return base;
+    }
+
+    public void setReferenceName(String referenceName) {
+        this.referenceName = referenceName;
+    }
+
+    public String getReferenceName() {
+        return referenceName;
     }
 
     public List<Symbol> getIndices() {

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/metadata/MetadataFnNode.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/metadata/MetadataFnNode.java
@@ -1,0 +1,20 @@
+package uk.ac.man.cs.llvm.ir.model.metadata;
+
+public class MetadataFnNode implements MetadataBaseNode {
+
+    private final int value;
+
+    public MetadataFnNode(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "MetadataFnNode [" + value + "]";
+    }
+
+}

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/metadata/MetadataFnNode.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/metadata/MetadataFnNode.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package uk.ac.man.cs.llvm.ir.model.metadata;
 
 public class MetadataFnNode implements MetadataBaseNode {

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/Function.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/Function.java
@@ -82,7 +82,8 @@ public class Function implements ParserListener {
                 return new ValueSymbolTable(generator);
 
             case METADATA:
-                return version.createMetadata(types, symbols);
+                // return version.createMetadata(types, symbols, generator);
+                return ParserListener.DEFAULT; // TODO
 
             case METADATA_ATTACHMENT:
                 return ParserListener.DEFAULT; // TODO

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/Function.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/Function.java
@@ -82,11 +82,10 @@ public class Function implements ParserListener {
                 return new ValueSymbolTable(generator);
 
             case METADATA:
-                // return version.createMetadata(types, symbols, generator);
-                return ParserListener.DEFAULT; // TODO
+                return version.createMetadata(types, symbols, generator); // TODO
 
             case METADATA_ATTACHMENT:
-                return ParserListener.DEFAULT; // TODO
+                return version.createMetadata(types, symbols, generator); // TODO
 
             default:
                 System.out.printf("ENTER #12-FUNCTION-BLOCK: %s%n", block);

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/Metadata.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/Metadata.java
@@ -36,6 +36,7 @@ import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
 
 import uk.ac.man.cs.llvm.bc.ParserListener;
+import uk.ac.man.cs.llvm.ir.ModuleGenerator;
 import uk.ac.man.cs.llvm.ir.model.MetadataBlock;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataBasicType;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataCompileUnit;
@@ -60,27 +61,21 @@ import uk.ac.man.cs.llvm.ir.types.Type;
 
 public class Metadata implements ParserListener {
 
-    protected int idx = 1; // TODO: remove
-
     protected final Types types;
 
     protected final List<Type> symbols;
 
-    protected final MetadataBlock metadata = new MetadataBlock();
+    protected final MetadataBlock metadata;
 
-    protected int oldMetadataSize = 0; // TODO: only for debugging purpose
-
-    public Metadata(Types types, List<Type> symbols) {
+    public Metadata(Types types, List<Type> symbols, ModuleGenerator generator) {
         this.types = types;
         this.symbols = symbols;
+        metadata = generator.getMetadata();
         metadata.setStartIndex(1);
     }
 
     protected void printMetadataDebugMsg() {
-        if (metadata.size() != oldMetadataSize) {
-            LLVMLogger.info("!" + idx + " - " + metadata.getAbsolute(metadata.size() - 1));
-            oldMetadataSize = metadata.size();
-        }
+        LLVMLogger.info("!" + (metadata.getCurrentIndex() - 1) + " - " + metadata.getAbsolute(metadata.size() - 1));
     }
 
     protected static long unrotateSign(long u) {
@@ -188,15 +183,14 @@ public class Metadata implements ParserListener {
                 break;
 
             default:
-                System.out.println("!" + idx + " - " + record + ": " + Arrays.toString(args));
+                metadata.add(null);
+                System.out.println("! - " + record + ": " + Arrays.toString(args));
                 break;
         }
 
         if (LLVMBaseOptionFacade.verboseEnabled()) {
             printMetadataDebugMsg();
         }
-
-        idx++;
     }
 
     protected void createString(long[] args) {
@@ -241,11 +235,12 @@ public class Metadata implements ParserListener {
 
     protected void createDistinctNode(long[] args) {
         // [n x md num]
-
-        System.out.println("!" + idx + " - " + MetadataRecord.DISTINCT_NODE + " - " + Arrays.toString(args));
+        metadata.add(null);
+        System.out.println("! - " + MetadataRecord.DISTINCT_NODE + " - " + Arrays.toString(args));
     }
 
     protected void createKind(long[] args) {
+        // symbols.add(MetaType.METADATA); // TODO
         StringBuilder builder = new StringBuilder();
         for (int i = 1; i < args.length; i++) {
             builder.append((char) args[i]); // TODO: unicode characters?
@@ -264,8 +259,8 @@ public class Metadata implements ParserListener {
         // long column = args[i++];
         // long scope = args[i++];
         // long inlineAt = args[i++];
-
-        System.out.println("!" + idx + " - " + MetadataRecord.LOCATION + " - " + Arrays.toString(args));
+        metadata.add(null);
+        System.out.println("! - " + MetadataRecord.LOCATION + " - " + Arrays.toString(args));
     }
 
     protected void createNamedNode(long[] args) {
@@ -280,8 +275,8 @@ public class Metadata implements ParserListener {
 
     protected void createAttachment(long[] args) {
         // [n x mdnodes]
-
-        System.out.println("!" + idx + " - " + MetadataRecord.ATTACHMENT + " - " + Arrays.toString(args));
+        metadata.add(null);
+        System.out.println("! - " + MetadataRecord.ATTACHMENT + " - " + Arrays.toString(args));
     }
 
     protected void createGenericDebug(long[] args) {
@@ -292,8 +287,8 @@ public class Metadata implements ParserListener {
         // long vers = args[i++];
         // long header = args[i++];
         // TODO: args[4] // n x md num
-
-        System.out.println("!" + idx + " - " + MetadataRecord.GENERIC_DEBUG + " - " + Arrays.toString(args));
+        metadata.add(null);
+        System.out.println("! - " + MetadataRecord.GENERIC_DEBUG + " - " + Arrays.toString(args));
     }
 
     protected void createSubrange(long[] args) {

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/Metadata.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/Metadata.java
@@ -36,7 +36,7 @@ import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
 
 import uk.ac.man.cs.llvm.bc.ParserListener;
-import uk.ac.man.cs.llvm.ir.ModuleGenerator;
+import uk.ac.man.cs.llvm.ir.SymbolGenerator;
 import uk.ac.man.cs.llvm.ir.model.MetadataBlock;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataBasicType;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataCompileUnit;
@@ -67,7 +67,7 @@ public class Metadata implements ParserListener {
 
     protected final MetadataBlock metadata;
 
-    public Metadata(Types types, List<Type> symbols, ModuleGenerator generator) {
+    public Metadata(Types types, List<Type> symbols, SymbolGenerator generator) {
         this.types = types;
         this.symbols = symbols;
         metadata = generator.getMetadata();

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
@@ -225,6 +225,7 @@ public class MetadataV32 extends Metadata {
         node.setName(metadata.getReference(args.next()));
         node.setDisplayName(metadata.getReference(args.next()));
         node.setLinkageName(metadata.getReference(args.next()));
+        node.setFile(metadata.getReference(args.next()));
         node.setLine(asInt32(args.next()));
         node.setType(metadata.getReference(args.next()));
         node.setLocalToCompileUnit(asInt1(args.next()));

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
 import uk.ac.man.cs.llvm.ir.module.records.MetadataRecord;
+import uk.ac.man.cs.llvm.ir.ModuleGenerator;
 import uk.ac.man.cs.llvm.ir.model.MetadataBlock;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataBasicType;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataCompileUnit;
@@ -53,11 +54,10 @@ import uk.ac.man.cs.llvm.ir.types.MetadataConstantType;
 import uk.ac.man.cs.llvm.ir.types.Type;
 
 public class MetadataV32 extends Metadata {
-    public MetadataV32(Types types, List<Type> symbols) {
-        super(types, symbols);
+    public MetadataV32(Types types, List<Type> symbols, ModuleGenerator generator) {
+        super(types, symbols, generator);
         // it seem's like there is a different offset of the id in LLVM 3.2 and LLVM 3.8
         metadata.setStartIndex(0);
-        idx = 0; // TODO: remove
     }
 
     protected boolean asInt1(Type t) {
@@ -97,8 +97,6 @@ public class MetadataV32 extends Metadata {
         if (LLVMBaseOptionFacade.verboseEnabled()) {
             printMetadataDebugMsg();
         }
-
-        idx++;
     }
 
     protected void createOldNode(long[] args) {
@@ -189,12 +187,14 @@ public class MetadataV32 extends Metadata {
                     break;
 
                 default:
-                    System.out.println("!" + idx + " - TODO: #" + record);
+                    metadata.add(null);
+                    System.out.println("! - TODO: #" + record);
                     break;
             }
         } else {
             parsedArgs.rewind();
-            System.out.println("!" + idx + " - " + MetadataRecord.OLD_NODE + ": " + parsedArgs);
+            metadata.add(null);
+            System.out.println("! - " + MetadataRecord.OLD_NODE + ": " + parsedArgs);
         }
     }
 

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
 import uk.ac.man.cs.llvm.ir.module.records.MetadataRecord;
-import uk.ac.man.cs.llvm.ir.ModuleGenerator;
+import uk.ac.man.cs.llvm.ir.SymbolGenerator;
 import uk.ac.man.cs.llvm.ir.model.MetadataBlock;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataBasicType;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataCompileUnit;
@@ -41,6 +41,7 @@ import uk.ac.man.cs.llvm.ir.model.metadata.MetadataCompositeType;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataDerivedType;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataEnumerator;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataFile;
+import uk.ac.man.cs.llvm.ir.model.metadata.MetadataFnNode;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataGlobalVariable;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataLexicalBlock;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataLexicalBlockFile;
@@ -54,7 +55,7 @@ import uk.ac.man.cs.llvm.ir.types.MetadataConstantType;
 import uk.ac.man.cs.llvm.ir.types.Type;
 
 public class MetadataV32 extends Metadata {
-    public MetadataV32(Types types, List<Type> symbols, ModuleGenerator generator) {
+    public MetadataV32(Types types, List<Type> symbols, SymbolGenerator generator) {
         super(types, symbols, generator);
         // it seem's like there is a different offset of the id in LLVM 3.2 and LLVM 3.8
         metadata.setStartIndex(0);
@@ -86,7 +87,7 @@ public class MetadataV32 extends Metadata {
                 break;
 
             case OLD_FN_NODE:
-                createOldFnNode(); // TODO: implement
+                createOldFnNode(args);
                 break;
 
             default:
@@ -198,8 +199,10 @@ public class MetadataV32 extends Metadata {
         }
     }
 
-    protected void createOldFnNode() {
-        // TODO: implement
+    protected void createOldFnNode(long[] args) {
+        MetadataArgumentParser parsedArgs = new MetadataArgumentParser(types, symbols, args);
+
+        metadata.add(new MetadataFnNode(asInt32(parsedArgs.next())));
     }
 
     protected void createDwNode(MetadataArgumentParser args) {

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV38.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV38.java
@@ -31,11 +31,11 @@ package uk.ac.man.cs.llvm.ir.module;
 
 import java.util.List;
 
-import uk.ac.man.cs.llvm.ir.ModuleGenerator;
+import uk.ac.man.cs.llvm.ir.SymbolGenerator;
 import uk.ac.man.cs.llvm.ir.types.Type;
 
 public class MetadataV38 extends Metadata {
-    public MetadataV38(Types types, List<Type> symbols, ModuleGenerator generator) {
+    public MetadataV38(Types types, List<Type> symbols, SymbolGenerator generator) {
         super(types, symbols, generator);
     }
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV38.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV38.java
@@ -31,10 +31,11 @@ package uk.ac.man.cs.llvm.ir.module;
 
 import java.util.List;
 
+import uk.ac.man.cs.llvm.ir.ModuleGenerator;
 import uk.ac.man.cs.llvm.ir.types.Type;
 
 public class MetadataV38 extends Metadata {
-    public MetadataV38(Types types, List<Type> symbols) {
-        super(types, symbols);
+    public MetadataV38(Types types, List<Type> symbols, ModuleGenerator generator) {
+        super(types, symbols, generator);
     }
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/Module.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/Module.java
@@ -96,7 +96,7 @@ public class Module implements ParserListener {
                 return new ValueSymbolTable(generator);
 
             case METADATA:
-                return version.createMetadata(types, symbols);
+                return version.createMetadata(types, symbols, generator);
 
             default:
                 return ParserListener.DEFAULT;

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/ModuleVersion.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/ModuleVersion.java
@@ -47,7 +47,7 @@ public enum ModuleVersion {
     @FunctionalInterface
     private interface MetadataParser {
 
-        Metadata instantiate(Types types, List<Type> symbols);
+        Metadata instantiate(Types types, List<Type> symbols, ModuleGenerator generator);
     }
 
     @FunctionalInterface
@@ -94,8 +94,8 @@ public enum ModuleVersion {
         }
     }
 
-    public Metadata createMetadata(Types types, List<Type> symbols) {
-        return metadata.instantiate(types, symbols);
+    public Metadata createMetadata(Types types, List<Type> symbols, ModuleGenerator generator) {
+        return metadata.instantiate(types, symbols, generator);
     }
 
     public Constants createConstants(Types types, List<Type> symbols, ConstantGenerator generator) {

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/ModuleVersion.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/ModuleVersion.java
@@ -36,6 +36,7 @@ import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import uk.ac.man.cs.llvm.ir.ConstantGenerator;
 import uk.ac.man.cs.llvm.ir.FunctionGenerator;
 import uk.ac.man.cs.llvm.ir.ModuleGenerator;
+import uk.ac.man.cs.llvm.ir.SymbolGenerator;
 import uk.ac.man.cs.llvm.ir.types.Type;
 
 public enum ModuleVersion {
@@ -47,7 +48,7 @@ public enum ModuleVersion {
     @FunctionalInterface
     private interface MetadataParser {
 
-        Metadata instantiate(Types types, List<Type> symbols, ModuleGenerator generator);
+        Metadata instantiate(Types types, List<Type> symbols, SymbolGenerator generator);
     }
 
     @FunctionalInterface
@@ -94,7 +95,7 @@ public enum ModuleVersion {
         }
     }
 
-    public Metadata createMetadata(Types types, List<Type> symbols, ModuleGenerator generator) {
+    public Metadata createMetadata(Types types, List<Type> symbols, SymbolGenerator generator) {
         return metadata.instantiate(types, symbols, generator);
     }
 

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/types/ArrayType.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/types/ArrayType.java
@@ -31,11 +31,16 @@ package uk.ac.man.cs.llvm.ir.types;
 
 import java.util.Objects;
 
+import uk.ac.man.cs.llvm.ir.model.MetadataBlock;
+import uk.ac.man.cs.llvm.ir.model.MetadataBlock.MetadataReference;
+
 public class ArrayType implements AggregateType {
 
     public final Type type;
 
     private final int size;
+
+    private MetadataReference metadata = MetadataBlock.voidRef;
 
     public ArrayType(Type type, int size) {
         super();
@@ -92,5 +97,15 @@ public class ArrayType implements AggregateType {
     @Override
     public String toString() {
         return String.format("[%d x %s]", getElementCount(), getElementType());
+    }
+
+    @Override
+    public void setMetadataReference(MetadataReference metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public MetadataReference getMetadataReference() {
+        return metadata;
     }
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/types/StructureType.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/types/StructureType.java
@@ -29,6 +29,8 @@
  */
 package uk.ac.man.cs.llvm.ir.types;
 
+import uk.ac.man.cs.llvm.ir.model.MetadataBlock;
+import uk.ac.man.cs.llvm.ir.model.MetadataBlock.MetadataReference;
 import uk.ac.man.cs.llvm.ir.model.ValueSymbol;
 
 public final class StructureType implements AggregateType, ValueSymbol {
@@ -38,6 +40,8 @@ public final class StructureType implements AggregateType, ValueSymbol {
     private final boolean isPacked;
 
     private final Type[] types;
+
+    private MetadataReference metadata = MetadataBlock.voidRef;
 
     public StructureType(boolean isPacked, Type[] types) {
         this.isPacked = isPacked;
@@ -140,5 +144,15 @@ public final class StructureType implements AggregateType, ValueSymbol {
         }
         int mask = alignment - 1;
         return (alignment - (address & mask)) & mask;
+    }
+
+    @Override
+    public void setMetadataReference(MetadataReference metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public MetadataReference getMetadataReference() {
+        return metadata;
     }
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/types/VectorType.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/types/VectorType.java
@@ -31,11 +31,16 @@ package uk.ac.man.cs.llvm.ir.types;
 
 import java.util.Objects;
 
+import uk.ac.man.cs.llvm.ir.model.MetadataBlock;
+import uk.ac.man.cs.llvm.ir.model.MetadataBlock.MetadataReference;
+
 public class VectorType implements AggregateType {
 
     public final Type type;
 
     private final int length;
+
+    private MetadataReference metadata = MetadataBlock.voidRef;
 
     public VectorType(Type type, int length) {
         this.type = type;
@@ -81,5 +86,15 @@ public class VectorType implements AggregateType {
     @Override
     public String toString() {
         return String.format("<%d x %s>", getElementCount(), getElementType());
+    }
+
+    @Override
+    public void setMetadataReference(MetadataReference metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public MetadataReference getMetadataReference() {
+        return metadata;
     }
 }


### PR DESCRIPTION
This is a first implementation to get the name of an struct element into the corresponding ```GetElementPointerInstruction```

The code is capable of parsing element names including references to other structs and some simple pointer arithmetic.

But there are also limitations, like doing for example a typecast from ```*point``` to ```*ball``` which would results in wrong name assignments.
One other example for the limitations of element name recognition is when someone tries to access a struct element using pointer arithmetic on the base pointer of the struct, like: ```*((int*)&p + 1) = 10;```.

Here is a little example of what element names could already be parsed with this code: 

```c
struct ball {
	float diameter;
};

struct point {
	int x, y;
	char a, b;
	long i, j;
	int array[10];
	struct ball *k;
};

int main() {
	struct point p;
	struct ball b;
	p.x = 10;           // x
	p.a = 'A';          // a
	p.i = 2016;         // i
	p.k = &b;           // k
	p.array[0] = 1;     // array
	p.array[9] = 2;     // array
	int i = 5;
	*(p.array + i) = 3; // array
	p.k->diameter = 2;  // diameter
}
```