### PR TITLE
Add support for idivl and small enhancements to inline assembly parser

### DIFF
--- a/docs/INLINE-ASSEMBLER.md
+++ b/docs/INLINE-ASSEMBLER.md
@@ -53,3 +53,4 @@ supported:
 | decl        |          |
 | incl        |          |
 | imull       |          |
+| idivl       |          |

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
@@ -77,17 +77,18 @@ AddSubOperation<> =						(.String op; String left = null, right = null;.)
 
 MulOperation<> =						(.String op; String left = null, right = null;.)
   MulOp<out op>
-  ((Register<out left> "," Register<out right>)
+  ((Register<out left> ["," Register<out right>])
   |
   (Immediate<out left> "," Register<out right>)
-  )";"									(.factory.createBinaryOperation(op, left, right);.)
+  )";"									(.	if (right == null) {
+												factory.addFrameSlot("%eax", this.retType);
+											}
+											factory.createBinaryOperation(op, left, right);.)
   .
 
 DivOperation<> =						(.String op; String left = null;.)
   DivOp<out op>
   ((Register<out left> ["," "%eax"])
-  |
-  (Immediate<out left> ["," "%eax"])
   )";"									(.	factory.addFrameSlot("%eax", this.retType);
 											factory.addFrameSlot("%edx", this.retType);
 											factory.createDivisionOperatoin(op, left);

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
@@ -61,8 +61,8 @@ PRODUCTIONS
 InlineAssembly<> =
 										(..)
   "\""
-  (AddSubOperation<> | IncDecOperation<> | LogicOperation<> | ShiftOperation<> | MoveOperation<> | MulOperation<>)
-  {AddSubOperation<> | IncDecOperation<> | LogicOperation<> | ShiftOperation<> | MoveOperation<> | MulOperation<>}
+  (AddSubOperation<> | IncDecOperation<> | LogicOperation<> | ShiftOperation<> | MoveOperation<> | MulOperation<> | DivOperation<>)
+  {AddSubOperation<> | IncDecOperation<> | LogicOperation<> | ShiftOperation<> | MoveOperation<> | MulOperation<> | DivOperation<>}
   "\""
   										(.root = factory.finishInline();.)
   .
@@ -77,6 +77,14 @@ AddSubOperation<> =						(.String op; String left = null, right = null;.)
 
 MulOperation<> =						(.String op; String left = null, right = null;.)
   MulOp<out op>
+  ((Register<out left> "," Register<out right>)
+  |
+  (Immediate<out left> "," Register<out right>)
+  )";"									(.factory.createBinaryOperation(op, left, right);.)
+  .
+
+DivOperation<> =						(.String op; String left = null, right = null;.)
+  DivOp<out op>
   ((Register<out left> "," Register<out right>)
   |
   (Immediate<out left> "," Register<out right>)
@@ -143,7 +151,11 @@ ShiftOp<out String op>					(.op = la.val;.)
 MulOp<out String op>					(.op = la.val;.)
   = "imull"
   .
-  
+
+DivOp<out String op>					(.op = la.val;.)
+  = "idivl"
+  .
+
 MoveOp<out String op>					(.op = la.val;.)
   = "movl"
   .  

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
@@ -83,12 +83,15 @@ MulOperation<> =						(.String op; String left = null, right = null;.)
   )";"									(.factory.createBinaryOperation(op, left, right);.)
   .
 
-DivOperation<> =						(.String op; String left = null, right = null;.)
+DivOperation<> =						(.String op; String left = null;.)
   DivOp<out op>
-  ((Register<out left> "," Register<out right>)
+  ((Register<out left> ["," "%eax"])
   |
-  (Immediate<out left> "," Register<out right>)
-  )";"									(.factory.createBinaryOperation(op, left, right);.)
+  (Immediate<out left> ["," "%eax"])
+  )";"									(.	factory.addFrameSlot("%eax", this.retType);
+											factory.addFrameSlot("%edx", this.retType);
+											factory.createDivisionOperatoin(op, left);
+										.)
   .
 
 IncDecOperation<> =						(.String op; String left = null;.)

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/Parser.frame
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/Parser.frame
@@ -63,6 +63,10 @@ public class Parser {
 		errDist = 0;
 	}
 
+	public int getErrorCount(){
+		return errors.count;
+	}
+
 	void Get () {
 		for (;;) {
 			t = la;

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
@@ -40,6 +40,7 @@ import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.asm.LLVMAMD64DeclNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.asm.LLVMAMD64I32BinaryNodeFactory.LLVMAMD64AddlNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.asm.LLVMAMD64I32BinaryNodeFactory.LLVMAMD64AndlNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.asm.LLVMAMD64I32BinaryNodeFactory.LLVMAMD64IdivNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.asm.LLVMAMD64I32BinaryNodeFactory.LLVMAMD64ImulNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.asm.LLVMAMD64I32BinaryNodeFactory.LLVMAMD64OrlNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.asm.LLVMAMD64I32BinaryNodeFactory.LLVMAMD64SallNodeGen;
@@ -126,6 +127,9 @@ public class AsmFactory {
                 break;
             case "imull":
                 opNode = LLVMAMD64ImulNodeGen.create(leftNode, rightNode);
+                break;
+            case "idivl":
+                opNode = LLVMAMD64IdivNodeGen.create(leftNode, rightNode);
                 break;
             default:
                 opNode = new LLVMI32UnsupportedInlineAssemblerNode();

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
@@ -89,7 +89,8 @@ public class AsmFactory {
 
     public void createBinaryOperation(String operation, String left, String right) {
         FrameSlot leftSlot = frameDescriptor.findFrameSlot(left);
-        FrameSlot rightSlot = frameDescriptor.findFrameSlot(right);
+        String rightOperand = (right == null) ? "%eax" : right;
+        FrameSlot rightSlot = frameDescriptor.findFrameSlot(rightOperand);
         LLVMI32Node leftNode = (leftSlot != null) ? LLVMI32ReadNodeGen.create(leftSlot) : getImmediateNode(left);
         LLVMI32Node rightNode = LLVMI32ReadNodeGen.create(rightSlot);
         this.result = LLVMI32ReadNodeGen.create(rightSlot);

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
@@ -172,8 +172,11 @@ public class AsmFactory {
             LLVMI32Node divisionNode = LLVMAMD64IdivlNodeGen.create(divisorNode, eaxNode, edxNode);
             statement = LLVMWriteI32NodeGen.create(divisionNode, eaxSlot);
             returnNode = LLVMI32ReadNodeGen.create(eaxSlot);
+        } else {
+            // TODO: Other div instruction shall go here
+            returnNode = new LLVMI32UnsupportedInlineAssemblerNode();
+            statement = returnNode;
         }
-        // TODO: Other div instruction shall go here
         this.statements.add(statement);
         this.result = returnNode;
     }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64I32BinaryNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64I32BinaryNode.java
@@ -125,12 +125,4 @@ public abstract class LLVMAMD64I32BinaryNode extends LLVMI32Node {
             return left * right;
         }
     }
-
-    public abstract static class LLVMAMD64IdivNode extends LLVMAMD64I32BinaryNode {
-
-        @Specialization
-        protected int executeI32(int left, int right) {
-            return right / left;
-        }
-    }
 }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64I32BinaryNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64I32BinaryNode.java
@@ -126,4 +126,11 @@ public abstract class LLVMAMD64I32BinaryNode extends LLVMI32Node {
         }
     }
 
+    public abstract static class LLVMAMD64IdivNode extends LLVMAMD64I32BinaryNode {
+
+        @Specialization
+        protected int executeI32(int left, int right) {
+            return right / left;
+        }
+    }
 }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64IdivlNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64IdivlNode.java
@@ -39,8 +39,7 @@ public abstract class LLVMAMD64IdivlNode extends LLVMI32Node {
 
     @Specialization
     public int executeI32(int left, int rightAX, int rightDX) {
-        final int registerBits = 32;
-        long divident = rightDX << registerBits;
+        long divident = (long) rightDX << LLVMI32Node.BYTE_SIZE * Byte.SIZE;
         divident = divident | rightAX;
         return (int) (divident / left);
     }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64IdivlNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64IdivlNode.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.asm;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
+
+@NodeChildren({@NodeChild("left"), @NodeChild("rightAX"), @NodeChild("rightDX")})
+public abstract class LLVMAMD64IdivlNode extends LLVMI32Node {
+
+    @Specialization
+    public int executeI32(int left, int rightAX, int rightDX) {
+        long divident = rightDX << 32;
+        divident = divident | rightAX;
+        return (int) (divident / left);
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64IdivlNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64IdivlNode.java
@@ -39,7 +39,8 @@ public abstract class LLVMAMD64IdivlNode extends LLVMI32Node {
 
     @Specialization
     public int executeI32(int left, int rightAX, int rightDX) {
-        long divident = rightDX << 32;
+        final int registerBits = 32;
+        long divident = rightDX << registerBits;
         divident = divident | rightAX;
         return (int) (divident / left);
     }

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMNodeGenerator.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMNodeGenerator.java
@@ -187,6 +187,9 @@ public final class LLVMNodeGenerator {
 
         final Parser asmParser = new Parser(asmConstant.getAsmExpression(), asmConstant.getAsmFlags(), argNodes, targetType);
         final LLVMInlineAssemblyRootNode assemblyRootNode = asmParser.Parse();
+        if (asmParser.getErrorCount() != 0) {
+            throw new AssertionError("Error while parsing inline assembly expression - " + asmConstant.getAsmExpression());
+        }
         final CallTarget callTarget = Truffle.getRuntime().createCallTarget(assemblyRootNode);
         switch (targetType) {
             case VOID:

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMNodeGenerator.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMNodeGenerator.java
@@ -187,9 +187,6 @@ public final class LLVMNodeGenerator {
 
         final Parser asmParser = new Parser(asmConstant.getAsmExpression(), asmConstant.getAsmFlags(), argNodes, targetType);
         final LLVMInlineAssemblyRootNode assemblyRootNode = asmParser.Parse();
-        if (asmParser.getErrorCount() != 0) {
-            throw new AssertionError("Error while parsing inline assembly expression - " + asmConstant.getAsmExpression());
-        }
         final CallTarget callTarget = Truffle.getRuntime().createCallTarget(assemblyRootNode);
         switch (targetType) {
             case VOID:

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import com.oracle.truffle.llvm.parser.base.util.LLVMTypeHelper;
 import org.eclipse.emf.ecore.EObject;
 
 import com.intel.llvm.ireditor.lLVM_IR.FunctionDef;
@@ -92,12 +91,13 @@ import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerN
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode.LLVMI64UnsupportedInlineAssemblerNode;
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode.LLVMI8UnsupportedInlineAssemblerNode;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
-import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.LLVMType;
 import com.oracle.truffle.llvm.parser.base.facade.NodeFactoryFacade;
 import com.oracle.truffle.llvm.parser.base.model.globals.GlobalVariable;
 import com.oracle.truffle.llvm.parser.base.model.types.ArrayType;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
+import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
+import com.oracle.truffle.llvm.parser.base.util.LLVMTypeHelper;
 import com.oracle.truffle.llvm.parser.instructions.LLVMArithmeticInstructionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMFloatComparisonType;
@@ -390,6 +390,10 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     public LLVMNode createInlineAssemblerExpression(String asmExpression, String asmFlags, LLVMExpressionNode[] args, LLVMBaseType retType) {
         Parser asmParser = new Parser(asmExpression, asmFlags, args, retType);
         LLVMInlineAssemblyRootNode assemblyRoot = asmParser.Parse();
+        if (asmParser.getErrorCount() != 0) {
+            throw new AssertionError("Error while parsing inline assembly expression - " + asmExpression);
+        }
+
         CallTarget target = Truffle.getRuntime().createCallTarget(assemblyRoot);
         switch (retType) {
             case VOID:

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -390,10 +390,6 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     public LLVMNode createInlineAssemblerExpression(String asmExpression, String asmFlags, LLVMExpressionNode[] args, LLVMBaseType retType) {
         Parser asmParser = new Parser(asmExpression, asmFlags, args, retType);
         LLVMInlineAssemblyRootNode assemblyRoot = asmParser.Parse();
-        if (asmParser.getErrorCount() != 0) {
-            throw new AssertionError("Error while parsing inline assembly expression - " + asmExpression);
-        }
-
         CallTarget target = Truffle.getRuntime().createCallTarget(assemblyRoot);
         switch (retType) {
             case VOID:

--- a/projects/com.oracle.truffle.llvm.test/inlineassemblytests/inlineassembly022.c
+++ b/projects/com.oracle.truffle.llvm.test/inlineassemblytests/inlineassembly022.c
@@ -1,0 +1,7 @@
+int main() {
+  int arg1 = 40;
+  int arg2 = 2;
+  int quot = 0;
+  __asm__("idivl %%ebx, %%eax;" : "=a"(quot): "a"(arg1), "d"(0), "b"(arg2));
+  return quot;
+}

--- a/projects/com.oracle.truffle.llvm.test/inlineassemblytests/inlineassembly023.c
+++ b/projects/com.oracle.truffle.llvm.test/inlineassemblytests/inlineassembly023.c
@@ -2,6 +2,6 @@ int main() {
   int arg1 = 40;
   int arg2 = 2;
   int quot = 0;
-  __asm__("idivl $5;" : "=a"(quot): "a"(arg1), "d"(0));
+  __asm__("idivl %%ebx;" : "=a"(quot): "a"(arg1), "d"(0), "b"(arg2));
   return quot;
 }

--- a/projects/com.oracle.truffle.llvm.test/inlineassemblytests/inlineassembly023.c
+++ b/projects/com.oracle.truffle.llvm.test/inlineassemblytests/inlineassembly023.c
@@ -1,0 +1,7 @@
+int main() {
+  int arg1 = 40;
+  int arg2 = 2;
+  int quot = 0;
+  __asm__("idivl $5;" : "=a"(quot): "a"(arg1), "d"(0));
+  return quot;
+}

--- a/projects/com.oracle.truffle.llvm.test/inlineassemblytests/inlineassembly024.c
+++ b/projects/com.oracle.truffle.llvm.test/inlineassemblytests/inlineassembly024.c
@@ -1,0 +1,7 @@
+int main() {
+  int arg1 = 40;
+  int arg2 = 2;
+  int mul = 0;
+  __asm__("imull %%ebx;" : "=a"(mul) : "a"(arg1), "b"(arg2));
+  return mul;
+}


### PR DESCRIPTION
This PR includes,
- Updates to mx_sulong.py file to make sure that if any of the configuration file (.atg and all .frame files) is updated then parser and scanner should be re-generated. Previously it was not checking for .frame files.
- Support idivl with two 32 bit register operands
- Support for single 32 bit register operand imull and idivl instruction
- Parser (or Parser.frame) is updated to extract number of parsing errors 
- Exit if any error occurred while parsing. e.g. idivl does not accept immediate. If we do not exit then execution fails with non-obvious error e.g. 
```
int main() {
  int arg1 = 40;
  int mul= 0;
  __asm__("imull $2;" : "=a"(mul): "a"(arg1));
  return mul;
}
```
In above case parsing error is shown on command line that ',' is expected but execution goes further resulting in ` IllegalStateException` because parser returned right operand string as '2'.

- Please suggest, 
- Currently just the error causing line is shown not the root cause as shown by clang/gcc e.g. `error: too few operands for instruction` for above example. Would you suggest to do that?
- Separate function to handle division operation due to special case of take EDX:EAX combination as dividend, any better/elegant way to do it?