### PR TITLE
Some Debugging fixes and improvements

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMMetadata.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMMetadata.java
@@ -176,7 +176,17 @@ public final class LLVMMetadata implements ModelVisitor {
 
                             // TODO: other variables than localVar should be possible here
                             MetadataLocalVariable localVar = (MetadataLocalVariable) metadata.getReference(metadataId).get();
-                            metadataRefType.setValidatedMetadataReference(localVar.getType());
+                            MetadataReference typeReference = localVar.getType();
+                            while (typeReference.get() instanceof MetadataDerivedType) {
+                                MetadataDerivedType derivedType = (MetadataDerivedType) typeReference.get();
+
+                                if (!derivedType.isOnlyReference()) {
+                                    break;
+                                }
+
+                                typeReference = derivedType.getBaseType();
+                            }
+                            metadataRefType.setValidatedMetadataReference(typeReference);
                         }
                     }
                 }

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMMetadata.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMMetadata.java
@@ -274,11 +274,25 @@ public final class LLVMMetadata implements ModelVisitor {
                                     int elementOffset = parsedIndex * cast.getType().sizeof();
 
                                     for (int i = 0; i < elements.size(); i++) {
-                                        MetadataReference element = elements.get(i);
-                                        MetadataDerivedType derivedType = (MetadataDerivedType) element.get();
-                                        if (derivedType.getOffset() == elementOffset) {
-                                            gep.setReferenceName(((MetadataString) derivedType.getName().get()).getString());
-                                            break;
+                                        MetadataBaseNode element = elements.get(i).get();
+                                        if (element instanceof MetadataDerivedType) {
+                                            MetadataDerivedType derivedType = (MetadataDerivedType) element;
+                                            if (derivedType.getOffset() == elementOffset) {
+                                                if (derivedType.getName().isPresent()) {
+                                                    gep.setReferenceName(((MetadataString) derivedType.getName().get()).getString());
+                                                }
+                                                break;
+                                            }
+                                        } else if (element instanceof MetadataCompositeType) {
+                                            MetadataCompositeType compositeType = (MetadataCompositeType) element;
+                                            if (compositeType.getOffset() == elementOffset) {
+                                                if (compositeType.getName().isPresent()) {
+                                                    gep.setReferenceName(((MetadataString) compositeType.getName().get()).getString());
+                                                }
+                                                break;
+                                            }
+                                        } else {
+                                            throw new AssertionError("element type not supported yet: " + element);
                                         }
                                     }
 

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/Symbols.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/Symbols.java
@@ -192,7 +192,7 @@ public final class Symbols {
     private static class ForwardReference implements Constant {
 
         private final List<Symbol> dependents = new ArrayList<>();
-        private final Map<AggregateConstant, Integer> aggregateDependents = new HashMap<>();
+        private final Map<AggregateConstant, List<Integer>> aggregateDependents = new HashMap<>();
 
         ForwardReference() {
         }
@@ -202,11 +202,13 @@ public final class Symbols {
         }
 
         void addDependent(AggregateConstant dependent, int index) {
-            aggregateDependents.put(dependent, index);
+            final List<Integer> indices = aggregateDependents.getOrDefault(dependent, new ArrayList<Integer>());
+            indices.add(index);
+            aggregateDependents.put(dependent, indices);
         }
 
         public void replace(Symbol replacement) {
-            aggregateDependents.forEach((key, val) -> key.replaceElement(val, replacement));
+            aggregateDependents.forEach((key, val) -> val.forEach(i -> key.replaceElement(i, replacement)));
             dependents.forEach(dependent -> dependent.replace(this, replacement));
         }
 

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/metadata/MetadataDerivedType.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/metadata/MetadataDerivedType.java
@@ -130,4 +130,20 @@ public class MetadataDerivedType implements MetadataBaseNode {
         return builder.toString();
     }
 
+    public boolean isOnlyReference() {
+        if (size != 0) {
+            return false;
+        }
+        if (align != 0) {
+            return false;
+        }
+        if (offset != 0) {
+            return false;
+        }
+        if (flags != 0) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/metadata/MetadataTemplateTypeParameter.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/metadata/MetadataTemplateTypeParameter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package uk.ac.man.cs.llvm.ir.model.metadata;
+
+import uk.ac.man.cs.llvm.ir.model.MetadataBlock;
+import uk.ac.man.cs.llvm.ir.model.MetadataBlock.MetadataReference;
+
+public class MetadataTemplateTypeParameter implements MetadataBaseNode {
+
+    private MetadataReference name = MetadataBlock.voidRef;
+    private MetadataReference baseType = MetadataBlock.voidRef;
+
+    public MetadataReference getName() {
+        return name;
+    }
+
+    public void setName(MetadataReference name) {
+        this.name = name;
+    }
+
+    public MetadataReference getBaseType() {
+        return baseType;
+    }
+
+    public void setBaseType(MetadataReference baseType) {
+        this.baseType = baseType;
+    }
+
+    @Override
+    public String toString() {
+        return "MetadataTemplateTypeParameter [name=" + name + ", baseType=" + baseType + "]";
+    }
+
+}

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/Metadata.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/Metadata.java
@@ -185,7 +185,7 @@ public class Metadata implements ParserListener {
 
             default:
                 metadata.add(null);
-                System.out.println("! - TODO: #" + record + ": " + Arrays.toString(args));
+                LLVMLogger.info("! - TODO: #" + record + ": " + Arrays.toString(args));
                 break;
         }
 
@@ -238,7 +238,7 @@ public class Metadata implements ParserListener {
     protected void createDistinctNode(long[] args) {
         // [n x md num]
         metadata.add(null);
-        System.out.println("! - " + MetadataRecord.DISTINCT_NODE + " - " + Arrays.toString(args));
+        LLVMLogger.info("! - " + MetadataRecord.DISTINCT_NODE + " - " + Arrays.toString(args));
     }
 
     protected void createKind(long[] args) {
@@ -259,7 +259,7 @@ public class Metadata implements ParserListener {
         // long scope = args[i++];
         // long inlineAt = args[i++];
         metadata.add(null);
-        System.out.println("! - " + MetadataRecord.LOCATION + " - " + Arrays.toString(args));
+        LLVMLogger.info("! - " + MetadataRecord.LOCATION + " - " + Arrays.toString(args));
     }
 
     protected void createNamedNode(long[] args) {
@@ -275,7 +275,7 @@ public class Metadata implements ParserListener {
     protected void createAttachment(long[] args) {
         // [n x mdnodes]
         metadata.add(null);
-        System.out.println("! - " + MetadataRecord.ATTACHMENT + " - " + Arrays.toString(args));
+        LLVMLogger.info("! - " + MetadataRecord.ATTACHMENT + " - " + Arrays.toString(args));
     }
 
     protected void createGenericDebug(long[] args) {
@@ -287,7 +287,7 @@ public class Metadata implements ParserListener {
         // long header = args[i++];
         // TODO: args[4] // n x md num
         metadata.add(null);
-        System.out.println("! - " + MetadataRecord.GENERIC_DEBUG + " - " + Arrays.toString(args));
+        LLVMLogger.info("! - " + MetadataRecord.GENERIC_DEBUG + " - " + Arrays.toString(args));
     }
 
     protected void createSubrange(long[] args) {

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
@@ -49,6 +49,7 @@ import uk.ac.man.cs.llvm.ir.model.metadata.MetadataLocalVariable;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataNode;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataSubprogram;
 import uk.ac.man.cs.llvm.ir.model.metadata.MetadataSubrange;
+import uk.ac.man.cs.llvm.ir.model.metadata.MetadataTemplateTypeParameter;
 import uk.ac.man.cs.llvm.ir.module.records.DwLangNameRecord;
 import uk.ac.man.cs.llvm.ir.module.records.DwTagRecord;
 import uk.ac.man.cs.llvm.ir.types.IntegerConstantType;
@@ -143,6 +144,7 @@ public class MetadataV32 extends Metadata {
                 case DW_TAG_VECTOR_TYPE:
                 case DW_TAG_SUBROUTINE_TYPE:
                 case DW_TAG_INHERITANCE:
+                case DW_TAG_CLASS_TYPE: // TODO: correct?
                     createDwCompositeType(parsedArgs);
                     break;
 
@@ -178,6 +180,11 @@ public class MetadataV32 extends Metadata {
                 case DW_TAG_LEXICAL_BLOCK:
                     createDwTagLexicalBlock(parsedArgs);
                     break;
+
+                case DW_TAG_TEMPLATE_TYPE_PARAMETER:
+                    createDwTagTemplateTypeParameter(parsedArgs);
+                    break;
+
                 case DW_TAG_UNKNOWN:
                     parsedArgs.rewind();
                     createDwNode(parsedArgs); // TODO: we need to know the type of the node
@@ -443,4 +450,15 @@ public class MetadataV32 extends Metadata {
         metadata.add(node);
     }
 
+    private void createDwTagTemplateTypeParameter(MetadataArgumentParser args) {
+        MetadataTemplateTypeParameter node = new MetadataTemplateTypeParameter();
+
+        metadata.getReference(args.next()); // Context?
+        node.setName(metadata.getReference(args.next()));
+        node.setBaseType(metadata.getReference(args.next()));
+        args.next(); // TODO: Unknown
+        args.next(); // TODO: Unknown
+
+        metadata.add(node);
+    }
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
@@ -31,6 +31,7 @@ package uk.ac.man.cs.llvm.ir.module;
 
 import java.util.List;
 
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.options.LLVMBaseOptionFacade;
 import uk.ac.man.cs.llvm.ir.module.records.MetadataRecord;
 import uk.ac.man.cs.llvm.ir.SymbolGenerator;
@@ -192,13 +193,13 @@ public class MetadataV32 extends Metadata {
 
                 default:
                     metadata.add(null);
-                    System.out.println("! - TODO: #" + record + " - " + ident);
+                    LLVMLogger.info("! - TODO: #" + record + " - " + ident);
                     break;
             }
         } else {
             parsedArgs.rewind();
             metadata.add(null);
-            System.out.println("! - TODO: #" + MetadataRecord.OLD_NODE + ": " + parsedArgs);
+            LLVMLogger.info("! - TODO: #" + MetadataRecord.OLD_NODE + ": " + parsedArgs);
         }
     }
 

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
@@ -269,15 +269,25 @@ public class MetadataV32 extends Metadata {
     protected void createDwTagBasicType(MetadataArgumentParser args) {
         MetadataBasicType node = new MetadataBasicType();
 
-        metadata.getReference(args.next()); // Reference to context
-        node.setName(metadata.getReference(args.next()));
-        node.setFile(metadata.getReference(args.next()));
-        node.setLine(asInt32(args.next()));
-        node.setSize(asInt64(args.next()));
-        node.setAlign(asInt64(args.next()));
-        node.setOffset(asInt64(args.next()));
-        node.setFlags(asInt32(args.next()));
-        node.setEncoding(asInt32(args.next()));
+        if (args.hasNext()) {
+            metadata.getReference(args.next()); // Reference to context
+            node.setName(metadata.getReference(args.next()));
+            node.setFile(metadata.getReference(args.next()));
+            node.setLine(asInt32(args.next()));
+            node.setSize(asInt64(args.next()));
+            node.setAlign(asInt64(args.next()));
+            node.setOffset(asInt64(args.next()));
+            node.setFlags(asInt32(args.next()));
+            node.setEncoding(asInt32(args.next()));
+        } else {
+            /*
+             * I don't know why, but there is the possibility for an empty DwTagBaseType
+             *
+             * example file which reproduces this special case:
+             *
+             * - test-suite-3.2.src/SingleSource/Regression/C++/2003-06-08-VirtualFunctions.cpp
+             */
+        }
 
         metadata.add(node);
     }
@@ -294,8 +304,18 @@ public class MetadataV32 extends Metadata {
         node.setOffset(asInt64(args.next()));
         node.setFlags(asInt32(args.next()));
         node.setDerivedFrom(metadata.getReference(args.next()));
-        node.setMemberDescriptors(metadata.getReference(args.next()));
-        node.setRuntimeLanguage(asInt32(args.next()));
+        if (args.hasNext()) {
+            node.setMemberDescriptors(metadata.getReference(args.next()));
+            node.setRuntimeLanguage(asInt32(args.next()));
+        } else {
+            /*
+             * I don't know why, but there is the possibility for an pre ended DwTagComposizeType
+             *
+             * example file which reproduces this special case:
+             *
+             * - test-suite-3.2.src/SingleSource/Regression/C++/2003-06-08-VirtualFunctions.cpp
+             */
+        }
 
         metadata.add(node);
     }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/module/MetadataV32.java
@@ -229,7 +229,9 @@ public class MetadataV32 extends Metadata {
         node.setType(metadata.getReference(args.next()));
         node.setLocalToCompileUnit(asInt1(args.next()));
         node.setDefinedInCompileUnit(asInt1(args.next()));
-        metadata.getReference(args.next()); // TODO: Reference to the global variable
+        // TODO: Reference to the global variable, can be MetadataConstant but also
+        // MetadataConstantPointer
+        args.next();
 
         metadata.add(node);
     }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/types/StructureType.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/types/StructureType.java
@@ -58,6 +58,23 @@ public final class StructureType implements AggregateType, ValueSymbol {
         return types[index];
     }
 
+    public long getElementOffset(int index) {
+        int offset = 0;
+        for (int i = 0; i <= index; i++) {
+            if (offset % types[i].getAlignment() != 0) {
+                offset += types[i].getAlignment() - (offset % types[i].getAlignment());
+            }
+
+            if (i == index) {
+                break;
+            }
+
+            offset += types[i].sizeof();
+        }
+
+        return offset * Byte.SIZE;
+    }
+
     @Override
     public int getElementCount() {
         return types.length;

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/types/StructureType.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/types/StructureType.java
@@ -61,7 +61,7 @@ public final class StructureType implements AggregateType, ValueSymbol {
     public long getElementOffset(int index) {
         int offset = 0;
         for (int i = 0; i <= index; i++) {
-            if (offset % types[i].getAlignment() != 0) {
+            if (!isPacked() && (offset % types[i].getAlignment() != 0)) {
                 offset += types[i].getAlignment() - (offset % types[i].getAlignment());
             }
 


### PR DESCRIPTION
* now, parsing of struct element names is much more reliable including support for bitfields
* fixed some issue based on incorrect forward reference resolution (thanks to @jakre for help)
* fixed most issues towards running ```mx su-tests llvm-bc``` with enabled debugging symbols

Please be patient with the current state of ```LLVMMetadata.java```. I know it needs lots of refactor in the future.