### PR TITLE
Better Support Globals in the Binary Parser

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
@@ -311,7 +311,10 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
             descriptor = context.getGlobalVaraibleRegistry().lookupOrAdd(name, nativeResolver);
         }
 
-        if (!descriptor.isDeclared()) {
+        // if the global does not have an associated value the compiler did not initialize it, in
+        // this case we assume memory has already been allocated elsewhere
+        final boolean allocateMemory = !descriptor.isDeclared() && global.getValue() != null;
+        if (allocateMemory) {
             final int byteSize = typeHelper.getByteSize(((PointerType) global.getType()).getPointeeType());
             final LLVMAddress nativeStorage = LLVMHeap.allocateMemory(byteSize);
             final LLVMAddressNode addressLiteralNode = new LLVMAddressLiteralNode(nativeStorage);

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/GlobalConstant.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/GlobalConstant.java
@@ -31,14 +31,18 @@ package uk.ac.man.cs.llvm.ir.model;
 
 import uk.ac.man.cs.llvm.ir.types.Type;
 
-public class GlobalConstant extends GlobalValueSymbol {
+public final class GlobalConstant extends GlobalValueSymbol {
 
-    public GlobalConstant(Type type, int initialiser, int align, long linkage) {
+    private GlobalConstant(Type type, int initialiser, int align, long linkage) {
         super(type, initialiser, align, linkage);
     }
 
     @Override
     public void accept(ModelVisitor visitor) {
         visitor.visit(this);
+    }
+
+    public static GlobalConstant create(Type type, int initialiser, int align, long linkage) {
+        return new GlobalConstant(type, initialiser, align, linkage);
     }
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/GlobalVariable.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/GlobalVariable.java
@@ -31,14 +31,18 @@ package uk.ac.man.cs.llvm.ir.model;
 
 import uk.ac.man.cs.llvm.ir.types.Type;
 
-public class GlobalVariable extends GlobalValueSymbol {
+public final class GlobalVariable extends GlobalValueSymbol {
 
-    public GlobalVariable(Type type, int initialiser, int align, long linkage) {
+    private GlobalVariable(Type type, int initialiser, int align, long linkage) {
         super(type, initialiser, align, linkage);
     }
 
     @Override
     public void accept(ModelVisitor visitor) {
         visitor.visit(this);
+    }
+
+    public static GlobalVariable create(Type type, int initialiser, int align, long linkage) {
+        return new GlobalVariable(type, initialiser, align, linkage);
     }
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/ModelModule.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/ModelModule.java
@@ -200,9 +200,9 @@ public final class ModelModule implements ModuleGenerator {
     public void createGlobal(Type type, boolean isConstant, int initialiser, int align, long linkage) {
         final GlobalValueSymbol global;
         if (isConstant) {
-            global = new GlobalConstant(type, initialiser, align, linkage);
+            global = GlobalConstant.create(type, initialiser, align, linkage);
         } else {
-            global = new GlobalVariable(type, initialiser, align, linkage);
+            global = GlobalVariable.create(type, initialiser, align, linkage);
         }
         symbols.addSymbol(global);
         globals.add(global);

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/constants/AggregateConstant.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/constants/AggregateConstant.java
@@ -29,21 +29,31 @@
  */
 package uk.ac.man.cs.llvm.ir.model.constants;
 
+import uk.ac.man.cs.llvm.ir.model.GlobalValueSymbol;
 import uk.ac.man.cs.llvm.ir.model.Symbol;
+import uk.ac.man.cs.llvm.ir.model.Symbols;
+import uk.ac.man.cs.llvm.ir.types.ArrayType;
+import uk.ac.man.cs.llvm.ir.types.StructureType;
 import uk.ac.man.cs.llvm.ir.types.Type;
+import uk.ac.man.cs.llvm.ir.types.VectorType;
 
 import java.util.Arrays;
 
 public abstract class AggregateConstant extends AbstractConstant {
 
-    private final Constant[] elements;
+    private final Symbol[] elements;
 
-    public AggregateConstant(Type type, Constant[] elements) {
+    AggregateConstant(Type type, Symbol[] elements) {
         super(type);
         this.elements = elements;
     }
 
-    public Constant getElement(int idx) {
+    AggregateConstant(Type type, int size) {
+        super(type);
+        this.elements = new Symbol[size];
+    }
+
+    public Symbol getElement(int idx) {
         return elements[idx];
     }
 
@@ -55,14 +65,80 @@ public abstract class AggregateConstant extends AbstractConstant {
         Arrays.fill(elements, element);
     }
 
-    public Constant[] getElements() {
+    public Symbol[] getElements() {
         return Arrays.copyOf(elements, elements.length);
     }
 
     public void replaceElement(int index, Symbol replacement) {
-        if (!(replacement instanceof Constant)) {
-            throw new IllegalStateException("Constants can only be replaced by Constants!");
+        if (!(replacement instanceof Constant || replacement instanceof GlobalValueSymbol)) {
+            throw new IllegalStateException("Values can only be replaced by Constants or Globals!");
         }
-        elements[index] = (Constant) replacement;
+        elements[index] = replacement;
+    }
+
+    protected String getContent() {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < getElementCount(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            Symbol value = getElement(i);
+            sb.append(value.getType()).append(" ").append(value);
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < getElementCount(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            Symbol value = getElement(i);
+            sb.append(value.getType()).append(" ").append(value);
+        }
+        return sb.toString();
+    }
+
+    static AggregateConstant fromData(Type type, long[] data) {
+        final AggregateConstant aggregateConstant;
+        final Type elementType;
+        if (type instanceof ArrayType) {
+            final ArrayType arrayType = (ArrayType) type;
+            elementType = arrayType.getElementType();
+            aggregateConstant = new ArrayConstant(arrayType, data.length);
+        } else if (type instanceof VectorType) {
+            final VectorType vectorType = (VectorType) type;
+            elementType = vectorType.getElementType();
+            aggregateConstant = new VectorConstant((VectorType) type, data.length);
+        } else {
+            throw new RuntimeException("Cannot create constant from data: " + type);
+        }
+
+        for (int i = 0; i < data.length; i++) {
+            aggregateConstant.replaceElement(i, Constant.createFromData(elementType, data[i]));
+        }
+
+        return aggregateConstant;
+    }
+
+    static AggregateConstant fromSymbols(Symbols symbols, Type type, int[] valueIndices) {
+        final AggregateConstant aggregateConstant;
+        if (type instanceof ArrayType) {
+            aggregateConstant = new ArrayConstant((ArrayType) type, valueIndices.length);
+        } else if (type instanceof StructureType) {
+            aggregateConstant = new StructureConstant((StructureType) type, valueIndices.length);
+        } else if (type instanceof VectorType) {
+            aggregateConstant = new VectorConstant((VectorType) type, valueIndices.length);
+        } else {
+            throw new RuntimeException("No value constant implementation for " + type);
+        }
+
+        for (int elementIndex = 0; elementIndex < valueIndices.length; elementIndex++) {
+            aggregateConstant.replaceElement(elementIndex, symbols.getSymbol(valueIndices[elementIndex], aggregateConstant, elementIndex));
+        }
+
+        return aggregateConstant;
     }
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/constants/ArrayConstant.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/constants/ArrayConstant.java
@@ -30,21 +30,11 @@
 package uk.ac.man.cs.llvm.ir.model.constants;
 
 import uk.ac.man.cs.llvm.ir.types.ArrayType;
-import uk.ac.man.cs.llvm.ir.types.Type;
 
 public final class ArrayConstant extends AggregateConstant {
 
-    public ArrayConstant(Constant value, int size) {
-        super(new ArrayType(value.getType(), size), new Constant[size]);
-        fill(value);
-    }
-
-    public ArrayConstant(ArrayType type, Constant[] values) {
-        super(type, values);
-    }
-
-    public ArrayConstant(ArrayType type, int valueCount) {
-        this(type, new Constant[valueCount]);
+    ArrayConstant(ArrayType type, int valueCount) {
+        super(type, valueCount);
     }
 
     @Override
@@ -54,15 +44,6 @@ public final class ArrayConstant extends AggregateConstant {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("[");
-        Type type = getType().getElementType();
-        for (int i = 0; i < getElementCount(); i++) {
-            if (i > 0) {
-                sb.append(", ");
-            }
-            sb.append(type).append(" ").append(getElement(i));
-        }
-        return sb.append("]").toString();
+        return String.format("[%s]", super.toString());
     }
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/constants/Constant.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/constants/Constant.java
@@ -32,17 +32,15 @@ package uk.ac.man.cs.llvm.ir.model.constants;
 import uk.ac.man.cs.llvm.bc.records.Records;
 import uk.ac.man.cs.llvm.ir.model.Symbol;
 import uk.ac.man.cs.llvm.ir.model.Symbols;
-import uk.ac.man.cs.llvm.ir.types.ArrayType;
 import uk.ac.man.cs.llvm.ir.types.FloatingPointType;
 import uk.ac.man.cs.llvm.ir.types.IntegerType;
 import uk.ac.man.cs.llvm.ir.types.Type;
-import uk.ac.man.cs.llvm.ir.types.VectorType;
 
 public interface Constant extends Symbol {
 
     static Constant createFromData(Type type, long datum) {
         if (type instanceof IntegerType) {
-            IntegerType t = (IntegerType) type;
+            final IntegerType t = (IntegerType) type;
 
             // Sign extend for everything except i1 (boolean)
             int bits = t.getBitCount();
@@ -52,40 +50,21 @@ public interface Constant extends Symbol {
             }
 
             return new IntegerConstant(t, d);
-        }
 
-        if (type instanceof FloatingPointType) {
+        } else if (type instanceof FloatingPointType) {
+
             return FloatingPointConstant.create((FloatingPointType) type, new long[]{datum});
-        }
 
-        throw new RuntimeException("No datum constant implementation for " + type);
+        } else {
+            throw new RuntimeException("No datum constant implementation for " + type);
+        }
     }
 
     static Constant createFromData(Type type, long[] data) {
-        if (type instanceof ArrayType) {
-            ArrayType array = (ArrayType) type;
-            Type subtype = array.getElementType();
-            Constant[] elements = new Constant[data.length];
-            for (int i = 0; i < data.length; i++) {
-                elements[i] = createFromData(subtype, data[i]);
-            }
-            return new ArrayConstant(array, elements);
-        }
-
-        if (type instanceof VectorType) {
-            VectorType vector = (VectorType) type;
-            Type subtype = vector.getElementType();
-            Constant[] elements = new Constant[data.length];
-            for (int i = 0; i < data.length; i++) {
-                elements[i] = createFromData(subtype, data[i]);
-            }
-            return new VectorConstant(vector, elements);
-        }
-
-        throw new RuntimeException("No data constant implementation for " + type);
+        return AggregateConstant.fromData(type, data);
     }
 
     static Constant createFromValues(Type type, Symbols symbols, int[] valueIndices) {
-        return symbols.createAggregate(type, valueIndices);
+        return AggregateConstant.fromSymbols(symbols, type, valueIndices);
     }
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/constants/StructureConstant.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/constants/StructureConstant.java
@@ -34,12 +34,8 @@ import uk.ac.man.cs.llvm.ir.types.Type;
 
 public final class StructureConstant extends AggregateConstant {
 
-    public StructureConstant(StructureType type, Constant[] values) {
-        super(type, values);
-    }
-
-    public StructureConstant(StructureType type, int valueCount) {
-        this(type, new Constant[valueCount]);
+    StructureConstant(StructureType type, int valueCount) {
+        super(type, valueCount);
     }
 
     public Type getElementType(int index) {
@@ -52,15 +48,6 @@ public final class StructureConstant extends AggregateConstant {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{ ");
-        for (int i = 0; i < getElementCount(); i++) {
-            if (i > 0) {
-                sb.append(", ");
-            }
-            Constant value = getElement(i);
-            sb.append(value.getType()).append(" ").append(value);
-        }
-        return sb.append("}").toString();
+        return String.format("{%s}", super.toString());
     }
 }

--- a/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/constants/VectorConstant.java
+++ b/projects/uk.ac.man.cs.llvm/src/uk/ac/man/cs/llvm/ir/model/constants/VectorConstant.java
@@ -34,17 +34,8 @@ import uk.ac.man.cs.llvm.ir.types.VectorType;
 
 public final class VectorConstant extends AggregateConstant {
 
-    public VectorConstant(VectorType type, Constant[] elements) {
-        super(type, elements);
-    }
-
-    public VectorConstant(VectorType type, int elemCount) {
-        this(type, new Constant[elemCount]);
-    }
-
-    public VectorConstant(VectorType type, Constant element) {
-        super(type, new Constant[type.getElementCount()]);
-        fill(element);
+    VectorConstant(VectorType type, int elemCount) {
+        super(type, elemCount);
     }
 
     public Type getElementType() {
@@ -57,15 +48,6 @@ public final class VectorConstant extends AggregateConstant {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("<");
-        for (int i = 0; i < getLength(); i++) {
-            if (i > 0) {
-                sb.append(", ");
-            }
-            Constant element = getElement(i);
-            sb.append(element.getType()).append(" ").append(element);
-        }
-        return sb.append(">").toString();
+        return String.format("<%s>", super.toString());
     }
 }


### PR DESCRIPTION
- Prevent Double Allocation of externally linked Globals (adresses #474)
- Allow Globals as Elements in Array and Vector Constants
- Refactoring of the Aggregate Constant and Symbol classes