### PR TITLE
Add hashCode and equals implementation to Type classes

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDeclaration.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDeclaration.java
@@ -29,20 +29,25 @@
  */
 package com.oracle.truffle.llvm.parser.base.model.functions;
 
-import com.oracle.truffle.llvm.parser.base.model.symbols.ValueSymbol;
 import com.oracle.truffle.llvm.parser.base.model.symbols.constants.Constant;
 import com.oracle.truffle.llvm.parser.base.model.types.FunctionType;
 
 public final class FunctionDeclaration extends FunctionType implements Constant {
-
-    private String name = ValueSymbol.UNKNOWN;
 
     public FunctionDeclaration(FunctionType type) {
         super(type.getReturnType(), type.getArgumentTypes(), type.isVarArg());
     }
 
     @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof FunctionDeclaration) {
+            return super.equals(obj);
+        }
+        return false;
+    }
+
+    @Override
     public String toString() {
-        return "FunctionDeclaration [name=" + name + ", types=" + super.toString() + "]";
+        return "FunctionDeclaration [name=" + getName() + ", types=" + super.toString() + "]";
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
@@ -261,7 +261,22 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
     public boolean equals(Object obj) {
         if (obj instanceof FunctionDefinition) {
             FunctionDefinition other = (FunctionDefinition) obj;
-            return super.equals(other) && Objects.equals(parameters, other.parameters) && Objects.equals(symbols, other.symbols);
+            if (!super.equals(other)) {
+                return false;
+            }
+            if (!Objects.equals(parameters, other.parameters)) {
+                return false;
+            }
+            if (!Objects.equals(symbols, other.symbols)) {
+                return false;
+            }
+            if (!Arrays.equals(blocks, other.blocks)) {
+                return false;
+            }
+            if (currentBlock != other.currentBlock) {
+                return false;
+            }
+            return true;
         }
         return false;
     }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
@@ -33,6 +33,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import com.oracle.truffle.llvm.parser.base.model.blocks.InstructionBlock;
 import com.oracle.truffle.llvm.parser.base.model.blocks.MetadataBlock;
@@ -70,8 +71,6 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
     private InstructionBlock[] blocks = new InstructionBlock[0];
 
     private int currentBlock = 0;
-
-    private String name = ValueSymbol.UNKNOWN;
 
     private MetadataBlock metadata;
 
@@ -251,7 +250,24 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
     }
 
     @Override
+    public int hashCode() {
+        int hash = super.hashCode();
+        hash = 43 * hash + ((parameters == null) ? 0 : parameters.hashCode());
+        hash = 43 * hash + ((symbols == null) ? 0 : symbols.hashCode());
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof FunctionDefinition) {
+            FunctionDefinition other = (FunctionDefinition) obj;
+            return super.equals(other) && Objects.equals(parameters, other.parameters) && Objects.equals(symbols, other.symbols);
+        }
+        return false;
+    }
+
+    @Override
     public String toString() {
-        return "FunctionDefinition [symbolCount=" + symbols.getSize() + ", parameters=" + parameters + ", blocks=" + blocks.length + ", currentBlock=" + currentBlock + ", name=" + name + "]";
+        return "FunctionDefinition [symbolCount=" + symbols.getSize() + ", parameters=" + parameters + ", blocks=" + blocks.length + ", currentBlock=" + currentBlock + ", name=" + getName() + "]";
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/ArrayType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/ArrayType.java
@@ -56,15 +56,6 @@ public class ArrayType implements AggregateType {
         return elementType.getBits() * length;
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof ArrayType) {
-            ArrayType other = (ArrayType) obj;
-            return length == other.length && elementType.equals(other.elementType);
-        }
-        return false;
-    }
-
     public Type getElementType() {
         return elementType;
     }
@@ -105,6 +96,16 @@ public class ArrayType implements AggregateType {
     }
 
     @Override
