### PR TITLE
Rewrite more parts of the Bitcode Visitor and Factory Facade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ mx.imports/**
 .idea/**
 build/**
 graal/**
+projects/.project
 projects/*/nbproject/
 projects/*/build.xml
 projects/*/\.settings

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/x86/LLVMX86_64BitVAStart.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/intrinsics/llvm/x86/LLVMX86_64BitVAStart.java
@@ -42,14 +42,14 @@ import com.oracle.truffle.llvm.types.memory.LLVMMemory;
 public class LLVMX86_64BitVAStart extends LLVMNode {
 
     private static final int LONG_DOUBLE_SIZE = 16;
-    private final int numberExplicitArguments;
+    private final int numberOfExplicitArguments;
     @Child private LLVMAddressNode target;
 
-    public LLVMX86_64BitVAStart(int numberExplicitArguments, LLVMAddressNode target) {
-        if (numberExplicitArguments < 0) {
+    public LLVMX86_64BitVAStart(int numberOfExplicitArguments, LLVMAddressNode target) {
+        if (numberOfExplicitArguments < 0) {
             throw new AssertionError();
         }
-        this.numberExplicitArguments = numberExplicitArguments;
+        this.numberOfExplicitArguments = numberOfExplicitArguments;
         this.target = target;
     }
 
@@ -91,7 +91,7 @@ public class LLVMX86_64BitVAStart extends LLVMNode {
     public void executeVoid(VirtualFrame frame) {
         LLVMAddress address = target.executePointee(frame);
         initOffsets(address);
-        int varArgsStartIndex = numberExplicitArguments;
+        int varArgsStartIndex = numberOfExplicitArguments;
         Object[] realArguments = getRealArguments(frame);
         int argumentsLength = realArguments.length;
         if (varArgsStartIndex != argumentsLength) {

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
@@ -37,9 +37,9 @@ import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMType;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 
-import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
 import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDefinition;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
+import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.dsl.NodeFactory;
@@ -113,7 +113,7 @@ public interface NodeFactoryFacade {
      * @param argCount number of arguments (could differ from declaration arg count)
      * @return the created intrinsic
      */
-    LLVMNode createLLVMIntrinsic(FunctionDeclaration declaration, Object[] argNodes, int argCount);
+    LLVMNode createLLVMIntrinsic(FunctionType declaration, Object[] argNodes, int argCount);
 
     LLVMNode createTruffleIntrinsic(String functionName, LLVMExpressionNode[] argNodes);
 

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
@@ -37,9 +37,9 @@ import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMType;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 
-import com.intel.llvm.ireditor.lLVM_IR.FunctionDef;
-import com.intel.llvm.ireditor.lLVM_IR.FunctionHeader;
+import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
+import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.dsl.NodeFactory;
@@ -112,7 +112,7 @@ public interface NodeFactoryFacade {
      * @param functionDef the function definition of the function from which the intrinsic is called
      * @return the created intrinsic
      */
-    LLVMNode createLLVMIntrinsic(String functionName, Object[] argNodes, FunctionDef functionDef);
+    LLVMNode createLLVMIntrinsic(String functionName, Object[] argNodes, FunctionType functionDef);
 
     LLVMNode createTruffleIntrinsic(String functionName, LLVMExpressionNode[] argNodes);
 
@@ -279,7 +279,7 @@ public interface NodeFactoryFacade {
      * @return a function root node
      */
     RootNode createFunctionStartNode(LLVMExpressionNode functionBodyNode, LLVMNode[] beforeFunction, LLVMNode[] afterFunction, SourceSection sourceSection, FrameDescriptor frameDescriptor,
-                    FunctionHeader functionHeader);
+                    FunctionDeclaration functionHeader);
 
     /**
      * Returns the index of the first argument of the formal parameter list.

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
@@ -38,6 +38,7 @@ import com.oracle.truffle.llvm.parser.LLVMType;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 
 import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
+import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDefinition;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 import com.oracle.truffle.api.RootCallTarget;
@@ -279,7 +280,7 @@ public interface NodeFactoryFacade {
      * @return a function root node
      */
     RootNode createFunctionStartNode(LLVMExpressionNode functionBodyNode, LLVMNode[] beforeFunction, LLVMNode[] afterFunction, SourceSection sourceSection, FrameDescriptor frameDescriptor,
-                    FunctionDeclaration functionHeader);
+                    FunctionDefinition functionHeader);
 
     /**
      * Returns the index of the first argument of the formal parameter list.

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
@@ -39,7 +39,6 @@ import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 
 import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
-import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.dsl.NodeFactory;
@@ -107,12 +106,13 @@ public interface NodeFactoryFacade {
     /**
      * Creates an intrinsic for a <code>@llvm.*</code> function.
      *
-     * @param functionName the name of the intrinsic function starting with <code>@llvm.</code>
+     * @param declaration the function declaration of the function from which the intrinsic is
+     *            called
      * @param argNodes the arguments to the intrinsic function
-     * @param functionDef the function definition of the function from which the intrinsic is called
+     * @param argCount number of arguments (could differ from declaration arg count)
      * @return the created intrinsic
      */
-    LLVMNode createLLVMIntrinsic(String functionName, Object[] argNodes, FunctionType functionDef);
+    LLVMNode createLLVMIntrinsic(FunctionDeclaration declaration, Object[] argNodes, int argCount);
 
     LLVMNode createTruffleIntrinsic(String functionName, LLVMExpressionNode[] argNodes);
 

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
@@ -110,10 +110,10 @@ public interface NodeFactoryFacade {
      * @param declaration the function declaration of the function from which the intrinsic is
      *            called
      * @param argNodes the arguments to the intrinsic function
-     * @param argCount number of arguments (could differ from declaration arg count)
+     * @param numberOfExplicitArguments number of explicite arguments passed to function
      * @return the created intrinsic
      */
-    LLVMNode createLLVMIntrinsic(FunctionType declaration, Object[] argNodes, int argCount);
+    LLVMNode createLLVMIntrinsic(FunctionType declaration, Object[] argNodes, int numberOfExplicitArguments);
 
     LLVMNode createTruffleIntrinsic(String functionName, LLVMExpressionNode[] argNodes);
 

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMType;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
-import org.eclipse.emf.ecore.EObject;
 
 import com.intel.llvm.ireditor.lLVM_IR.FunctionDef;
 import com.intel.llvm.ireditor.lLVM_IR.FunctionHeader;
@@ -97,7 +96,7 @@ public interface NodeFactoryFacade {
 
     LLVMExpressionNode createLogicalOperation(LLVMExpressionNode left, LLVMExpressionNode right, LLVMLogicalInstructionType opCode, LLVMBaseType llvmType, LLVMExpressionNode target);
 
-    LLVMExpressionNode createUndefinedValue(EObject t);
+    LLVMExpressionNode createUndefinedValue(Type t);
 
     LLVMExpressionNode createLiteral(Object value, LLVMBaseType type);
 

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
@@ -130,7 +130,7 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMNode createLLVMIntrinsic(String functionName, Object[] argNodes, FunctionType functionDef) {
+    public LLVMNode createLLVMIntrinsic(FunctionDeclaration declaration, Object[] argNodes, int argCount) {
         return null;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
@@ -37,8 +37,6 @@ import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMType;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 
-import com.intel.llvm.ireditor.lLVM_IR.FunctionDef;
-import com.intel.llvm.ireditor.lLVM_IR.FunctionHeader;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.frame.FrameDescriptor;
@@ -51,7 +49,9 @@ import com.oracle.truffle.api.source.SourceSection;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller;
+import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
+import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 import com.oracle.truffle.llvm.parser.instructions.LLVMArithmeticInstructionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
@@ -130,7 +130,7 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMNode createLLVMIntrinsic(String functionName, Object[] argNodes, FunctionDef functionDef) {
+    public LLVMNode createLLVMIntrinsic(String functionName, Object[] argNodes, FunctionType functionDef) {
         return null;
     }
 
@@ -297,7 +297,7 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
 
     @Override
     public RootNode createFunctionStartNode(LLVMExpressionNode functionBodyNode, LLVMNode[] beforeFunction, LLVMNode[] afterFunction, SourceSection sourceSection, FrameDescriptor frameDescriptor,
-                    FunctionHeader functionHeader) {
+                    FunctionDeclaration functionHeader) {
         return null;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
@@ -130,7 +130,7 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMNode createLLVMIntrinsic(FunctionType declaration, Object[] argNodes, int argCount) {
+    public LLVMNode createLLVMIntrinsic(FunctionType declaration, Object[] argNodes, int numberOfExplicitArguments) {
         return null;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
@@ -49,9 +49,9 @@ import com.oracle.truffle.api.source.SourceSection;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller;
-import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
 import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDefinition;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
+import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 import com.oracle.truffle.llvm.parser.instructions.LLVMArithmeticInstructionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
@@ -130,7 +130,7 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMNode createLLVMIntrinsic(FunctionDeclaration declaration, Object[] argNodes, int argCount) {
+    public LLVMNode createLLVMIntrinsic(FunctionType declaration, Object[] argNodes, int argCount) {
         return null;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMType;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
-import org.eclipse.emf.ecore.EObject;
 
 import com.intel.llvm.ireditor.lLVM_IR.FunctionDef;
 import com.intel.llvm.ireditor.lLVM_IR.FunctionHeader;
@@ -111,7 +110,7 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMExpressionNode createUndefinedValue(EObject t) {
+    public LLVMExpressionNode createUndefinedValue(Type t) {
         return null;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
@@ -50,8 +50,8 @@ import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMStackFrameNuller;
 import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
+import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDefinition;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
-import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 import com.oracle.truffle.llvm.parser.instructions.LLVMArithmeticInstructionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
@@ -297,7 +297,7 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
 
     @Override
     public RootNode createFunctionStartNode(LLVMExpressionNode functionBodyNode, LLVMNode[] beforeFunction, LLVMNode[] afterFunction, SourceSection sourceSection, FrameDescriptor frameDescriptor,
-                    FunctionDeclaration functionHeader) {
+                    FunctionDefinition functionHeader) {
         return null;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/LLVMToBitcodeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/LLVMToBitcodeAdapter.java
@@ -54,6 +54,7 @@ import com.intel.llvm.ireditor.types.ResolvedVectorType;
 import com.intel.llvm.ireditor.types.ResolvedVoidType;
 import com.oracle.truffle.llvm.parser.base.model.enums.Linkage;
 import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
+import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDefinition;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
 import com.oracle.truffle.llvm.parser.base.model.types.ArrayType;
 import com.oracle.truffle.llvm.parser.base.model.types.FloatingPointType;
@@ -317,8 +318,10 @@ public final class LLVMToBitcodeAdapter {
         return new ResolvedVectorType(type.getLength(), elementType);
     }
 
-    public static FunctionDeclaration resolveFunctionDef(LLVMParserRuntime runtime, FunctionDef def) {
-        return resolveFunctionHeader(runtime, def.getHeader());
+    public static FunctionDefinition resolveFunctionDef(LLVMParserRuntime runtime, FunctionDef def) {
+        FunctionDefinition funcDef = new FunctionDefinition(resolveFunctionHeader(runtime, def.getHeader()), null);
+        funcDef.setName(def.getHeader().getName().substring(1));
+        return funcDef;
     }
 
     public static FunctionDeclaration resolveFunctionHeader(LLVMParserRuntime runtime, FunctionHeader header) {

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/LLVMToBitcodeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/LLVMToBitcodeAdapter.java
@@ -324,7 +324,7 @@ public final class LLVMToBitcodeAdapter {
         return funcDef;
     }
 
-    public static FunctionDeclaration resolveFunctionHeader(LLVMParserRuntime runtime, FunctionHeader header) {
+    public static FunctionType resolveFunctionHeader(LLVMParserRuntime runtime, FunctionHeader header) {
         Type returnType = resolveType(runtime.resolve(header.getRettype()));
         List<Type> args = new ArrayList<>();
         boolean hasVararg = false;
@@ -337,9 +337,8 @@ public final class LLVMToBitcodeAdapter {
             }
         }
         FunctionType funcType = new FunctionType(returnType, args.toArray(new Type[args.size()]), hasVararg);
-        FunctionDeclaration funcDecl = new FunctionDeclaration(funcType);
-        funcDecl.setName(header.getName().substring(1));
-        return funcDecl;
+        funcType.setName(header.getName().substring(1));
+        return funcType;
     }
 
     private static Linkage resolveLinkage(String linkage) {

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDeclaration.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDeclaration.java
@@ -32,30 +32,13 @@ package com.oracle.truffle.llvm.parser.base.model.functions;
 import com.oracle.truffle.llvm.parser.base.model.symbols.ValueSymbol;
 import com.oracle.truffle.llvm.parser.base.model.symbols.constants.Constant;
 import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
-import com.oracle.truffle.llvm.parser.base.model.types.PointerType;
-import com.oracle.truffle.llvm.parser.base.model.types.Type;
 
-public final class FunctionDeclaration extends FunctionType implements Constant, ValueSymbol {
+public final class FunctionDeclaration extends FunctionType implements Constant {
 
     private String name = ValueSymbol.UNKNOWN;
 
     public FunctionDeclaration(FunctionType type) {
         super(type.getReturnType(), type.getArgumentTypes(), type.isVarArg());
-    }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public Type getType() {
-        return new PointerType(super.getType());
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = "@" + name;
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
@@ -56,13 +56,12 @@ import com.oracle.truffle.llvm.parser.base.model.symbols.instructions.ValueInstr
 import com.oracle.truffle.llvm.parser.base.model.types.FloatingPointType;
 import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
 import com.oracle.truffle.llvm.parser.base.model.types.IntegerType;
-import com.oracle.truffle.llvm.parser.base.model.types.PointerType;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 import com.oracle.truffle.llvm.parser.base.model.generators.FunctionGenerator;
 import com.oracle.truffle.llvm.parser.base.model.blocks.InstructionGenerator;
 import com.oracle.truffle.llvm.parser.base.model.visitors.FunctionVisitor;
 
-public final class FunctionDefinition extends FunctionType implements Constant, FunctionGenerator, ValueSymbol {
+public final class FunctionDefinition extends FunctionType implements Constant, FunctionGenerator {
 
     private final Symbols symbols = new Symbols();
 
@@ -153,16 +152,6 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
         return Arrays.asList(blocks);
     }
 
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public Type getType() {
-        return new PointerType(super.getType());
-    }
-
     public List<FunctionParameter> getParameters() {
         return parameters;
     }
@@ -184,11 +173,6 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
     @Override
     public void nameFunction(int index, int offset, String argName) {
         symbols.setSymbolName(index, argName);
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = "@" + name;
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/FunctionType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/FunctionType.java
@@ -31,15 +31,18 @@ package com.oracle.truffle.llvm.parser.base.model.types;
 
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.base.datalayout.DataLayoutConverter;
+import com.oracle.truffle.llvm.parser.base.model.symbols.ValueSymbol;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
-public class FunctionType implements Type {
+public class FunctionType implements Type, ValueSymbol {
 
     private final Type type;
 
     private final Type[] args;
 
     private final boolean isVarArg;
+
+    private String name;
 
     public FunctionType(Type type, Type[] args, boolean isVarArg) {
         this.type = type;
@@ -54,6 +57,11 @@ public class FunctionType implements Type {
     @Override
     public LLVMBaseType getLLVMBaseType() {
         return LLVMBaseType.FUNCTION_ADDRESS;
+    }
+
+    @Override
+    public Type getType() {
+        return new PointerType(Type.super.getType());
     }
 
     public Type getReturnType() {
@@ -81,6 +89,16 @@ public class FunctionType implements Type {
     @Override
     public int getBits() {
         return 0;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = "@" + name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeInstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeInstructionVisitor.java
@@ -65,7 +65,6 @@ import com.oracle.truffle.llvm.parser.bc.impl.LLVMPhiManager.Phi;
 import com.oracle.truffle.llvm.parser.bc.impl.nodes.LLVMNodeGenerator;
 import com.oracle.truffle.llvm.parser.base.util.LLVMBitcodeTypeHelper;
 import com.oracle.truffle.llvm.parser.bc.impl.util.LLVMFrameIDs;
-import com.oracle.truffle.llvm.parser.factories.LLVMIntrinsicFactory;
 import com.oracle.truffle.llvm.parser.factories.LLVMSelectFactory;
 import com.oracle.truffle.llvm.parser.factories.LLVMVectorFactory;
 import com.oracle.truffle.llvm.parser.instructions.LLVMArithmeticInstructionType;
@@ -249,7 +248,8 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
         final Symbol target = call.getCallTarget();
         LLVMExpressionNode result;
         if (target instanceof FunctionDeclaration && (((ValueSymbol) target).getName()).startsWith("@llvm.")) {
-            result = (LLVMExpressionNode) factoryFacade.createLLVMIntrinsic(((ValueSymbol) target).getName(), argNodes, call.getCallType());
+            FunctionDeclaration targetDecl = (FunctionDeclaration) target;
+            result = (LLVMExpressionNode) factoryFacade.createLLVMIntrinsic(targetDecl, argNodes, targetDecl.getArgumentTypes().length);
 
         } else if (target instanceof FunctionDeclaration && (((ValueSymbol) target).getName()).startsWith("@truffle_")) {
             method.addInstruction(factoryFacade.createTruffleIntrinsic(((ValueSymbol) target).getName(), argNodes));
@@ -627,7 +627,7 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
         if (target instanceof FunctionDeclaration && (((ValueSymbol) target).getName()).startsWith("@llvm.")) {
             // number of arguments of the caller so llvm intrinsics can distinguish varargs
             final int parentArgCount = method.getArgCount();
-            node = LLVMIntrinsicFactory.create(((ValueSymbol) target).getName(), args, parentArgCount, method.getStackSlot());
+            node = factoryFacade.createLLVMIntrinsic((FunctionDeclaration) target, args, parentArgCount);
 
         } else if (target instanceof FunctionDeclaration && (((ValueSymbol) target).getName()).startsWith("@truffle_")) {
             node = factoryFacade.createTruffleIntrinsic(((ValueSymbol) target).getName(), args);

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeInstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeInstructionVisitor.java
@@ -249,7 +249,7 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
         final Symbol target = call.getCallTarget();
         LLVMExpressionNode result;
         if (target instanceof FunctionDeclaration && (((ValueSymbol) target).getName()).startsWith("@llvm.")) {
-            result = (LLVMExpressionNode) LLVMIntrinsicFactory.create(((ValueSymbol) target).getName(), argNodes, call.getCallType().getArgumentTypes().length, method.getStackSlot());
+            result = (LLVMExpressionNode) factoryFacade.createLLVMIntrinsic(((ValueSymbol) target).getName(), argNodes, call.getCallType());
 
         } else if (target instanceof FunctionDeclaration && (((ValueSymbol) target).getName()).startsWith("@truffle_")) {
             method.addInstruction(factoryFacade.createTruffleIntrinsic(((ValueSymbol) target).getName(), argNodes));

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
@@ -35,6 +35,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.emf.ecore.EObject;
+
+import com.intel.llvm.ireditor.types.ResolvedType;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.FrameDescriptor;
@@ -67,9 +70,10 @@ import com.oracle.truffle.llvm.parser.base.model.symbols.instructions.Instructio
 import com.oracle.truffle.llvm.parser.base.model.target.TargetDataLayout;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserAsserts;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserResultImpl;
+import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
+import com.oracle.truffle.llvm.parser.base.util.LLVMTypeHelper;
 import com.oracle.truffle.llvm.parser.base.datalayout.DataLayoutConverter;
 import com.oracle.truffle.llvm.parser.base.facade.NodeFactoryFacade;
-import com.oracle.truffle.llvm.parser.base.util.LLVMTypeHelper;
 import com.oracle.truffle.llvm.parser.bc.impl.nodes.LLVMConstantGenerator;
 import com.oracle.truffle.llvm.parser.base.util.LLVMBitcodeTypeHelper;
 import com.oracle.truffle.llvm.parser.bc.impl.util.LLVMFrameIDs;
@@ -93,6 +97,7 @@ import com.oracle.truffle.llvm.parser.base.model.globals.GlobalAlias;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalConstant;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalValueSymbol;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
+import com.oracle.truffle.llvm.parser.base.model.LLVMToBitcodeAdapter;
 import com.oracle.truffle.llvm.parser.base.model.Model;
 import com.oracle.truffle.llvm.parser.base.model.ModelModule;
 import com.oracle.truffle.llvm.parser.base.model.visitors.ModelVisitor;
@@ -187,6 +192,7 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
         this.targetDataLayout = layout;
         this.typeHelper = new LLVMBitcodeTypeHelper(targetDataLayout);
         this.factoryFacade = factoryFacade;
+        this.factoryFacade.setUpFacade(new LLVMBitcodeVisitorParserRuntime());
     }
 
     private LLVMExpressionNode createFunction(FunctionDefinition method, LLVMLifetimeAnalysis lifetimes) {
@@ -512,6 +518,80 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
 
     @Override
     public void visit(Type type) {
+    }
+
+    private class LLVMBitcodeVisitorParserRuntime implements LLVMParserRuntime {
+
+        @Override
+        public ResolvedType resolve(EObject e) {
+            throw new UnsupportedOperationException("Not implemented!");
+        }
+
+        @Override
+        public LLVMExpressionNode allocateFunctionLifetime(ResolvedType type, int size, int alignment) {
+            return factoryFacade.createAlloc(LLVMToBitcodeAdapter.resolveType(type), size, alignment, null, null);
+        }
+
+        @Override
+        public FrameSlot getReturnSlot() {
+            throw new UnsupportedOperationException("Not implemented!");
+        }
+
+        @Override
+        public LLVMExpressionNode allocateVectorResult(EObject type) {
+            throw new UnsupportedOperationException("Not implemented!");
+        }
+
+        @Override
+        public Object getGlobalAddress(com.intel.llvm.ireditor.lLVM_IR.GlobalVariable var) {
+            throw new UnsupportedOperationException("Not implemented!");
+        }
+
+        @Override
+        public FrameSlot getStackPointerSlot() {
+            throw new UnsupportedOperationException("Not implemented!");
+        }
+
+        @Override
+        public int getBitAlignment(LLVMBaseType type) {
+            return targetDataLayout.getBitAlignment(type);
+        }
+
+        @Override
+        public int getByteSize(Type type) {
+            return type.getSize(targetDataLayout);
+        }
+
+        @Override
+        public FrameDescriptor getGlobalFrameDescriptor() {
+            throw new UnsupportedOperationException("Not implemented!");
+        }
+
+        @Override
+        public void addDestructor(LLVMNode destructorNode) {
+            throw new UnsupportedOperationException("Not implemented!");
+        }
+
+        @Override
+        public long getNativeHandle(String name) {
+            return nativeLookup.getNativeHandle(name);
+        }
+
+        @Override
+        public LLVMTypeHelper getTypeHelper() {
+            throw new UnsupportedOperationException("Not implemented!");
+        }
+
+        @Override
+        public Map<String, Type> getVariableNameTypesMapping() {
+            throw new UnsupportedOperationException("Not implemented!");
+        }
+
+        @Override
+        public NodeFactoryFacade getNodeFactoryFacade() {
+            return factoryFacade;
+        }
+
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAggregateFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAggregateFactory.java
@@ -118,7 +118,7 @@ public final class LLVMAggregateFactory {
         int[] offsets = new int[types.length];
         LLVMStructWriteNode[] nodes = new LLVMStructWriteNode[types.length];
         int currentOffset = 0;
-        int structSize = runtime.getTypeHelper().getByteSize(structType);
+        int structSize = runtime.getByteSize(structType);
         int structAlignment = runtime.getTypeHelper().getAlignmentByte(structType);
         LLVMExpressionNode alloc = runtime.allocateFunctionLifetime(LLVMToBitcodeAdapter.unresolveType(structType), structSize, structAlignment);
         for (int i = 0; i < types.length; i++) {
@@ -127,7 +127,7 @@ public final class LLVMAggregateFactory {
                 currentOffset += runtime.getTypeHelper().computePaddingByte(currentOffset, resolvedType);
             }
             offsets[i] = currentOffset;
-            int byteSize = runtime.getTypeHelper().getByteSize(resolvedType);
+            int byteSize = runtime.getByteSize(resolvedType);
             nodes[i] = createStructWriteNode(runtime, constants[i], resolvedType);
             currentOffset += byteSize;
         }
@@ -135,7 +135,7 @@ public final class LLVMAggregateFactory {
     }
 
     private static LLVMStructWriteNode createStructWriteNode(LLVMParserRuntime runtime, LLVMExpressionNode parsedConstant, Type resolvedType) {
-        int byteSize = runtime.getTypeHelper().getByteSize(resolvedType);
+        int byteSize = runtime.getByteSize(resolvedType);
         LLVMBaseType llvmType = LLVMTypeHelper.getLLVMType(resolvedType).getType();
         switch (llvmType) {
             case I1:

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMFunctionFactory.java
@@ -152,7 +152,7 @@ public final class LLVMFunctionFactory {
                 case FUNCTION_ADDRESS:
                     return LLVMFunctionRetNodeGen.create((LLVMFunctionNode) retValue, retSlot);
                 case STRUCT:
-                    int size = runtime.getTypeHelper().getByteSize(resolvedType);
+                    int size = runtime.getByteSize(resolvedType);
                     return LLVMStructRetNodeGen.create((LLVMAddressNode) retValue, retSlot, size);
                 default:
                     throw new AssertionError(type);

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMIntrinsicFactory.java
@@ -32,7 +32,6 @@ package com.oracle.truffle.llvm.parser.factories;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.intel.llvm.ireditor.lLVM_IR.FunctionDef;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -82,6 +81,7 @@ import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.bit.CountTrailingZeroe
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.x86.LLVMX86_64BitVACopyNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.x86.LLVMX86_64BitVAEnd;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.x86.LLVMX86_64BitVAStart;
+import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
@@ -137,8 +137,8 @@ public final class LLVMIntrinsicFactory {
     // The nodes are directly inserted in the current LLVM AST for the moment. To change this later
     // one,
     // reuse the same intrinsic node classes but pass arg read nodes as there arguments.
-    public static LLVMNode create(String functionName, Object[] argNodes, FunctionDef functionDef, LLVMParserRuntime runtime) {
-        int argCount = functionDef.getHeader().getParameters().getParameters().size();
+    public static LLVMNode create(String functionName, Object[] argNodes, FunctionType functionDef, LLVMParserRuntime runtime) {
+        int argCount = functionDef.getArgumentTypes().length;
         return create(functionName, argNodes, argCount, runtime.getStackPointerSlot());
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMIntrinsicFactory.java
@@ -81,7 +81,7 @@ import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.bit.CountTrailingZeroe
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.x86.LLVMX86_64BitVACopyNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.x86.LLVMX86_64BitVAEnd;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.x86.LLVMX86_64BitVAStart;
-import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
+import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
@@ -137,9 +137,8 @@ public final class LLVMIntrinsicFactory {
     // The nodes are directly inserted in the current LLVM AST for the moment. To change this later
     // one,
     // reuse the same intrinsic node classes but pass arg read nodes as there arguments.
-    public static LLVMNode create(String functionName, Object[] argNodes, FunctionType functionDef, LLVMParserRuntime runtime) {
-        int argCount = functionDef.getArgumentTypes().length;
-        return create(functionName, argNodes, argCount, runtime.getStackPointerSlot());
+    public static LLVMNode create(FunctionDeclaration declaration, Object[] argNodes, int argCount, LLVMParserRuntime runtime) {
+        return create(declaration.getName(), argNodes, argCount, runtime.getStackPointerSlot());
     }
 
     public static LLVMNode create(String functionName, Object[] argNodes, int argCount, FrameSlot stack) {

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMIntrinsicFactory.java
@@ -81,7 +81,7 @@ import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.bit.CountTrailingZeroe
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.x86.LLVMX86_64BitVACopyNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.x86.LLVMX86_64BitVAEnd;
 import com.oracle.truffle.llvm.nodes.impl.intrinsics.llvm.x86.LLVMX86_64BitVAStart;
-import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
+import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException;
 import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReason;
@@ -137,7 +137,7 @@ public final class LLVMIntrinsicFactory {
     // The nodes are directly inserted in the current LLVM AST for the moment. To change this later
     // one,
     // reuse the same intrinsic node classes but pass arg read nodes as there arguments.
-    public static LLVMNode create(FunctionDeclaration declaration, Object[] argNodes, int argCount, LLVMParserRuntime runtime) {
+    public static LLVMNode create(FunctionType declaration, Object[] argNodes, int argCount, LLVMParserRuntime runtime) {
         return create(declaration.getName(), argNodes, argCount, runtime.getStackPointerSlot());
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMIntrinsicFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMIntrinsicFactory.java
@@ -137,11 +137,11 @@ public final class LLVMIntrinsicFactory {
     // The nodes are directly inserted in the current LLVM AST for the moment. To change this later
     // one,
     // reuse the same intrinsic node classes but pass arg read nodes as there arguments.
-    public static LLVMNode create(FunctionType declaration, Object[] argNodes, int argCount, LLVMParserRuntime runtime) {
-        return create(declaration.getName(), argNodes, argCount, runtime.getStackPointerSlot());
+    public static LLVMNode create(FunctionType declaration, Object[] argNodes, int numberOfExplicitArguments, LLVMParserRuntime runtime) {
+        return create(declaration.getName(), argNodes, numberOfExplicitArguments, runtime.getStackPointerSlot());
     }
 
-    public static LLVMNode create(String functionName, Object[] argNodes, int argCount, FrameSlot stack) {
+    public static LLVMNode create(String functionName, Object[] argNodes, int numberOfExplicitArguments, FrameSlot stack) {
         NodeFactory<? extends LLVMNode> factory = factories.get(functionName);
         LLVMContext context = LLVMLanguage.INSTANCE.findContext0(LLVMLanguage.INSTANCE.createFindContextNode0());
         LLVMAddressNode readStackPointerNode = (LLVMAddressNode) argNodes[0];
@@ -157,11 +157,11 @@ public final class LLVMIntrinsicFactory {
             } else if (functionName.equals("@llvm.frameaddress")) {
                 return LLVMFrameAddressNodeGen.create((LLVMI32Node) realArgNodes[0], stack);
             } else if (functionName.startsWith("@llvm.va_start")) {
-                return new LLVMX86_64BitVAStart(argCount, (LLVMAddressNode) realArgNodes[0]);
+                return new LLVMX86_64BitVAStart(numberOfExplicitArguments, (LLVMAddressNode) realArgNodes[0]);
             } else if (functionName.startsWith("@llvm.va_end")) {
                 return new LLVMX86_64BitVAEnd((LLVMAddressNode) realArgNodes[0]);
             } else if (functionName.startsWith("@llvm.va_copy")) {
-                return LLVMX86_64BitVACopyNodeGen.create((LLVMAddressNode) realArgNodes[0], (LLVMAddressNode) realArgNodes[1], argCount);
+                return LLVMX86_64BitVACopyNodeGen.create((LLVMAddressNode) realArgNodes[0], (LLVMAddressNode) realArgNodes[1], numberOfExplicitArguments);
             } else if (functionName.equals("@llvm.eh.sjlj.longjmp") || functionName.equals("@llvm.eh.sjlj.setjmp")) {
                 throw new LLVMUnsupportedException(UnsupportedReason.SET_JMP_LONG_JMP);
             } else if (functionName.startsWith("@llvm.objectsize.i64")) {

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
@@ -378,7 +378,7 @@ public final class LLVMLiteralFactory {
         int nrElements = arrayValues.size();
         Type elementType = arrayType.getElementType();
         LLVMBaseType llvmElementType = elementType.getLLVMBaseType();
-        int baseTypeSize = runtime.getTypeHelper().getByteSize(elementType);
+        int baseTypeSize = runtime.getByteSize(elementType);
         int size = nrElements * baseTypeSize;
         LLVMAddressNode arrayAlloc = (LLVMAddressNode) runtime.allocateFunctionLifetime(LLVMToBitcodeAdapter.unresolveType(arrayType), size,
                         runtime.getTypeHelper().getAlignmentByte(arrayType));

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
@@ -34,7 +34,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.oracle.truffle.llvm.parser.base.util.LLVMTypeHelper;
-import org.eclipse.emf.ecore.EObject;
 
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
@@ -99,8 +98,7 @@ public final class LLVMLiteralFactory {
     private LLVMLiteralFactory() {
     }
 
-    public static LLVMExpressionNode createUndefinedValue(LLVMParserRuntime runtime, EObject t) {
-        Type resolvedType = LLVMToBitcodeAdapter.resolveType(runtime.resolve(t));
+    public static LLVMExpressionNode createUndefinedValue(LLVMParserRuntime runtime, Type resolvedType) {
         LLVMBaseType type = resolvedType.getLLVMBaseType();
         if (LLVMTypeHelper.isVectorType(type)) {
             LLVMAddressLiteralNode addr = new LLVMAddressLiteralNode(LLVMAddress.createUndefinedAddress());

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMMemoryReadWriteFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMMemoryReadWriteFactory.java
@@ -89,7 +89,6 @@ import com.oracle.truffle.llvm.nodes.impl.memory.load.LLVMI8LoadNodeFactory.LLVM
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMAccessGlobalVariableStorageNode;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
-import com.oracle.truffle.llvm.parser.base.model.LLVMToBitcodeAdapter;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 import com.oracle.truffle.llvm.parser.base.model.types.VectorType;
 import com.oracle.truffle.llvm.parser.base.util.LLVMTypeHelper;
@@ -195,7 +194,7 @@ public final class LLVMMemoryReadWriteFactory {
     }
 
     public static LLVMNode createStore(LLVMParserRuntime runtime, LLVMAddressNode pointerNode, LLVMExpressionNode valueNode, Type type) {
-        return createStore(pointerNode, valueNode, type.getLLVMBaseType(), runtime.getTypeHelper().getByteSize(LLVMToBitcodeAdapter.unresolveType(type)));
+        return createStore(pointerNode, valueNode, type.getLLVMBaseType(), runtime.getByteSize(type));
     }
 
     public static LLVMNode createStore(LLVMAddressNode pointerNode, LLVMExpressionNode valueNode, LLVMBaseType type, int size) {

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -33,8 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import com.intel.llvm.ireditor.lLVM_IR.FunctionDef;
-import com.intel.llvm.ireditor.lLVM_IR.FunctionHeader;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
@@ -91,8 +89,10 @@ import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerN
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMType;
 import com.oracle.truffle.llvm.parser.base.facade.NodeFactoryFacade;
+import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
 import com.oracle.truffle.llvm.parser.base.model.types.ArrayType;
+import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.base.util.LLVMTypeHelper;
@@ -181,7 +181,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMNode createLLVMIntrinsic(String functionName, Object[] argNodes, FunctionDef def) {
+    public LLVMNode createLLVMIntrinsic(String functionName, Object[] argNodes, FunctionType def) {
         return LLVMIntrinsicFactory.create(functionName, argNodes, def, runtime);
     }
 
@@ -360,14 +360,14 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
 
     @Override
     public RootNode createFunctionStartNode(LLVMExpressionNode functionBodyNode, LLVMNode[] beforeFunction, LLVMNode[] afterFunction, SourceSection sourceSection, FrameDescriptor frameDescriptor,
-                    FunctionHeader functionHeader) {
+                    FunctionDeclaration functionHeader) {
         LLVMStackFrameNuller[] nullers = new LLVMStackFrameNuller[frameDescriptor.getSlots().size()];
         int i = 0;
         for (FrameSlot slot : frameDescriptor.getSlots()) {
             String identifier = (String) slot.getIdentifier();
             Type slotType = runtime.getVariableNameTypesMapping().get(identifier);
             if (slot.equals(runtime.getReturnSlot())) {
-                nullers[i] = runtime.getNodeFactoryFacade().createFrameNuller(identifier, LLVMTypeHelper.getLLVMType(runtime.resolve(functionHeader.getRettype())), slot);
+                nullers[i] = runtime.getNodeFactoryFacade().createFrameNuller(identifier, LLVMTypeHelper.getLLVMType(functionHeader.getReturnType()), slot);
             } else if (slot.equals(runtime.getStackPointerSlot())) {
                 nullers[i] = runtime.getNodeFactoryFacade().createFrameNuller(identifier, new LLVMType(LLVMBaseType.ADDRESS), slot);
             } else {

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -89,10 +89,10 @@ import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerN
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMType;
 import com.oracle.truffle.llvm.parser.base.facade.NodeFactoryFacade;
-import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
 import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDefinition;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
 import com.oracle.truffle.llvm.parser.base.model.types.ArrayType;
+import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.base.util.LLVMTypeHelper;
@@ -181,7 +181,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMNode createLLVMIntrinsic(FunctionDeclaration declaration, Object[] argNodes, int argCount) {
+    public LLVMNode createLLVMIntrinsic(FunctionType declaration, Object[] argNodes, int argCount) {
         return LLVMIntrinsicFactory.create(declaration, argNodes, argCount, runtime);
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -90,6 +90,7 @@ import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.LLVMType;
 import com.oracle.truffle.llvm.parser.base.facade.NodeFactoryFacade;
 import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
+import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDefinition;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
 import com.oracle.truffle.llvm.parser.base.model.types.ArrayType;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
@@ -359,7 +360,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
 
     @Override
     public RootNode createFunctionStartNode(LLVMExpressionNode functionBodyNode, LLVMNode[] beforeFunction, LLVMNode[] afterFunction, SourceSection sourceSection, FrameDescriptor frameDescriptor,
-                    FunctionDeclaration functionHeader) {
+                    FunctionDefinition functionHeader) {
         LLVMStackFrameNuller[] nullers = new LLVMStackFrameNuller[frameDescriptor.getSlots().size()];
         int i = 0;
         for (FrameSlot slot : frameDescriptor.getSlots()) {

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -92,7 +92,6 @@ import com.oracle.truffle.llvm.parser.base.facade.NodeFactoryFacade;
 import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
 import com.oracle.truffle.llvm.parser.base.model.types.ArrayType;
-import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.base.util.LLVMTypeHelper;
@@ -181,8 +180,8 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMNode createLLVMIntrinsic(String functionName, Object[] argNodes, FunctionType def) {
-        return LLVMIntrinsicFactory.create(functionName, argNodes, def, runtime);
+    public LLVMNode createLLVMIntrinsic(FunctionDeclaration declaration, Object[] argNodes, int argCount) {
+        return LLVMIntrinsicFactory.create(declaration, argNodes, argCount, runtime);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -456,7 +456,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
 
         if (!globalVariable.isExtern() && !descriptor.isDeclared()) {
             Type resolvedType = globalVariable.getType();
-            int byteSize = runtime.getTypeHelper().getByteSize(resolvedType);
+            int byteSize = runtime.getByteSize(resolvedType);
             LLVMAddress nativeStorage = LLVMHeap.allocateMemory(byteSize);
             LLVMAddressNode addressLiteralNode = (LLVMAddressNode) createLiteral(nativeStorage, LLVMBaseType.ADDRESS);
             runtime.addDestructor(LLVMFreeFactory.create(addressLiteralNode));

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -181,8 +181,8 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMNode createLLVMIntrinsic(FunctionType declaration, Object[] argNodes, int argCount) {
-        return LLVMIntrinsicFactory.create(declaration, argNodes, argCount, runtime);
+    public LLVMNode createLLVMIntrinsic(FunctionType declaration, Object[] argNodes, int numberOfExplicitArguments) {
+        return LLVMIntrinsicFactory.create(declaration, argNodes, numberOfExplicitArguments, runtime);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -33,8 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.eclipse.emf.ecore.EObject;
-
 import com.intel.llvm.ireditor.lLVM_IR.FunctionDef;
 import com.intel.llvm.ireditor.lLVM_IR.FunctionHeader;
 import com.oracle.truffle.api.CallTarget;
@@ -168,7 +166,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMExpressionNode createUndefinedValue(EObject t) {
+    public LLVMExpressionNode createUndefinedValue(Type t) {
         return LLVMLiteralFactory.createUndefinedValue(runtime, t);
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -1232,7 +1232,7 @@ public final class LLVMVisitor implements LLVMParserRuntime {
     private LLVMExpressionNode getUndefinedValueNode(EObject type) {
         LLVMBaseType llvmType = getLLVMType(type).getType();
         if (llvmType != LLVMBaseType.ARRAY && llvmType != LLVMBaseType.STRUCT) {
-            return factoryFacade.createUndefinedValue(type);
+            return factoryFacade.createUndefinedValue(LLVMToBitcodeAdapter.resolveType(resolve(type)));
         } else {
             ResolvedType resolvedType = resolve(type);
             int byteSize = typeHelper.getByteSize(resolvedType);

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -658,7 +658,8 @@ public final class LLVMVisitor implements LLVMParserRuntime {
             FunctionHeader functionHeader = (FunctionHeader) ((GlobalValueRef) callee).getConstant().getRef();
             String functionName = functionHeader.getName();
             if (functionName.startsWith("@llvm.")) {
-                return factoryFacade.createLLVMIntrinsic(functionName, finalArgs, LLVMToBitcodeAdapter.resolveFunctionDef(this, containingFunctionDef));
+                return factoryFacade.createLLVMIntrinsic(LLVMToBitcodeAdapter.resolveFunctionHeader(this, functionHeader), finalArgs,
+                                LLVMToBitcodeAdapter.resolveFunctionDef(this, containingFunctionDef).getArgumentTypes().length);
             } else if (functionName.startsWith("@truffle_")) {
                 LLVMNode truffleIntrinsic = factoryFacade.createTruffleIntrinsic(functionName, finalArgs);
                 if (truffleIntrinsic != null) {

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -470,7 +470,8 @@ public final class LLVMVisitor implements LLVMParserRuntime {
         LLVMExpressionNode block = getFunctionBlockStatements(def);
         LLVMNode[] beforeFunction = formalParameters.toArray(new LLVMNode[formalParameters.size()]);
         LLVMNode[] afterFunction = functionEpilogue.toArray(new LLVMNode[functionEpilogue.size()]);
-        RootNode rootNode = factoryFacade.createFunctionStartNode(block, beforeFunction, afterFunction, sourceFile.createSection(1), frameDescriptor, def.getHeader());
+        RootNode rootNode = factoryFacade.createFunctionStartNode(block, beforeFunction, afterFunction, sourceFile.createSection(1), frameDescriptor,
+                        LLVMToBitcodeAdapter.resolveFunctionDef(this, def));
         if (LLVMBaseOptionFacade.printFunctionASTs()) {
             NodeUtil.printTree(System.out, rootNode);
         }
@@ -657,7 +658,7 @@ public final class LLVMVisitor implements LLVMParserRuntime {
             FunctionHeader functionHeader = (FunctionHeader) ((GlobalValueRef) callee).getConstant().getRef();
             String functionName = functionHeader.getName();
             if (functionName.startsWith("@llvm.")) {
-                return factoryFacade.createLLVMIntrinsic(functionName, finalArgs, containingFunctionDef);
+                return factoryFacade.createLLVMIntrinsic(functionName, finalArgs, LLVMToBitcodeAdapter.resolveFunctionDef(this, containingFunctionDef));
             } else if (functionName.startsWith("@truffle_")) {
                 LLVMNode truffleIntrinsic = factoryFacade.createTruffleIntrinsic(functionName, finalArgs);
                 if (truffleIntrinsic != null) {


### PR DESCRIPTION
* Use the ```factoryFacade``` at more points inside the ```LLVMBitcodeInstructionVisitor``` (remove direct references to some Factories)
* Add initial implementation of ```LLVMParserRuntime``` to ```LLVMBitcodeVisitor```
* Cleanup ```NodeFactoryFacade``` (now there are no longer old llvm types used in this class)