### PR TITLE
Use LLVMFunction as an interface in the parser and function registry …

### DIFF
--- a/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
+++ b/projects/com.oracle.truffle.llvm.nativeint/src/com/oracle/truffle/llvm/nativeint/NativeLookup.java
@@ -50,7 +50,7 @@ import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
 import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
-import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.LLVMFunction;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
 public class NativeLookup {
@@ -61,9 +61,9 @@ public class NativeLookup {
 
     private List<NativeLibraryHandle> libraryHandles;
 
-    private final Map<LLVMFunctionDescriptor, Integer> nativeFunctionLookupStats;
+    private final Map<LLVMFunction, Integer> nativeFunctionLookupStats;
 
-    private final Map<LLVMFunctionDescriptor, NativeFunctionHandle> cachedNativeFunctions = new WeakHashMap<>();
+    private final Map<LLVMFunction, NativeFunctionHandle> cachedNativeFunctions = new WeakHashMap<>();
 
     private final NodeFactoryFacade facade;
 
@@ -153,7 +153,7 @@ public class NativeLookup {
         return lookupSymbol(name.substring(1));
     }
 
-    public NativeFunctionHandle getNativeHandle(LLVMFunctionDescriptor function, LLVMExpressionNode[] args) {
+    public NativeFunctionHandle getNativeHandle(LLVMFunction function, LLVMExpressionNode[] args) {
         CompilerAsserts.neverPartOfCompilation();
         if (cachedNativeFunctions.containsKey(function)) {
             return cachedNativeFunctions.get(function);
@@ -167,7 +167,7 @@ public class NativeLookup {
         }
     }
 
-    private NativeFunctionHandle uncachedGetNativeFunctionHandle(LLVMFunctionDescriptor function, LLVMExpressionNode[] args) {
+    private NativeFunctionHandle uncachedGetNativeFunctionHandle(LLVMFunction function, LLVMExpressionNode[] args) {
         Class<?> retType = getJavaClass(function.getReturnType());
         Class<?>[] paramTypes = getJavaClassses(args);
         String functionName = function.getName().substring(1);
@@ -186,7 +186,7 @@ public class NativeLookup {
         return functionHandle;
     }
 
-    private void recordNativeFunctionCallSite(LLVMFunctionDescriptor function) {
+    private void recordNativeFunctionCallSite(LLVMFunction function) {
         CompilerAsserts.neverPartOfCompilation();
         Integer val = nativeFunctionLookupStats.get(function);
         int newVal;
@@ -245,7 +245,7 @@ public class NativeLookup {
         }
     }
 
-    public Map<LLVMFunctionDescriptor, Integer> getNativeFunctionLookupStats() {
+    public Map<LLVMFunction, Integer> getNativeFunctionLookupStats() {
         return nativeFunctionLookupStats;
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMContext.java
@@ -44,6 +44,7 @@ import com.oracle.truffle.llvm.nativeint.NativeLookup;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMThread;
 import com.oracle.truffle.llvm.parser.NodeFactoryFacade;
+import com.oracle.truffle.llvm.types.LLVMFunction;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.memory.LLVMStack;
 
@@ -83,7 +84,7 @@ public class LLVMContext extends ExecutionContext {
     }
 
     public NativeFunctionHandle getNativeHandle(LLVMFunctionDescriptor function, LLVMExpressionNode[] args) {
-        LLVMFunctionDescriptor sameFunction = getFunctionDescriptor(function);
+        LLVMFunction sameFunction = getFunctionDescriptor(function);
         return getNativeLookup().getNativeHandle(sameFunction, args);
     }
 
@@ -96,9 +97,9 @@ public class LLVMContext extends ExecutionContext {
      * needs the return type of the function, we here have to look up the complete function
      * descriptor.
      */
-    private LLVMFunctionDescriptor getFunctionDescriptor(LLVMFunctionDescriptor incompleteFunctionDescriptor) {
+    private LLVMFunction getFunctionDescriptor(LLVMFunctionDescriptor incompleteFunctionDescriptor) {
         int validFunctionIndex = incompleteFunctionDescriptor.getFunctionIndex();
-        LLVMFunctionDescriptor[] completeFunctionDescriptors = functionRegistry.getFunctionDescriptors();
+        LLVMFunction[] completeFunctionDescriptors = functionRegistry.getFunctionDescriptors();
         return completeFunctionDescriptors[validFunctionIndex];
     }
 
@@ -114,7 +115,7 @@ public class LLVMContext extends ExecutionContext {
         return getNativeLookup().getNativeHandle(functionName);
     }
 
-    public Map<LLVMFunctionDescriptor, Integer> getNativeFunctionLookupStats() {
+    public Map<LLVMFunction, Integer> getNativeFunctionLookupStats() {
         return getNativeLookup().getNativeFunctionLookupStats();
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMFunctionRegistry.java
@@ -104,6 +104,9 @@ public class LLVMFunctionRegistry {
         RootCallTarget[] newFunctionPtrCallTargetMap = new RootCallTarget[maxFunctionIndex];
         System.arraycopy(functionPtrCallTargetMap, 0, newFunctionPtrCallTargetMap, 0, functionPtrCallTargetMap.length);
         for (LLVMFunction func : functionCallTargets.keySet()) {
+            if (func.getFunctionIndex() == -1) {
+                throw new AssertionError(func.getName());
+            }
             newFunctionPtrCallTargetMap[func.getFunctionIndex()] = functionCallTargets.get(func);
         }
         functionPtrCallTargetMap = newFunctionPtrCallTargetMap;

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMLanguage.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMLanguage.java
@@ -36,7 +36,7 @@ import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.Source;
-import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.LLVMFunction;
 
 @TruffleLanguage.Registration(name = "Sulong", version = "0.01", mimeType = {LLVMLanguage.LLVM_IR_MIME_TYPE, LLVMLanguage.LLVM_BITCODE_MIME_TYPE, LLVMLanguage.SULONG_LIBRARY_MIME_TYPE})
 public final class LLVMLanguage extends TruffleLanguage<LLVMContext> {
@@ -104,7 +104,7 @@ public final class LLVMLanguage extends TruffleLanguage<LLVMContext> {
     @Override
     protected Object findExportedSymbol(LLVMContext context, String globalName, boolean onlyExplicit) {
         String atname = "@" + globalName; // for interop
-        for (LLVMFunctionDescriptor descr : context.getFunctionRegistry().getFunctionDescriptors()) {
+        for (LLVMFunction descr : context.getFunctionRegistry().getFunctionDescriptors()) {
             if (descr != null && descr.getName().equals(globalName)) {
                 return descr;
             } else if (descr != null && descr.getName().equals(atname)) {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
@@ -51,7 +51,7 @@ import com.oracle.truffle.llvm.runtime.LLVMExitException;
 import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.LLVMFunction;
 
 /**
  * The global entry point initializes the global scope and starts execution with the main function.
@@ -166,13 +166,13 @@ public class LLVMGlobalRootNode extends RootNode {
 
     @TruffleBoundary
     protected static void printNativeCallStats(LLVMContext context) {
-        Map<LLVMFunctionDescriptor, Integer> nativeFunctionCallSites = context.getNativeFunctionLookupStats();
+        Map<LLVMFunction, Integer> nativeFunctionCallSites = context.getNativeFunctionLookupStats();
         // Checkstyle: stop
         if (!nativeFunctionCallSites.isEmpty()) {
             System.out.println("==========================");
             System.out.println("native function sites:");
             System.out.println("==========================");
-            for (LLVMFunctionDescriptor function : nativeFunctionCallSites.keySet()) {
+            for (LLVMFunction function : nativeFunctionCallSites.keySet()) {
                 String output = String.format("%15s: %3d", function.getName(), nativeFunctionCallSites.get(function));
                 System.out.println(output);
             }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMTruffleOnlyIntrinsics.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMTruffleOnlyIntrinsics.java
@@ -47,7 +47,7 @@ import com.oracle.truffle.llvm.nodes.impl.intrinsics.interop.ToLLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsic.LLVMI32Intrinsic;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.LLVMIntrinsic.LLVMI64Intrinsic;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.LLVMFunction;
 
 public final class LLVMTruffleOnlyIntrinsics {
 
@@ -58,7 +58,7 @@ public final class LLVMTruffleOnlyIntrinsics {
 
         protected final NativeFunctionHandle handle;
 
-        public LLVMTruffleOnlyI64Intrinsic(LLVMFunctionDescriptor descriptor) {
+        public LLVMTruffleOnlyI64Intrinsic(LLVMFunction descriptor) {
             handle = NativeLookup.getNFI().getFunctionHandle(descriptor.getName().substring(1), getReturnValueClass(), getParameterClasses());
         }
 
@@ -73,7 +73,7 @@ public final class LLVMTruffleOnlyIntrinsics {
 
         protected final NativeFunctionHandle handle;
 
-        public LLVMTruffleOnlyI32Intrinsic(LLVMFunctionDescriptor descriptor) {
+        public LLVMTruffleOnlyI32Intrinsic(LLVMFunction descriptor) {
             handle = NativeLookup.getNFI().getFunctionHandle(descriptor.getName().substring(1), getReturnValueClass(), getParameterClasses());
         }
 
@@ -87,7 +87,7 @@ public final class LLVMTruffleOnlyIntrinsics {
     @NodeChild(type = LLVMExpressionNode.class)
     public abstract static class LLVMStrlen extends LLVMTruffleOnlyI64Intrinsic {
 
-        public LLVMStrlen(LLVMFunctionDescriptor descriptor) {
+        public LLVMStrlen(LLVMFunction descriptor) {
             super(descriptor);
         }
 
@@ -128,7 +128,7 @@ public final class LLVMTruffleOnlyIntrinsics {
     @NodeChildren({@NodeChild(type = LLVMExpressionNode.class), @NodeChild(type = LLVMExpressionNode.class)})
     public abstract static class LLVMStrCmp extends LLVMTruffleOnlyI32Intrinsic {
 
-        public LLVMStrCmp(LLVMFunctionDescriptor descriptor) {
+        public LLVMStrCmp(LLVMFunction descriptor) {
             super(descriptor);
         }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMDirectLoadNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/memory/load/LLVMDirectLoadNode.java
@@ -83,7 +83,7 @@ public abstract class LLVMDirectLoadNode {
 
         @Specialization
         public LLVMFunctionDescriptor executeAddress(LLVMAddress addr) {
-            return getFunctionRegistry().createFromIndex(LLVMHeap.getFunctionIndex(addr));
+            return (LLVMFunctionDescriptor) getFunctionRegistry().createFromIndex(LLVMHeap.getFunctionIndex(addr));
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/LLVMParserResultImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/LLVMParserResultImpl.java
@@ -27,7 +27,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.oracle.truffle.llvm.parser.bc.impl;
+package com.oracle.truffle.llvm.parser.base;
 
 import java.util.List;
 import java.util.Map;
@@ -36,27 +36,27 @@ import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.llvm.parser.LLVMParserResult;
 import com.oracle.truffle.llvm.types.LLVMFunction;
 
-public class LLVMBitcodeParserResult implements LLVMParserResult {
+public class LLVMParserResultImpl implements LLVMParserResult {
 
     private final RootCallTarget mainFunction;
-    private final RootCallTarget staticInits;
-    private final RootCallTarget staticDestructors;
+    private final RootCallTarget globalVarInits;
+    private final RootCallTarget globalVarDeallocs;
     private final List<RootCallTarget> constructorFunctions;
     private final List<RootCallTarget> destructorFunctions;
     private final Map<LLVMFunction, RootCallTarget> parsedFunctions;
 
-    public LLVMBitcodeParserResult(RootCallTarget mainFunction,
-                    RootCallTarget staticInits,
-                    RootCallTarget staticDestructors,
-                    Map<LLVMFunction, RootCallTarget> parsedFunctions,
+    public LLVMParserResultImpl(RootCallTarget mainFunction,
+                    RootCallTarget globalVarInits,
+                    RootCallTarget globalVarDeallocs,
                     List<RootCallTarget> constructorFunctions,
-                    List<RootCallTarget> destructorFunctions) {
+                    List<RootCallTarget> destructorFunctions,
+                    Map<LLVMFunction, RootCallTarget> parsedFunctions) {
         this.mainFunction = mainFunction;
-        this.staticInits = staticInits;
-        this.staticDestructors = staticDestructors;
-        this.parsedFunctions = parsedFunctions;
+        this.globalVarInits = globalVarInits;
+        this.globalVarDeallocs = globalVarDeallocs;
         this.constructorFunctions = constructorFunctions;
         this.destructorFunctions = destructorFunctions;
+        this.parsedFunctions = parsedFunctions;
     }
 
     @Override
@@ -71,12 +71,12 @@ public class LLVMBitcodeParserResult implements LLVMParserResult {
 
     @Override
     public RootCallTarget getGlobalVarInits() {
-        return staticInits;
+        return globalVarInits;
     }
 
     @Override
     public RootCallTarget getGlobalVarDeallocs() {
-        return staticDestructors;
+        return globalVarDeallocs;
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeParserResult.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeParserResult.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.llvm.parser.LLVMParserResult;
-import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.LLVMFunction;
 
 public class LLVMBitcodeParserResult implements LLVMParserResult {
 
@@ -43,12 +43,12 @@ public class LLVMBitcodeParserResult implements LLVMParserResult {
     private final RootCallTarget staticDestructors;
     private final List<RootCallTarget> constructorFunctions;
     private final List<RootCallTarget> destructorFunctions;
-    private final Map<LLVMFunctionDescriptor, RootCallTarget> parsedFunctions;
+    private final Map<LLVMFunction, RootCallTarget> parsedFunctions;
 
     public LLVMBitcodeParserResult(RootCallTarget mainFunction,
                     RootCallTarget staticInits,
                     RootCallTarget staticDestructors,
-                    Map<LLVMFunctionDescriptor, RootCallTarget> parsedFunctions,
+                    Map<LLVMFunction, RootCallTarget> parsedFunctions,
                     List<RootCallTarget> constructorFunctions,
                     List<RootCallTarget> destructorFunctions) {
         this.mainFunction = mainFunction;
@@ -65,7 +65,7 @@ public class LLVMBitcodeParserResult implements LLVMParserResult {
     }
 
     @Override
-    public Map<LLVMFunctionDescriptor, RootCallTarget> getParsedFunctions() {
+    public Map<LLVMFunction, RootCallTarget> getParsedFunctions() {
         return parsedFunctions;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
@@ -75,7 +75,7 @@ import com.oracle.truffle.llvm.parser.factories.LLVMMemoryReadWriteFactory;
 import com.oracle.truffle.llvm.parser.factories.LLVMRootNodeFactory;
 import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
 import com.oracle.truffle.llvm.types.LLVMAddress;
-import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.LLVMFunction;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 import com.oracle.truffle.llvm.types.LLVMGlobalVariableDescriptor;
 import com.oracle.truffle.llvm.types.memory.LLVMHeap;
@@ -120,7 +120,7 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
 
         model.accept(module);
 
-        LLVMFunctionDescriptor mainFunction = module.getFunction("@main");
+        LLVMFunction mainFunction = module.getFunction("@main");
 
         FrameDescriptor frame = new FrameDescriptor();
         FrameSlot stack = frame.addFrameSlot(LLVMFrameIDs.STACK_ADDRESS_FRAME_SLOT_ID);
@@ -159,7 +159,7 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
 
     private final Map<GlobalAlias, Symbol> aliases = new HashMap<>();
 
-    private final Map<LLVMFunctionDescriptor, RootCallTarget> functions = new HashMap<>();
+    private final Map<LLVMFunction, RootCallTarget> functions = new HashMap<>();
 
     private final Map<GlobalValueSymbol, LLVMAddressNode> globals = new HashMap<>();
 
@@ -273,8 +273,8 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
         return deallocations.toArray(new LLVMNode[deallocations.size()]);
     }
 
-    public LLVMFunctionDescriptor getFunction(String name) {
-        for (LLVMFunctionDescriptor function : functions.keySet()) {
+    public LLVMFunction getFunction(String name) {
+        for (LLVMFunction function : functions.keySet()) {
             if (function.getName().equals(name)) {
                 return function;
             }
@@ -282,7 +282,7 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
         return null;
     }
 
-    public Map<LLVMFunctionDescriptor, RootCallTarget> getFunctions() {
+    public Map<LLVMFunction, RootCallTarget> getFunctions() {
         return functions;
     }
 
@@ -432,7 +432,7 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
 
         LLVMRuntimeType llvmReturnType = LLVMBitcodeTypeHelper.toRuntimeType(method.getReturnType());
         LLVMRuntimeType[] llvmParamTypes = LLVMBitcodeTypeHelper.toRuntimeTypes(method.getArgumentTypes());
-        LLVMFunctionDescriptor function = context.getFunctionRegistry().createFunctionDescriptor(method.getName(), llvmReturnType, llvmParamTypes, method.isVarArg());
+        LLVMFunction function = context.getFunctionRegistry().createFunctionDescriptor(method.getName(), llvmReturnType, llvmParamTypes, method.isVarArg());
         RootCallTarget callTarget = Truffle.getRuntime().createCallTarget(rootNode);
         functions.put(function, callTarget);
     }

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
@@ -62,6 +62,7 @@ import com.oracle.truffle.llvm.nodes.impl.others.LLVMAccessGlobalVariableStorage
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMStaticInitsBlockNode;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMParserResult;
+import com.oracle.truffle.llvm.parser.base.LLVMParserResultImpl;
 import com.oracle.truffle.llvm.parser.base.datalayout.DataLayoutConverter;
 import com.oracle.truffle.llvm.parser.bc.impl.nodes.LLVMConstantGenerator;
 import com.oracle.truffle.llvm.parser.base.util.LLVMBitcodeTypeHelper;
@@ -136,15 +137,15 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
         final List<RootCallTarget> destructorFunctions = module.getStructor("@llvm.global_dtors", frame, stack);
 
         if (mainFunction == null) {
-            return new LLVMBitcodeParserResult(Truffle.getRuntime().createCallTarget(RootNode.createConstantNode(stack)), globalVarInitsTarget, globalVarDeallocsTarget, module.getFunctions(),
-                            constructorFunctions, destructorFunctions);
+            return new LLVMParserResultImpl(Truffle.getRuntime().createCallTarget(RootNode.createConstantNode(stack)), globalVarInitsTarget, globalVarDeallocsTarget, constructorFunctions,
+                            destructorFunctions, module.getFunctions());
         }
         RootCallTarget mainCallTarget = module.getFunctions().get(mainFunction);
         RootNode globalFunction = LLVMRootNodeFactory.createGlobalRootNode(context, stack, frame, mainCallTarget, context.getMainArguments(), source, mainFunction.getParameterTypes());
         RootCallTarget globalFunctionRoot = Truffle.getRuntime().createCallTarget(globalFunction);
         RootNode globalRootNode = LLVMFunctionFactory.createGlobalRootNodeWrapping(globalFunctionRoot, mainFunction.getReturnType());
         RootCallTarget wrappedCallTarget = Truffle.getRuntime().createCallTarget(globalRootNode);
-        return new LLVMBitcodeParserResult(wrappedCallTarget, globalVarInitsTarget, globalVarDeallocsTarget, module.getFunctions(), constructorFunctions, destructorFunctions);
+        return new LLVMParserResultImpl(wrappedCallTarget, globalVarInitsTarget, globalVarDeallocsTarget, constructorFunctions, destructorFunctions, module.getFunctions());
     }
 
     private final LLVMContext context;

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMConstantGenerator.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMConstantGenerator.java
@@ -114,7 +114,7 @@ public final class LLVMConstantGenerator {
             final LLVMFunctionDescriptor.LLVMRuntimeType[] argTypes = LLVMBitcodeTypeHelper.toRuntimeTypes(type.getArgumentTypes());
 
             final String name = ((ValueSymbol) value).getName();
-            return LLVMFunctionLiteralNodeGen.create(context.getFunctionRegistry().createFunctionDescriptor(name, returnType, argTypes, type.isVarArg()));
+            return LLVMFunctionLiteralNodeGen.create((LLVMFunctionDescriptor) context.getFunctionRegistry().createFunctionDescriptor(name, returnType, argTypes, type.isVarArg()));
 
         } else if (value instanceof StringConstant) {
             final StringConstant constant = (StringConstant) value;
@@ -409,6 +409,7 @@ public final class LLVMConstantGenerator {
             final LLVMExpressionNode resolvedConstant = toConstantNode(constant.getElement(i), align, variables, context, stackSlot, labels, typeHelper);
             nodes[i] = createStructWriteNode(resolvedConstant, elementType.getLLVMBaseType(), byteSize);
             currentOffset += byteSize;
+
         }
 
         return new StructLiteralNode(offsets, nodes, allocation);
@@ -470,7 +471,7 @@ public final class LLVMConstantGenerator {
 
         } else if (type instanceof PointerType) {
             if (((PointerType) type).getPointeeType() instanceof FunctionType) {
-                final LLVMFunctionDescriptor functionDescriptor = context.getFunctionRegistry().createZeroFunctionDescriptor();
+                final LLVMFunctionDescriptor functionDescriptor = (LLVMFunctionDescriptor) context.getFunctionRegistry().createZeroFunctionDescriptor();
                 return LLVMFunctionLiteralNodeGen.create(functionDescriptor);
             } else {
                 return new LLVMSimpleLiteralNode.LLVMAddressLiteralNode(LLVMAddress.fromLong(0));
@@ -488,7 +489,8 @@ public final class LLVMConstantGenerator {
             return LLVMLiteralFactory.createVectorLiteralNode(Arrays.asList(zeroes), target, vectorType.getLLVMBaseType());
 
         } else if (type instanceof FunctionType) {
-            final LLVMFunctionDescriptor functionDescriptor = context.getFunctionRegistry().createFunctionDescriptor("<zero function>", LLVMFunctionDescriptor.LLVMRuntimeType.ILLEGAL,
+            final LLVMFunctionDescriptor functionDescriptor = (LLVMFunctionDescriptor) context.getFunctionRegistry().createFunctionDescriptor("<zero function>",
+                            LLVMFunctionDescriptor.LLVMRuntimeType.ILLEGAL,
                             new LLVMFunctionDescriptor.LLVMRuntimeType[0], false);
             return LLVMFunctionLiteralNodeGen.create(functionDescriptor);
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
@@ -82,10 +82,11 @@ import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
 import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.LLVMFunction;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 import com.oracle.truffle.llvm.types.LLVMGlobalVariableDescriptor;
 import com.oracle.truffle.llvm.types.LLVMIVarBit;
-import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 import com.oracle.truffle.llvm.types.floating.LLVM80BitFloat;
 
 public final class LLVMLiteralFactory {
@@ -144,8 +145,8 @@ public final class LLVMLiteralFactory {
                 return new LLVMAddressLiteralNode(LLVMAddress.createUndefinedAddress());
             case FUNCTION_ADDRESS:
                 LLVMContext context = LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0());
-                LLVMFunctionDescriptor functionDescriptor = context.getFunctionRegistry().createFunctionDescriptor("<undefined function>", LLVMRuntimeType.ILLEGAL, new LLVMRuntimeType[0], false);
-                return LLVMFunctionLiteralNodeGen.create(functionDescriptor);
+                LLVMFunction functionDescriptor = context.getFunctionRegistry().createFunctionDescriptor("<undefined function>", LLVMRuntimeType.ILLEGAL, new LLVMRuntimeType[0], false);
+                return LLVMFunctionLiteralNodeGen.create((LLVMFunctionDescriptor) functionDescriptor);
             default:
                 throw new AssertionError(type);
         }
@@ -199,8 +200,8 @@ public final class LLVMLiteralFactory {
             case FUNCTION_ADDRESS:
                 if (stringValue.equals("null")) {
                     LLVMContext context = LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0());
-                    LLVMFunctionDescriptor functionDescriptor = context.getFunctionRegistry().createFunctionDescriptor("<zero function>", LLVMRuntimeType.ILLEGAL, new LLVMRuntimeType[0], false);
-                    return LLVMFunctionLiteralNodeGen.create(functionDescriptor);
+                    LLVMFunction functionDescriptor = context.getFunctionRegistry().createFunctionDescriptor("<zero function>", LLVMRuntimeType.ILLEGAL, new LLVMRuntimeType[0], false);
+                    return LLVMFunctionLiteralNodeGen.create((LLVMFunctionDescriptor) functionDescriptor);
                 } else {
                     throw new AssertionError(stringValue);
                 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -107,6 +107,7 @@ import com.oracle.truffle.llvm.parser.util.LLVMTypeHelper;
 import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
 import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.LLVMFunction;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 import com.oracle.truffle.llvm.types.LLVMGlobalVariableDescriptor;
@@ -432,7 +433,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMFunctionDescriptor createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs) {
+    public LLVMFunction createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs) {
         return LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0()).getFunctionRegistry().createFunctionDescriptor(name, convertType, convertTypes, varArgs);
     }
 
@@ -518,6 +519,12 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
             default:
                 throw new AssertionError();
         }
+
+    }
+
+    @Override
+    public LLVMFunction createFunctionDescriptor(String name, LLVMRuntimeType returnType, boolean varArgs, LLVMRuntimeType[] paramTypes, int functionIndex) {
+        return LLVMFunctionDescriptor.create(name, returnType, paramTypes, varArgs, functionIndex);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -522,4 +522,9 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
         return LLVMFunctionDescriptor.create(name, returnType, paramTypes, varArgs, functionIndex);
     }
 
+    @Override
+    public LLVMFunction createAndRegisterFunctionDescriptor(String name, LLVMRuntimeType convertType, boolean varArgs, LLVMRuntimeType[] convertTypes) {
+        return LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0()).getFunctionRegistry().createFunctionDescriptor(name, convertType, convertTypes, varArgs);
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -433,11 +433,6 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMFunction createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs) {
-        return LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0()).getFunctionRegistry().createFunctionDescriptor(name, convertType, convertTypes, varArgs);
-    }
-
-    @Override
     public LLVMGlobalVariableDescriptor allocateGlobalVariable(GlobalVariable globalVariable) {
         String linkage = globalVariable.getLinkage();
         boolean isStatic = "internal".equals(linkage) || "private".equals(linkage);

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -1302,7 +1302,7 @@ public final class LLVMVisitor implements LLVMParserRuntime {
         for (int i = 0; i < params.size(); i++) {
             llvmParamTypes[i] = getLLVMType(params.get(i).getType().getType());
         }
-        return factoryFacade.createFunctionDescriptor(header.getName(), LLVMTypeHelper.convertType(llvmReturnType), LLVMTypeHelper.convertTypes(llvmParamTypes), varArgs);
+        return factoryFacade.createFunctionDescriptor(header.getName(), LLVMTypeHelper.convertType(llvmReturnType), varArgs, LLVMTypeHelper.convertTypes(llvmParamTypes), -1);
     }
 
     private LLVMExpressionNode parseSimpleConstant(EObject type, SimpleConstant simpleConst) {

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -1249,7 +1249,7 @@ public final class LLVMVisitor implements LLVMParserRuntime {
         for (int i = 0; i < params.size(); i++) {
             llvmParamTypes[i] = getLLVMType(params.get(i).getType().getType());
         }
-        return factoryFacade.createFunctionDescriptor(header.getName(), LLVMTypeHelper.convertType(llvmReturnType), varArgs, LLVMTypeHelper.convertTypes(llvmParamTypes), -1);
+        return factoryFacade.createAndRegisterFunctionDescriptor(header.getName(), LLVMTypeHelper.convertType(llvmReturnType), varArgs, LLVMTypeHelper.convertTypes(llvmParamTypes));
     }
 
     private LLVMExpressionNode parseSimpleConstant(EObject type, SimpleConstant simpleConst) {

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -310,8 +310,6 @@ public interface NodeFactoryFacade {
      */
     RootNode createFunctionSubstitutionRootNode(LLVMNode intrinsicNode);
 
-    LLVMFunction createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs);
-
     Object allocateGlobalVariable(GlobalVariable globalVariable);
 
     RootNode createStaticInitsRootNode(LLVMNode[] staticInits);

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -58,7 +58,7 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
-import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.LLVMFunction;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
 /**
@@ -310,7 +310,7 @@ public interface NodeFactoryFacade {
      */
     RootNode createFunctionSubstitutionRootNode(LLVMNode intrinsicNode);
 
-    LLVMFunctionDescriptor createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs);
+    LLVMFunction createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs);
 
     Object allocateGlobalVariable(GlobalVariable globalVariable);
 
@@ -324,5 +324,7 @@ public interface NodeFactoryFacade {
     Optional<Boolean> hasStackPointerArgument();
 
     LLVMStackFrameNuller createFrameNuller(String identifier, LLVMType type, FrameSlot slot);
+
+    LLVMFunction createFunctionDescriptor(String name, LLVMRuntimeType returnType, boolean varArgs, LLVMRuntimeType[] paramTypes, int functionIndex);
 
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacade.java
@@ -325,4 +325,6 @@ public interface NodeFactoryFacade {
 
     LLVMFunction createFunctionDescriptor(String name, LLVMRuntimeType returnType, boolean varArgs, LLVMRuntimeType[] paramTypes, int functionIndex);
 
+    LLVMFunction createAndRegisterFunctionDescriptor(String name, LLVMRuntimeType convertType, boolean varArgs, LLVMRuntimeType[] convertTypes);
+
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -324,11 +324,6 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMFunction createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs) {
-        return null;
-    }
-
-    @Override
     public Object allocateGlobalVariable(GlobalVariable globalVariable) {
         return null;
     }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -348,4 +348,9 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
         return null;
     }
 
+    @Override
+    public LLVMFunction createAndRegisterFunctionDescriptor(String name, LLVMRuntimeType convertType, boolean varArgs, LLVMRuntimeType[] convertTypes) {
+        return null;
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactoryFacadeAdapter.java
@@ -58,7 +58,7 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMIntegerComparisonType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
-import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.LLVMFunction;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
 /**
@@ -324,7 +324,7 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMFunctionDescriptor createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs) {
+    public LLVMFunction createFunctionDescriptor(String name, LLVMRuntimeType convertType, LLVMRuntimeType[] convertTypes, boolean varArgs) {
         return null;
     }
 
@@ -345,6 +345,11 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
 
     @Override
     public LLVMStackFrameNuller createFrameNuller(String identifier, LLVMType type, FrameSlot slot) {
+        return null;
+    }
+
+    @Override
+    public LLVMFunction createFunctionDescriptor(String name, LLVMRuntimeType returnType, boolean varArgs, LLVMRuntimeType[] paramTypes, int functionIndex) {
         return null;
     }
 

--- a/projects/com.oracle.truffle.llvm.test/tests/c/i128/left-shift.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/i128/left-shift.c
@@ -10,7 +10,6 @@ int main() {
   volatile __uint128_t val = -1;
   volatile __uint128_t val2 = val << 30;
   volatile struct asdf *ptr = (struct asdf *)&val2;
-  printf("%ld %ld\n", ptr->a, ptr->b);
   if (ptr->a != -1073741824 || ptr->b != -1) {
     abort();
   }

--- a/projects/com.oracle.truffle.llvm.test/tests/c/truffle-c/structTest/noopt/structTest18.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/truffle-c/structTest/noopt/structTest18.c
@@ -18,6 +18,5 @@ int main() {
   test.uni.b[2] = 1;
   test.uni.b[3] = 1;
   int sum = test.a + test.c + test.uni.a + a;
-  printf("vals: %d %d %d %d", test.a, test.c, test.uni.a, a);
   return sum % 256;
 }

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunction.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunction.java
@@ -27,25 +27,20 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.oracle.truffle.llvm.parser;
+package com.oracle.truffle.llvm.types;
 
-import java.util.List;
-import java.util.Map;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 
-import com.oracle.truffle.api.RootCallTarget;
-import com.oracle.truffle.llvm.types.LLVMFunction;
+public interface LLVMFunction {
 
-public interface LLVMParserResult {
+    String getName();
 
-    RootCallTarget getMainFunction();
+    LLVMRuntimeType[] getParameterTypes();
 
-    Map<LLVMFunction, RootCallTarget> getParsedFunctions();
+    LLVMRuntimeType getReturnType();
 
-    RootCallTarget getGlobalVarInits();
+    int getFunctionIndex();
 
-    RootCallTarget getGlobalVarDeallocs();
+    boolean isVarArgs();
 
-    List<RootCallTarget> getConstructorFunctions();
-
-    List<RootCallTarget> getDestructorFunctions();
 }

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
@@ -34,7 +34,7 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.interop.ForeignAccess;
 import com.oracle.truffle.api.interop.TruffleObject;
 
-public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<LLVMFunctionDescriptor> {
+public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<LLVMFunctionDescriptor>, LLVMFunction {
 
     public enum LLVMRuntimeType {
         I1,
@@ -94,18 +94,22 @@ public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<L
         return new LLVMFunctionDescriptor(null, LLVMRuntimeType.ILLEGAL, new LLVMRuntimeType[0], false, index);
     }
 
+    @Override
     public String getName() {
         return functionName;
     }
 
+    @Override
     public LLVMRuntimeType getReturnType() {
         return returnType;
     }
 
+    @Override
     public LLVMRuntimeType[] getParameterTypes() {
         return parameterTypes;
     }
 
+    @Override
     public boolean isVarArgs() {
         return hasVarArgs;
     }
@@ -115,6 +119,7 @@ public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<L
      *
      * @return the function's index
      */
+    @Override
     public int getFunctionIndex() {
         return functionId;
     }

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/LLVMFunctionDescriptor.java
@@ -29,7 +29,6 @@
  */
 package com.oracle.truffle.llvm.types;
 
-import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.interop.ForeignAccess;
 import com.oracle.truffle.api.interop.TruffleObject;
@@ -85,7 +84,6 @@ public final class LLVMFunctionDescriptor implements TruffleObject, Comparable<L
     }
 
     public static LLVMFunctionDescriptor create(String name, LLVMRuntimeType llvmReturnType, LLVMRuntimeType[] llvmParamTypes, boolean varArgs, int functionId) {
-        CompilerAsserts.neverPartOfCompilation();
         LLVMFunctionDescriptor func = new LLVMFunctionDescriptor(name, llvmReturnType, llvmParamTypes, varArgs, functionId);
         return func;
     }


### PR DESCRIPTION
…instead of LLVMFunctionDescriptor

`LLVMFunctionDescriptor` is a final class which can thus not be replaced or modified. Its usage in the factory facade thus restricts alternative implementations to use the same function representation.