+    public void setMetadataReference(MetadataReference metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public MetadataReference getMetadataReference() {
+        return metadata;
+    }
+
+    @Override
     public int hashCode() {
         int hash = 7;
         hash = 67 * hash + Objects.hashCode(this.elementType);
@@ -113,17 +114,16 @@ public class ArrayType implements AggregateType {
     }
 
     @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof ArrayType) {
+            ArrayType other = (ArrayType) obj;
+            return length == other.length && Objects.equals(elementType, other.elementType);
+        }
+        return false;
+    }
+
+    @Override
     public String toString() {
         return String.format("[%d x %s]", getLength(), getElementType());
-    }
-
-    @Override
-    public void setMetadataReference(MetadataReference metadata) {
-        this.metadata = metadata;
-    }
-
-    @Override
-    public MetadataReference getMetadataReference() {
-        return metadata;
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/BigIntegerConstantType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/BigIntegerConstantType.java
@@ -32,6 +32,7 @@ package com.oracle.truffle.llvm.parser.base.model.types;
 import com.oracle.truffle.llvm.parser.base.datalayout.DataLayoutConverter;
 
 import java.math.BigInteger;
+import java.util.Objects;
 
 public final class BigIntegerConstantType implements Type {
 
@@ -59,14 +60,6 @@ public final class BigIntegerConstantType implements Type {
     }
 
     @Override
-    public String toString() {
-        if (getType().getBits() == 1) {
-            return value.equals(BigInteger.ZERO) ? "i1 false" : "i1 true";
-        }
-        return String.format("%s %s", type, value);
-    }
-
-    @Override
     public int getAlignment(DataLayoutConverter.DataSpecConverter targetDataLayout) {
         if (targetDataLayout != null) {
             return targetDataLayout.getBitAlignment(type.getLLVMBaseType()) / Byte.SIZE;
@@ -79,5 +72,30 @@ public final class BigIntegerConstantType implements Type {
     @Override
     public int getSize(DataLayoutConverter.DataSpecConverter targetDataLayout) {
         return type.getSize(targetDataLayout);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 41 * hash + ((type == null) ? 0 : type.hashCode());
+        hash = 41 * hash + ((value == null) ? 0 : value.hashCode());
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BigIntegerConstantType) {
+            BigIntegerConstantType other = (BigIntegerConstantType) obj;
+            return Objects.equals(type, other.type) && Objects.equals(value, other.value);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        if (getType().getBits() == 1) {
+            return value.equals(BigInteger.ZERO) ? "i1 false" : "i1 true";
+        }
+        return String.format("%s %s", type, value);
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/FunctionType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/FunctionType.java
@@ -122,7 +122,19 @@ public class FunctionType implements Type, ValueSymbol {
     public boolean equals(Object obj) {
         if (obj instanceof FunctionType) {
             FunctionType other = (FunctionType) obj;
-            return Arrays.equals(args, other.args) && isVarArg == other.isVarArg && Objects.equals(type, other.type);
+            if (!Objects.equals(type, other.type)) {
+                return false;
+            }
+            if (!Arrays.equals(args, other.args)) {
+                return false;
+            }
+            if (isVarArg != other.isVarArg) {
+                return false;
+            }
+            if (!Objects.equals(name, other.name)) {
+                return false;
+            }
+            return true;
         }
         return false;
     }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/FunctionType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/FunctionType.java
@@ -29,6 +29,9 @@
  */
 package com.oracle.truffle.llvm.parser.base.model.types;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.base.datalayout.DataLayoutConverter;
 import com.oracle.truffle.llvm.parser.base.model.symbols.ValueSymbol;
@@ -42,7 +45,7 @@ public class FunctionType implements Type, ValueSymbol {
 
     private final boolean isVarArg;
 
-    private String name;
+    private String name = ValueSymbol.UNKNOWN;
 
     public FunctionType(Type type, Type[] args, boolean isVarArg) {
         this.type = type;
@@ -102,6 +105,29 @@ public class FunctionType implements Type, ValueSymbol {
     }
 
     @Override
+    public LLVMFunctionDescriptor.LLVMRuntimeType getRuntimeType() {
+        return LLVMFunctionDescriptor.LLVMRuntimeType.FUNCTION_ADDRESS;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 29;
+        hash = 17 * hash + Arrays.hashCode(args);
+        hash = 17 * hash + (isVarArg ? 1231 : 1237);
+        hash = 17 * hash + ((type == null) ? 0 : type.hashCode());
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof FunctionType) {
+            FunctionType other = (FunctionType) obj;
+            return Arrays.equals(args, other.args) && isVarArg == other.isVarArg && Objects.equals(type, other.type);
+        }
+        return false;
+    }
+
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
 
@@ -123,10 +149,5 @@ public class FunctionType implements Type, ValueSymbol {
         sb.append(")");
 
         return sb.toString();
-    }
-
-    @Override
-    public LLVMFunctionDescriptor.LLVMRuntimeType getRuntimeType() {
-        return LLVMFunctionDescriptor.LLVMRuntimeType.FUNCTION_ADDRESS;
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/IntegerConstantType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/IntegerConstantType.java
@@ -29,6 +29,8 @@
  */
 package com.oracle.truffle.llvm.parser.base.model.types;
 
+import java.util.Objects;
+
 import com.oracle.truffle.llvm.parser.base.datalayout.DataLayoutConverter;
 
 public final class IntegerConstantType implements Type {
@@ -69,6 +71,23 @@ public final class IntegerConstantType implements Type {
     @Override
     public int getSize(DataLayoutConverter.DataSpecConverter targetDataLayout) {
         return type.getSize(targetDataLayout);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 13;
+        hash = 17 * hash + ((type == null) ? 0 : type.hashCode());
+        hash = 17 * hash + (int) (value ^ (value >>> 32));
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof IntegerConstantType) {
+            IntegerConstantType other = (IntegerConstantType) obj;
+            return Objects.equals(type, other.type) && Objects.equals(value, other.value);
+        }
+        return false;
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/IntegerType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/IntegerType.java
@@ -113,25 +113,8 @@ public final class IntegerType implements Type {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        return obj instanceof IntegerType && bits == ((IntegerType) obj).bits;
-    }
-
-    @Override
     public int getBits() {
         return bits;
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = 7;
-        hash = 71 * hash + this.bits;
-        return hash;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("i%d", bits);
     }
 
     @Override
@@ -156,5 +139,22 @@ public final class IntegerType implements Type {
     @Override
     public int getSize(DataLayoutConverter.DataSpecConverter targetDataLayout) {
         return Math.max(1, bits / Byte.SIZE);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 71 * hash + this.bits;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof IntegerType && bits == ((IntegerType) obj).bits;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("i%d", bits);
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/MetadataConstantPointerType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/MetadataConstantPointerType.java
@@ -46,6 +46,21 @@ public class MetadataConstantPointerType implements Type {
     }
 
     @Override
+    public int hashCode() {
+        int hash = 19;
+        hash = 37 * hash + symbolIndex;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof MetadataConstantPointerType) {
+            return symbolIndex == ((MetadataConstantPointerType) obj).symbolIndex;
+        }
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "!!" + symbolIndex;
     }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/MetadataConstantType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/MetadataConstantType.java
@@ -52,6 +52,21 @@ public class MetadataConstantType implements Type {
     }
 
     @Override
+    public int hashCode() {
+        int hash = 13;
+        hash = 47 * hash + (int) (value ^ (value >>> 32));
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof MetadataConstantType) {
+            return value == ((MetadataConstantType) obj).value;
+        }
+        return false;
+    }
+
+    @Override
     public String toString() {
         return String.format("%s %d", getType(), value);
     }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/PointerType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/PointerType.java
@@ -45,14 +45,6 @@ public final class PointerType implements Type {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof PointerType) {
-            return type.equals(((PointerType) obj).type);
-        }
-        return false;
-    }
-
-    @Override
     public LLVMBaseType getLLVMBaseType() {
         // if the pointeetype is also a pointer it will not resolve to LLVMBaseType.ADDRESS but to
         // its own pointeetype's LLVMBaseType, so we cannot just use type.getLLVMBaseType() but
@@ -62,11 +54,6 @@ public final class PointerType implements Type {
         } else {
             return LLVMBaseType.ADDRESS;
         }
-    }
-
-    @Override
-    public int hashCode() {
-        return type.hashCode();
     }
 
     public Type getPointeeType() {
@@ -80,11 +67,6 @@ public final class PointerType implements Type {
     @Override
     public int getBits() {
         return Long.BYTES * Byte.SIZE;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("%s*", type);
     }
 
     @Override
@@ -139,5 +121,23 @@ public final class PointerType implements Type {
             default:
                 return LLVMFunctionDescriptor.LLVMRuntimeType.ADDRESS;
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return type.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof PointerType) {
+            return type.equals(((PointerType) obj).type);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s*", type);
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/StructureType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/StructureType.java
@@ -178,15 +178,6 @@ public final class StructureType implements AggregateType, ValueSymbol {
     }
 
     @Override
-    public String toString() {
-        if (name.equals(ValueSymbol.UNKNOWN)) {
-            return toDeclarationString();
-        } else {
-            return "%" + name;
-        }
-    }
-
-    @Override
     public void setMetadataReference(MetadataReference metadata) {
         this.metadata = metadata;
     }
@@ -194,5 +185,31 @@ public final class StructureType implements AggregateType, ValueSymbol {
     @Override
     public MetadataReference getMetadataReference() {
         return metadata;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 11;
+        hash = 23 * hash + (isPacked ? 1231 : 1237);
+        hash = 23 * hash + Arrays.hashCode(types);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof StructureType) {
+            StructureType other = (StructureType) obj;
+            return isPacked == other.isPacked && Arrays.equals(types, other.types);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        if (name.equals(ValueSymbol.UNKNOWN)) {
+            return toDeclarationString();
+        } else {
+            return "%" + name;
+        }
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/StructureType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/StructureType.java
@@ -37,6 +37,7 @@ import com.oracle.truffle.llvm.parser.base.model.symbols.ValueSymbol;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public final class StructureType implements AggregateType, ValueSymbol {
 
@@ -199,7 +200,16 @@ public final class StructureType implements AggregateType, ValueSymbol {
     public boolean equals(Object obj) {
         if (obj instanceof StructureType) {
             StructureType other = (StructureType) obj;
-            return isPacked == other.isPacked && Arrays.equals(types, other.types);
+            if (!Objects.equals(name, other.name)) {
+                return false;
+            }
+            if (isPacked != other.isPacked) {
+                return false;
+            }
+            if (!Arrays.equals(types, other.types)) {
+                return false;
+            }
+            return true;
         }
         return false;
     }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/VectorType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/VectorType.java
@@ -51,15 +51,6 @@ public class VectorType implements AggregateType {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof VectorType) {
-            VectorType other = (VectorType) obj;
-            return length == other.length && elementType.equals(other.getElementType());
-        }
-        return false;
-    }
-
-    @Override
     public int getBits() {
         return elementType.getBits() * length;
     }
@@ -139,6 +130,16 @@ public class VectorType implements AggregateType {
     }
 
     @Override
+    public void setMetadataReference(MetadataReference metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public MetadataReference getMetadataReference() {
+        return metadata;
+    }
+
+    @Override
     public int hashCode() {
         int hash = 5;
         hash = 59 * hash + Objects.hashCode(this.elementType);
@@ -147,17 +148,16 @@ public class VectorType implements AggregateType {
     }
 
     @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof VectorType) {
+            VectorType other = (VectorType) obj;
+            return length == other.length && elementType.equals(other.getElementType());
+        }
+        return false;
+    }
+
+    @Override
     public String toString() {
         return String.format("<%d x %s>", getLength(), getElementType());
-    }
-
-    @Override
-    public void setMetadataReference(MetadataReference metadata) {
-        this.metadata = metadata;
-    }
-
-    @Override
-    public MetadataReference getMetadataReference() {
-        return metadata;
     }
 }


### PR DESCRIPTION
* add ```hashCode``` and ```equals``` implementation
* fix a little issue from 8f3d022560e4ed5348724236f1f45db6540f7a66 regarding name handling
* unify location of ```hashCode```, ```equals``` and ```toString``` so they are always located at the bottom of the Type classes