### PR TITLE
Implement basic Signal handling (closes #277)

### DIFF
--- a/mx.sulong/libs/signal.c
+++ b/mx.sulong/libs/signal.c
@@ -1,7 +1,0 @@
-#include <stdio.h>
-
-void (*signal(int sig, void (*func)(int)))(int) {
-  fprintf(stderr, "Sulong does not support signals, registering a signal handler over "
-                  "the signal function has no effect!\n");
-  return func;
-}

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMBasicBlockNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/base/LLVMBasicBlockNode.java
@@ -102,7 +102,8 @@ public class LLVMBasicBlockNode extends LLVMNode {
                 if (exceptionSourceSection == null) {
                     throw e;
                 } else {
-                    String message = String.format("LLVM error in %s in %s - %s", exceptionSourceSection.getIdentifier(), exceptionSourceSection.getSource().getName(), e.getMessage());
+                    String message = String.format("LLVM error in %s in %s - %s", exceptionSourceSection.getIdentifier(),
+                                    exceptionSourceSection.getSource() != null ? exceptionSourceSection.getSource().getName() : "<unknow>", e.getMessage());
                     throw new RuntimeException(message, e);
                 }
             }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
@@ -93,6 +93,7 @@ public class LLVMGlobalRootNode extends RootNode {
         } catch (LLVMExitException e) {
             return e.getReturnCode();
         } finally {
+            context.awaitThreadTermination();
             if (printNativeStats) {
                 printNativeCallStats(context);
             }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/func/LLVMGlobalRootNode.java
@@ -84,7 +84,7 @@ public class LLVMGlobalRootNode extends RootNode {
         try {
             Object result = null;
             for (int i = 0; i < executionCount; i++) {
-                assert (LLVMSignal.getNumberOfRegisteredSignals() == 0);
+                assert LLVMSignal.getNumberOfRegisteredSignals() == 0;
 
                 frame.setObject(stackPointerSlot, stackPointer);
                 Object[] realArgs = new Object[arguments.length + LLVMCallNode.ARG_START_INDEX];
@@ -93,12 +93,12 @@ public class LLVMGlobalRootNode extends RootNode {
                 result = executeIteration(frame, i, realArgs);
 
                 context.awaitThreadTermination();
-                assert (LLVMSignal.getNumberOfRegisteredSignals() == 0);
+                assert LLVMSignal.getNumberOfRegisteredSignals() == 0;
             }
             return result;
         } catch (LLVMExitException e) {
             context.awaitThreadTermination();
-            assert (LLVMSignal.getNumberOfRegisteredSignals() == 0);
+            assert LLVMSignal.getNumberOfRegisteredSignals() == 0;
             return e.getReturnCode();
         } finally {
             // if not done already, we want at least call a shutdown command

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMSignal.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMSignal.java
@@ -298,7 +298,7 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
         }
 
         /**
-         * Unregister this SignalHandler from context
+         * Unregister this SignalHandler from context.
          */
         private void unregisterFromContext() {
             assert !isRunning.get();
@@ -313,14 +313,17 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
             }
 
             lock.lock();
-            if (!stack.isFreed()) {
-                stack.free();
+            try {
+                if (!stack.isFreed()) {
+                    stack.free();
+                }
+            } finally {
+                lock.unlock();
             }
-            lock.unlock();
         }
 
         /**
-         * Only unregister this SignalHandler, if there is currently no lock held
+         * Only unregister this SignalHandler, if there is currently no lock held.
          */
         private boolean tryUnregisterFromContext() {
             assert !isRunning.get();

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMSignal.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMSignal.java
@@ -37,16 +37,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameDescriptor;
-import com.oracle.truffle.api.source.SourceSection;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMThread;
@@ -57,8 +56,8 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode.LLVMUnresolvedCallNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMFunctionStartNode;
 import com.oracle.truffle.llvm.nodes.impl.literals.LLVMFunctionLiteralNodeGen;
-import com.oracle.truffle.llvm.nodes.impl.literals.LLVMSimpleLiteralNode.LLVMI32LiteralNode;
 import com.oracle.truffle.llvm.nodes.impl.literals.LLVMSimpleLiteralNode.LLVMAddressLiteralNode;
+import com.oracle.truffle.llvm.nodes.impl.literals.LLVMSimpleLiteralNode.LLVMI32LiteralNode;
 import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
@@ -202,7 +201,7 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
                                 new LLVMFunctionStartNode(callNode,
                                                 new LLVMNode[]{},
                                                 new LLVMNode[]{},
-                                                SourceSection.createUnavailable("", null),
+                                                null,
                                                 new FrameDescriptor(), ""));
 
                 isRunning.set(true);

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMSignal.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMSignal.java
@@ -32,6 +32,7 @@ package com.oracle.truffle.llvm.nodes.impl.intrinsics.c;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -95,20 +96,39 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
         }
     }
 
+    private static Lock globalSignalHandlerLock = new ReentrantLock();
+
     private static final Map<Integer, LLVMSignalHandler> registeredSignals = new HashMap<>();
+
+    public static int getNumberOfRegisteredSignals() {
+        return registeredSignals.size();
+    }
 
     @TruffleBoundary
     private static LLVMFunctionDescriptor setSignalHandler(Signal signal, LLVMFunctionDescriptor function) {
         int signalId = signal.getNumber();
         LLVMFunctionDescriptor returnFunction = LLVM_SIG_DFL;
 
-        if (registeredSignals.containsKey(signalId)) {
-            LLVMSignalHandler currentFunction = registeredSignals.get(signalId);
-            returnFunction = currentFunction.getFunction();
-        }
-
         try {
-            registeredSignals.put(signalId, new LLVMSignalHandler(signal, function));
+            LLVMSignalHandler newSignalHandler = new LLVMSignalHandler(signal, function);
+            synchronized (registeredSignals) {
+                if (registeredSignals.containsKey(signalId)) {
+
+                    LLVMSignalHandler currentFunction = registeredSignals.get(signalId);
+
+                    if (currentFunction.isRunning()) {
+                        returnFunction = currentFunction.getFunction();
+
+                        /*
+                         * the new signal handler already manages this signal, so we can safely
+                         * deactivate the old one.
+                         */
+                        currentFunction.setStopped();
+                    }
+                }
+
+                registeredSignals.put(signalId, newSignalHandler);
+            }
         } catch (IllegalArgumentException e) {
             LLVMLogger.error("could not register signal with id " + signalId + " (" + signal + ")");
             return LLVM_SIG_ERR;
@@ -121,6 +141,19 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
     private static final long TMP_SIGNAL_STACK_SIZE_KB = 512;
     private static final long TMP_SIGNAL_STACK_SIZE_BYTE = TMP_SIGNAL_STACK_SIZE_KB * 1024;
 
+    /**
+     * Registers a signal handler using sun.misc.SignalHandler. Unfortunately, using signals in java
+     * leads to some problems which are not resolved in our implementation yet.
+     *
+     * One of this issue is, that signals are executed in an asynchronous way, which means raise()
+     * exits before the signal was handled. Another Issue is that Java already registered some
+     * signal handlers, which therefore cannot be used in sulong.
+     *
+     * Therefore, our implementation does not comply with the ANSI C standard and could lead to
+     * timing issues when calling multiple signals in a defined sequence, or when a program has to
+     * wait until the signal was handled (which is not guaranteed because of the asynchronous
+     * behavior in our implementation).
+     */
     private static final class LLVMSignalHandler implements SignalHandler, LLVMThreadNode {
 
         private final Signal signal;
@@ -129,8 +162,8 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
         private RootCallTarget callTarget;
         private final LLVMStack stack = new LLVMStack();
 
-        Lock lock = new ReentrantLock();
-        private AtomicBoolean isRunning = new AtomicBoolean(true);
+        private final Lock lock = new ReentrantLock();
+        private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
         @TruffleBoundary
         private LLVMSignalHandler(Signal signal, LLVMFunctionDescriptor function) throws IllegalArgumentException {
@@ -153,15 +186,31 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
                                             SourceSection.createUnavailable("", null),
                                             new FrameDescriptor(), ""));
 
-            context.registerThread(this);
+            lock.lock();
+            try {
+                if (function.equals(LLVM_SIG_DFL)) {
+                    Signal.handle(signal, SignalHandler.SIG_DFL);
+                    stack.free();
+                } else if (function.equals(LLVM_SIG_IGN)) {
+                    Signal.handle(signal, SignalHandler.SIG_IGN);
+                    stack.free();
+                } else {
+                    Signal.handle(signal, this);
+                }
 
-            if (function.equals(LLVM_SIG_DFL)) {
-                Signal.handle(signal, SignalHandler.SIG_DFL);
-            } else if (function.equals(LLVM_SIG_IGN)) {
-                Signal.handle(signal, SignalHandler.SIG_IGN);
-            } else {
-                Signal.handle(signal, this);
+                // only when we reach this point, the signal handler was registered successfully
+                isRunning.set(true);
+                context.registerThread(this);
+            } catch (IllegalArgumentException e) {
+                stack.free();
+                throw e;
+            } finally {
+                lock.unlock();
             }
+        }
+
+        public boolean isRunning() {
+            return isRunning.get();
         }
 
         @Override
@@ -169,23 +218,21 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
         protected void finalize() throws Throwable {
             super.finalize();
             stop();
-            // TODO: wait for finish of running handle?
-            context.unregisterThread(this);
-            stack.free();
+            unregisterFromContext();
         }
+
+        private static final long HANDLE_MAX_WAITING_TIME = 250; // ms
 
         @Override
         public void handle(Signal arg0) {
-            /*
-             * https://en.wikipedia.org/wiki/Sigaction#Replacement_of_deprecated_signal.28.29
-             *
-             * Signal handlers installed by the signal() interface will be uninstalled immediately
-             * prior to execution of the handler.
-             *
-             * @note I made such a program, and I had to delete the handler manually, so this
-             * sentence is probably not true
-             */
-
+            try {
+                if (!globalSignalHandlerLock.tryLock(HANDLE_MAX_WAITING_TIME, TimeUnit.MILLISECONDS)) {
+                    LLVMLogger.error("could not execute signal handler. Sulong can currently only execute one signal at once!");
+                    return;
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
             lock.lock();
             try {
                 if (isRunning.get()) {
@@ -193,6 +240,12 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
                 }
             } finally {
                 lock.unlock();
+                globalSignalHandlerLock.unlock();
+            }
+
+            // probably, this was our last turn for the signal handler
+            if (!isRunning.get()) {
+                unregisterFromContext();
             }
         }
 
@@ -200,9 +253,36 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
             return function;
         }
 
+        /**
+         * Required to call if a new LLVMSignalHandler take over the signal. Otherwise it would
+         * unregister the signal when this Object is going to be deallocated or stopped.
+         */
+        private void setStopped() {
+            isRunning.set(false);
+
+            /*
+             * Either no handler is currently running, or it would unregister after finishing it's
+             * execution.
+             */
+            tryUnregisterFromContext();
+        }
+
         @Override
         public void stop() {
-            isRunning.set(false);
+            if (isRunning.getAndSet(false)) {
+                /*
+                 * it seems like we don't want to catch this signal anymore, as well as there is no
+                 * other signal handler which want to catch it. So we simply reset it to look like
+                 * no signal handler was registered at all.
+                 */
+                Signal.handle(signal, SignalHandler.SIG_DFL);
+            }
+
+            /*
+             * Either no handler is currently running, or it would unregister after finishing it's
+             * execution.
+             */
+            tryUnregisterFromContext();
         }
 
         @Override
@@ -212,6 +292,48 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
             // wait until handle is finished
             lock.lock();
             lock.unlock();
+
+            // this thread wouldn't start anymore, so we can assume it's stopped
+            unregisterFromContext();
+        }
+
+        /**
+         * Unregister this SignalHandler from context
+         */
+        private void unregisterFromContext() {
+            assert !isRunning.get();
+
+            context.unregisterThread(this);
+
+            int signalId = signal.getNumber();
+            synchronized (registeredSignals) {
+                if (registeredSignals.get(signalId) == this) {
+                    registeredSignals.remove(signalId);
+                }
+            }
+
+            lock.lock();
+            if (!stack.isFreed()) {
+                stack.free();
+            }
+            lock.unlock();
+        }
+
+        /**
+         * Only unregister this SignalHandler, if there is currently no lock held
+         */
+        private boolean tryUnregisterFromContext() {
+            assert !isRunning.get();
+
+            if (lock.tryLock()) {
+                try {
+                    unregisterFromContext();
+                } finally {
+                    lock.unlock();
+                }
+                return true;
+            }
+            return false;
         }
 
         @Override

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMSignal.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMSignal.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.intrinsics.c;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.source.SourceSection;
+import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
+import com.oracle.truffle.llvm.nodes.base.LLVMNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMFunctionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.LLVMLanguage;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
+import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode.LLVMUnresolvedCallNode;
+import com.oracle.truffle.llvm.nodes.impl.func.LLVMFunctionStartNode;
+import com.oracle.truffle.llvm.nodes.impl.literals.LLVMFunctionLiteralNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.literals.LLVMSimpleLiteralNode.LLVMI32LiteralNode;
+import com.oracle.truffle.llvm.nodes.impl.literals.LLVMSimpleLiteralNode.LLVMAddressLiteralNode;
+import com.oracle.truffle.llvm.runtime.LLVMLogger;
+import com.oracle.truffle.llvm.types.LLVMAddress;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
+import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
+import com.oracle.truffle.llvm.types.memory.LLVMStack;
+
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
+
+@GenerateNodeFactory
+@NodeChildren({@NodeChild(type = LLVMI32Node.class, value = "signal"), @NodeChild(type = LLVMFunctionNode.class, value = "handler")})
+public abstract class LLVMSignal extends LLVMFunctionNode {
+
+    private static final LLVMFunctionDescriptor LLVM_SIG_DFL = LLVMFunctionDescriptor.create(0);
+    private static final LLVMFunctionDescriptor LLVM_SIG_IGN = LLVMFunctionDescriptor.create(1);
+    private static final LLVMFunctionDescriptor LLVM_SIG_ERR = LLVMFunctionDescriptor.create(-1);
+
+    @Specialization
+    public LLVMFunctionDescriptor executeAddress(int signal, LLVMFunctionDescriptor handler) {
+        return setSignalHandler(signal, handler);
+    }
+
+    @TruffleBoundary
+    private static LLVMFunctionDescriptor setSignalHandler(int signalId, LLVMFunctionDescriptor function) {
+        Signals decodedSignal = Signals.decode(signalId);
+
+        if (decodedSignal == null) {
+            LLVMLogger.error("unknown signal: " + signalId);
+            return LLVM_SIG_ERR;
+        }
+
+        return setSignalHandler(decodedSignal.signal(), function);
+    }
+
+    private static final Map<Integer, LLVMSignalHandler> registeredSignals = new HashMap<>();
+
+    @TruffleBoundary
+    private static LLVMFunctionDescriptor setSignalHandler(Signal signal, LLVMFunctionDescriptor function) {
+        int signalId = signal.getNumber();
+        LLVMFunctionDescriptor returnFunction = LLVM_SIG_DFL;
+
+        if (registeredSignals.containsKey(signalId)) {
+            LLVMSignalHandler currentFunction = registeredSignals.get(signalId);
+            returnFunction = currentFunction.getFunction();
+        }
+
+        try {
+            registeredSignals.put(signalId, new LLVMSignalHandler(signal, function));
+        } catch (IllegalArgumentException e) {
+            LLVMLogger.error("could not register signal with id " + signalId + " (" + signal + ")");
+            return LLVM_SIG_ERR;
+        }
+
+        return returnFunction;
+    }
+
+    // TODO: stack handling should work without predefined sizes,...
+    private static final long TMP_SIGNAL_STACK_SIZE_BYTE = 1 * 1024;
+
+    private static final class LLVMSignalHandler implements SignalHandler {
+
+        private final LLVMFunctionDescriptor function;
+        private RootCallTarget callTarget;
+
+        private LLVMSignalHandler(Signal signal, LLVMFunctionDescriptor function) throws IllegalArgumentException {
+            this.function = function;
+            LLVMFunctionNode functionNode = LLVMFunctionLiteralNodeGen.create(function);
+
+            // TODO: currently we create a new stack with a specific size, this has to be changed
+            LLVMAddressLiteralNode signalStack = new LLVMAddressLiteralNode(LLVMAddress.fromLong(LLVMStack.allocate(TMP_SIGNAL_STACK_SIZE_BYTE)));
+            LLVMI32LiteralNode sigNumArg = new LLVMI32LiteralNode(signal.getNumber());
+            LLVMExpressionNode[] args = {signalStack, sigNumArg};
+
+            LLVMContext context = LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0());
+
+            LLVMUnresolvedCallNode callNode = new LLVMUnresolvedCallNode(functionNode, args, LLVMRuntimeType.VOID, context);
+
+            callTarget = Truffle.getRuntime().createCallTarget(
+                            new LLVMFunctionStartNode(callNode,
+                                            new LLVMNode[]{},
+                                            new LLVMNode[]{},
+                                            SourceSection.createUnavailable("", null),
+                                            new FrameDescriptor(), ""));
+
+            if (function.equals(LLVM_SIG_DFL)) {
+                Signal.handle(signal, SignalHandler.SIG_DFL);
+            } else if (function.equals(LLVM_SIG_IGN)) {
+                Signal.handle(signal, SignalHandler.SIG_IGN);
+            } else {
+                Signal.handle(signal, this);
+            }
+        }
+
+        @Override
+        public void handle(Signal arg0) {
+            /*
+             * https://en.wikipedia.org/wiki/Sigaction#Replacement_of_deprecated_signal.28.29
+             *
+             * Signal handlers installed by the signal() interface will be uninstalled immediately
+             * prior to execution of the handler.
+             *
+             * @note I made such a program, and I had to delete the handler manually, so this
+             * sentence is probably not true
+             */
+            callTarget.call();
+        }
+
+        public LLVMFunctionDescriptor getFunction() {
+            return function;
+        }
+
+    }
+
+    /**
+     * Handling conversation from Signal number to Signal Object in a clean way.
+     *
+     * documentation: http://man7.org/linux/man-pages/man7/signal.7.html
+     */
+    private enum Signals {
+
+        // POSIX.1-1990
+        SIG_HUP("HUP"),
+        SIG_INT("INT"),
+        SIG_QUIT("QUIT"),
+        SIG_ILL("ILL"),
+        SIG_ABRT("ABRT"),
+        SIG_FPE("FPE"),
+        SIG_KILL("KILL"),
+        SIG_SEGV("SEGV"),
+        SIG_PIPE("PIPE"),
+        SIG_ALRM("ALRM"),
+        SIG_TERM("TERM"),
+        SIG_USR1("USR1"),
+        SIG_USR2("USR2"),
+        SIG_CHLD("CHLD"),
+        SIG_CONT("CONT"),
+        SIG_STOP("STOP"),
+        SIG_TSTP("TSTP"),
+        SIG_TTIN("TTIN"),
+
+        // SUSv2 and POSIX.1-2001
+        SIG_BUS("BUS"),
+        SIG_POLL("POLL"),
+        SIG_PROF("PROF"),
+        SIG_SYS("SYS"),
+        SIG_TRAP("TRAP"),
+        SIG_URG("URG"),
+        SIG_VTALRM("VTALRM"),
+        SIG_XCPU("XCPU"),
+        SIG_XFSZ("XFSZ"),
+
+        // various other signals
+        SIG_IOT("IOT"),
+        SIG_EMT("EMT"),
+        SIG_STKFLT("STKFLT"),
+        SIG_IO("IO"),
+        SIG_CLD("CLD"),
+        SIG_PWR("PWR"),
+        SIG_INFO("INFO"),
+        SIG_LOST("LOST"),
+        SIG_WINCH("WINCH"),
+        SIG_UNUSED("UNUSED");
+
+        public static Signals decode(int code) {
+            for (Signals currentSignal : values()) {
+                if (currentSignal.signal() != null && currentSignal.signal().getNumber() == code) {
+                    return currentSignal;
+                }
+            }
+            return null;
+        }
+
+        private final Signal signal;
+
+        Signals(String signalName) {
+            Signal constructedSignal;
+            try {
+                constructedSignal = new Signal(signalName);
+            } catch (IllegalArgumentException e) {
+                // it seems like this signal is not available on your system
+                constructedSignal = null;
+            }
+            this.signal = constructedSignal;
+        }
+
+        public Signal signal() {
+            return signal;
+        }
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMSignal.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMSignal.java
@@ -55,7 +55,6 @@ import com.oracle.truffle.llvm.nodes.impl.literals.LLVMFunctionLiteralNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.literals.LLVMSimpleLiteralNode.LLVMI32LiteralNode;
 import com.oracle.truffle.llvm.nodes.impl.literals.LLVMSimpleLiteralNode.LLVMAddressLiteralNode;
 import com.oracle.truffle.llvm.runtime.LLVMLogger;
-import com.oracle.truffle.llvm.types.LLVMAddress;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
 import com.oracle.truffle.llvm.types.memory.LLVMStack;
@@ -115,19 +114,20 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
     }
 
     // TODO: stack handling should work without predefined sizes,...
-    private static final long TMP_SIGNAL_STACK_SIZE_BYTE = 1 * 1024;
+    private static final long TMP_SIGNAL_STACK_SIZE_KB = 512;
+    private static final long TMP_SIGNAL_STACK_SIZE_BYTE = TMP_SIGNAL_STACK_SIZE_KB * 1024;
 
     private static final class LLVMSignalHandler implements SignalHandler {
 
         private final LLVMFunctionDescriptor function;
         private RootCallTarget callTarget;
+        private final LLVMStack stack = new LLVMStack();
 
         private LLVMSignalHandler(Signal signal, LLVMFunctionDescriptor function) throws IllegalArgumentException {
             this.function = function;
             LLVMFunctionNode functionNode = LLVMFunctionLiteralNodeGen.create(function);
 
-            // TODO: currently we create a new stack with a specific size, this has to be changed
-            LLVMAddressLiteralNode signalStack = new LLVMAddressLiteralNode(LLVMAddress.fromLong(LLVMStack.allocate(TMP_SIGNAL_STACK_SIZE_BYTE)));
+            LLVMAddressLiteralNode signalStack = new LLVMAddressLiteralNode(stack.allocate(TMP_SIGNAL_STACK_SIZE_BYTE));
             LLVMI32LiteralNode sigNumArg = new LLVMI32LiteralNode(signal.getNumber());
             LLVMExpressionNode[] args = {signalStack, sigNumArg};
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMSignal.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/c/LLVMSignal.java
@@ -132,6 +132,7 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
         Lock lock = new ReentrantLock();
         private AtomicBoolean isRunning = new AtomicBoolean(true);
 
+        @TruffleBoundary
         private LLVMSignalHandler(Signal signal, LLVMFunctionDescriptor function) throws IllegalArgumentException {
             this.signal = signal;
             this.function = function;
@@ -164,6 +165,7 @@ public abstract class LLVMSignal extends LLVMFunctionNode {
         }
 
         @Override
+        @TruffleBoundary
         protected void finalize() throws Throwable {
             super.finalize();
             stop();

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/vars/LLVMWriteNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/vars/LLVMWriteNode.java
@@ -80,7 +80,11 @@ public abstract class LLVMWriteNode extends LLVMNode {
             } else {
                 identifier = String.format("assignment of %s in basic block %s in function %s", getSlot().getIdentifier(), basicBlock.getBlockName(), functionStartNode.getFunctionName());
             }
-            sourceSection = functionStartNode.getSourceSection().getSource().createSection(identifier, 1);
+            if (functionStartNode.getSourceSection() != null) {
+                sourceSection = functionStartNode.getSourceSection().getSource().createSection(identifier, 1);
+            } else {
+                sourceSection = SourceSection.createUnavailable("", null);
+            }
         }
         return sourceSection;
     }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/base/LLVMThread.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/base/LLVMThread.java
@@ -29,7 +29,7 @@
  */
 package com.oracle.truffle.llvm.nodes.base;
 
-public interface LLVMThreadNode {
+public interface LLVMThread {
     void stop();
 
     void awaitFinish();

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/base/LLVMThreadNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/base/LLVMThreadNode.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.base;
+
+public interface LLVMThreadNode {
+    void stop();
+
+    void awaitFinish();
+}

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMRuntimeIntrinsicFactory.java
@@ -47,6 +47,7 @@ import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFacto
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMRintFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMCMathsIntrinsicsFactory.LLVMSqrtFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMExitFactory;
+import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMSignalFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMTruffleOnlyIntrinsicsFactory.LLVMStrCmpFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMTruffleOnlyIntrinsicsFactory.LLVMStrlenFactory;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.c.LLVMTruffleReadBytesFactory;
@@ -230,6 +231,7 @@ public class LLVMRuntimeIntrinsicFactory {
         // C
         intrinsics.put("@abort", LLVMAbortFactory.getInstance());
         intrinsics.put("@exit", LLVMExitFactory.getInstance());
+        intrinsics.put("@signal", LLVMSignalFactory.getInstance());
 
         intrinsics.put("@strlen", LLVMStrlenFactory.getInstance());
         intrinsics.put("@strcmp", LLVMStrCmpFactory.getInstance());

--- a/projects/com.oracle.truffle.llvm.test/tests/c/signal/signal001.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/signal/signal001.c
@@ -2,18 +2,15 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-void sig_handler_1(int signo) {
-	abort();
-}
+void sig_handler_1(int signo) { abort(); }
 
 int main() {
-	if(signal(-1, sig_handler_1) != SIG_ERR) {
-		abort();
-	}
+  if (signal(-1, sig_handler_1) != SIG_ERR) {
+    abort();
+  }
+  if (signal(SIGKILL, sig_handler_1) != SIG_ERR) {
+    abort();
+  }
 
-	if(signal(SIGKILL, sig_handler_1) != SIG_ERR) {
-		abort();
-	}
-
-	return 0;
+  return 0;
 }

--- a/projects/com.oracle.truffle.llvm.test/tests/c/signal/signal001.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/signal/signal001.c
@@ -1,0 +1,19 @@
+#include <signal.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void sig_handler_1(int signo) {
+	abort();
+}
+
+int main() {
+	if(signal(-1, sig_handler_1) != SIG_ERR) {
+		abort();
+	}
+
+	if(signal(SIGKILL, sig_handler_1) != SIG_ERR) {
+		abort();
+	}
+
+	return 0;
+}

--- a/projects/com.oracle.truffle.llvm.test/tests/c/signal/signal002.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/signal/signal002.c
@@ -8,61 +8,57 @@ volatile int glob = 0;
 volatile int sigHandled = 1;
 const int MAX_SIG_HANDLED_WAIT = 1000; // ms
 void sulong_raise(int signo) {
-	sigHandled = 0;
-	if(raise(signo) != 0) {
-		abort();
-	}
-	int i = 0;
-	while(!sigHandled) {
-		if((i++) >= MAX_SIG_HANDLED_WAIT * 10) {
-			abort();
-		}
-		usleep(100); // cause lot's of possibilities for context switches
-	}
+  sigHandled = 0;
+  if (raise(signo) != 0) {
+    abort();
+  }
+  int i = 0;
+  while (!sigHandled) {
+    if ((i++) >= MAX_SIG_HANDLED_WAIT * 10) {
+      abort();
+    }
+    usleep(100); // cause lot's of possibilities for context switches
+  }
 }
 
 void sig_handler_1(int signo) {
-	abort();
-	sigHandled = 1;
+  abort();
+  sigHandled = 1;
 }
 
 void sig_handler_2(int signo) {
-	if(signo != SIGTERM) {
-		abort();
-	}
-	glob += 10;
-	sigHandled = 1;
+  if (signo != SIGTERM) {
+    abort();
+  }
+  glob += 10;
+  sigHandled = 1;
 }
 
 void sig_handler_3(int signo) {
-	if(signo != SIGINT) {
-		abort();
-	}
-	glob *= 2;
-	sigHandled = 1;
+  if (signo != SIGINT) {
+    abort();
+  }
+  glob *= 2;
+  sigHandled = 1;
 }
 
-
 int main() {
-	if(signal(SIGTERM, sig_handler_1) != SIG_DFL) {
-		abort();
-	}
+  if (signal(SIGTERM, sig_handler_1) != SIG_DFL) {
+    abort();
+  }
+  if (signal(SIGTERM, sig_handler_2) != sig_handler_1) {
+    abort();
+  }
+  if (signal(SIGINT, sig_handler_3) != SIG_DFL) {
+    abort();
+  }
+  if (signal(SIGHUP, SIG_IGN) != SIG_DFL) {
+    abort();
+  }
 
-	if(signal(SIGTERM, sig_handler_2) != sig_handler_1) {
-		abort();
-	}
+  sulong_raise(SIGTERM);
+  sulong_raise(SIGINT);
+  sulong_raise(SIGHUP);
 
-	if(signal(SIGINT, sig_handler_3) != SIG_DFL) {
-		abort();
-	}
-
-	if(signal(SIGHUP, SIG_IGN) != SIG_DFL) {
-		abort();
-	}
-
-	sulong_raise(SIGTERM);
-	sulong_raise(SIGINT);
-	sulong_raise(SIGHUP);
-
-	return glob;
+  return glob;
 }

--- a/projects/com.oracle.truffle.llvm.test/tests/c/signal/signal002.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/signal/signal002.c
@@ -1,0 +1,68 @@
+#include <signal.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+volatile int glob = 0;
+
+// workaround for the asynchronous sulong signal handler
+volatile int sigHandled = 1;
+const int MAX_SIG_HANDLED_WAIT = 1000; // ms
+void sulong_raise(int signo) {
+	sigHandled = 0;
+	if(raise(signo) != 0) {
+		abort();
+	}
+	int i = 0;
+	while(!sigHandled) {
+		if((i++) >= MAX_SIG_HANDLED_WAIT * 10) {
+			abort();
+		}
+		usleep(100); // cause lot's of possibilities for context switches
+	}
+}
+
+void sig_handler_1(int signo) {
+	abort();
+	sigHandled = 1;
+}
+
+void sig_handler_2(int signo) {
+	if(signo != SIGTERM) {
+		abort();
+	}
+	glob += 10;
+	sigHandled = 1;
+}
+
+void sig_handler_3(int signo) {
+	if(signo != SIGINT) {
+		abort();
+	}
+	glob *= 2;
+	sigHandled = 1;
+}
+
+
+int main() {
+	if(signal(SIGTERM, sig_handler_1) != SIG_DFL) {
+		abort();
+	}
+
+	if(signal(SIGTERM, sig_handler_2) != sig_handler_1) {
+		abort();
+	}
+
+	if(signal(SIGINT, sig_handler_3) != SIG_DFL) {
+		abort();
+	}
+
+	if(signal(SIGHUP, SIG_IGN) != SIG_DFL) {
+		abort();
+	}
+
+	sulong_raise(SIGTERM);
+	sulong_raise(SIGINT);
+	sulong_raise(SIGHUP);
+
+	return glob;
+}

--- a/projects/com.oracle.truffle.llvm.test/tests/c/signal/signal003.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/signal/signal003.c
@@ -8,43 +8,42 @@ volatile int glob = 0;
 volatile int sigHandled = 1;
 const int MAX_SIG_HANDLED_WAIT = 1000; // ms
 void sulong_raise(int signo) {
-	sigHandled = 0;
-	if(raise(signo) != 0) {
-		abort();
-	}
-	int i = 0;
-	while(!sigHandled) {
-		if((i++) >= MAX_SIG_HANDLED_WAIT * 10) {
-			abort();
-		}
-		usleep(100); // cause lot's of possibilities for context switches
-	}
+  sigHandled = 0;
+  if (raise(signo) != 0) {
+    abort();
+  }
+  int i = 0;
+  while (!sigHandled) {
+    if ((i++) >= MAX_SIG_HANDLED_WAIT * 10) {
+      abort();
+    }
+    usleep(100); // cause lot's of possibilities for context switches
+  }
 }
 
 void sig_handler(int signo) {
-	if(signo == SIGINT) {
-		glob += 10;
-	} else if(signo == SIGHUP) {
-		glob *= 2;
-	} else {
-		abort();
-	}
-	sigHandled = 1;
+  if (signo == SIGINT) {
+    glob += 10;
+  } else if (signo == SIGHUP) {
+    glob *= 2;
+  } else {
+    abort();
+  }
+  sigHandled = 1;
 }
 
-
 int main() {
-	if(signal(SIGINT, sig_handler) != SIG_DFL) {
-		abort();
-	}
+  if (signal(SIGINT, sig_handler) != SIG_DFL) {
+    abort();
+  }
+  if (signal(SIGHUP, sig_handler) != SIG_DFL) {
+    abort();
+  }
 
-	if(signal(SIGHUP, sig_handler) != SIG_DFL) {
-		abort();
-	}
+  for (int i = 0; i < 2; i++) {
+    sulong_raise(SIGINT);
+    sulong_raise(SIGHUP);
+  }
 
-	for (int i = 0; i < 2; i++) {
-		sulong_raise(SIGINT);
-		sulong_raise(SIGHUP);
-	}
-	return glob;
+  return glob;
 }

--- a/projects/com.oracle.truffle.llvm.test/tests/c/signal/signal003.c
+++ b/projects/com.oracle.truffle.llvm.test/tests/c/signal/signal003.c
@@ -1,0 +1,50 @@
+#include <signal.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+volatile int glob = 0;
+
+// workaround for the asynchronous sulong signal handler
+volatile int sigHandled = 1;
+const int MAX_SIG_HANDLED_WAIT = 1000; // ms
+void sulong_raise(int signo) {
+	sigHandled = 0;
+	if(raise(signo) != 0) {
+		abort();
+	}
+	int i = 0;
+	while(!sigHandled) {
+		if((i++) >= MAX_SIG_HANDLED_WAIT * 10) {
+			abort();
+		}
+		usleep(100); // cause lot's of possibilities for context switches
+	}
+}
+
+void sig_handler(int signo) {
+	if(signo == SIGINT) {
+		glob += 10;
+	} else if(signo == SIGHUP) {
+		glob *= 2;
+	} else {
+		abort();
+	}
+	sigHandled = 1;
+}
+
+
+int main() {
+	if(signal(SIGINT, sig_handler) != SIG_DFL) {
+		abort();
+	}
+
+	if(signal(SIGHUP, sig_handler) != SIG_DFL) {
+		abort();
+	}
+
+	for (int i = 0; i < 2; i++) {
+		sulong_raise(SIGINT);
+		sulong_raise(SIGHUP);
+	}
+	return glob;
+}

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
@@ -51,13 +51,20 @@ public final class LLVMStack extends LLVMMemory {
      * Allocates the stack memory.
      */
     public LLVMAddress allocate() {
+        return allocate(STACK_SIZE_BYTE);
+    }
+
+    /**
+     * Allocates the stack memory.
+     */
+    public LLVMAddress allocate(final long stackSize) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
         if (!isFreed) {
             throw new AssertionError("previously not deallocated");
         }
-        final long stackAllocation = UNSAFE.allocateMemory(STACK_SIZE_BYTE);
+        final long stackAllocation = UNSAFE.allocateMemory(stackSize);
         lowerBounds = stackAllocation;
-        upperBounds = stackAllocation + STACK_SIZE_BYTE;
+        upperBounds = stackAllocation + stackSize;
         isFreed = false;
         return LLVMAddress.fromLong(upperBounds);
     }
@@ -74,10 +81,6 @@ public final class LLVMStack extends LLVMMemory {
         lowerBounds = 0;
         upperBounds = 0;
         isFreed = true;
-    }
-
-    public static long allocate(long size) {
-        return UNSAFE.allocateMemory(size);
     }
 
     public static final int NO_ALIGNMENT_REQUIREMENTS = 1;

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
@@ -69,6 +69,10 @@ public final class LLVMStack extends LLVMMemory {
         return LLVMAddress.fromLong(upperBounds);
     }
 
+    public boolean isFreed() {
+        return isFreed;
+    }
+
     /**
      * Deallocates the stack memory.
      */

--- a/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
+++ b/projects/com.oracle.truffle.llvm.types/src/com/oracle/truffle/llvm/types/memory/LLVMStack.java
@@ -76,6 +76,10 @@ public final class LLVMStack extends LLVMMemory {
         isFreed = true;
     }
 
+    public static long allocate(long size) {
+        return UNSAFE.allocateMemory(size);
+    }
+
     public static final int NO_ALIGNMENT_REQUIREMENTS = 1;
 
     public static class AllocationResult {


### PR DESCRIPTION
now we can use signals inside sulong (with a few exceptions for signals which are used by Java itself)

There is a big TODO regarding stack size calculation, but the rest should be fine.

This PR fixes #277 

There exists a second (much more complex) signal handling system, which is not supported by this patch: [sigaction](https://en.wikipedia.org/wiki/Sigaction)

Here is a simple test program:

```c
#include <stdio.h>
#include <signal.h>
#include <unistd.h>
#include <stdlib.h>
#include <string.h>

void sig_handler(int signo) {
    printf(" * received SIGNAL: %d (%s)\n", signo, strsignal(signo));
}

int main(void)
{
    if (signal(SIGINT, sig_handler) == SIG_ERR) {
        printf("\ncan't catch SIGINT\n");
        exit(1);
    }

    // A long wait so that we can easily issue a signal to this process
    int i = 1;
    while(i) {
        sleep(1);
        printf(".\n");
    }
    return 0;
}
```