### PR TITLE
Add support for idivl instruction to return struct inline assembly 

### DIFF
--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
@@ -81,7 +81,7 @@ MulOperation<> =						(.String op; String left = null, right = null;.)
   |
   (Immediate<out left> "," Register<out right>)
   )";"									(.	if (right == null) {
-												factory.addFrameSlot("%eax", this.retType);
+												factory.addFrameSlot("%eax", LLVMBaseType.I32);
 											}
 											factory.createBinaryOperation(op, left, right);.)
   .
@@ -89,8 +89,8 @@ MulOperation<> =						(.String op; String left = null, right = null;.)
 DivOperation<> =						(.String op; String left = null;.)
   DivOp<out op>
   ((Register<out left> ["," "%eax"])
-  )";"									(.	factory.addFrameSlot("%eax", this.retType);
-											factory.addFrameSlot("%edx", this.retType);
+  )";"									(.	factory.addFrameSlot("%eax", LLVMBaseType.I32);
+											factory.addFrameSlot("%edx", LLVMBaseType.I32);
 											factory.createDivisionOperatoin(op, left);
 										.)
   .
@@ -173,7 +173,7 @@ Register<out String reg> =
   | "%ebp"
   | "%esi"
   | "%edi"
-  )										(.reg = t.val; factory.addFrameSlot(reg, this.retType);.)
+  )										(.reg = t.val; factory.addFrameSlot(reg, LLVMBaseType.I32);.)
   .
 
 Immediate<out String n> =				(.n = null;.)

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/Parser.frame
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/Parser.frame
@@ -43,14 +43,12 @@ public class Parser {
 	public final Errors errors;
 	private final AsmFactory factory;
 	private LLVMInlineAssemblyRootNode root;
-	private LLVMBaseType retType;
 	-->declarations
 
 	public Parser(String asmSnippet, String asmFlags, @SuppressWarnings("unused") LLVMExpressionNode[] args, LLVMBaseType retType) {
 		this.scanner = new Scanner(new ByteArrayInputStream(asmSnippet.getBytes()));
 		errors = new Errors();
-		this.factory = new AsmFactory(asmFlags);
-		this.retType = retType;
+		this.factory = new AsmFactory(asmFlags, retType);
 	}
 
 	void SynErr (int n) {

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
@@ -56,6 +56,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMArgNodeFactory.LLVMI32ArgNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMInlineAssemblyRootNode;
+import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode;
 import com.oracle.truffle.llvm.nodes.impl.others.LLVMUnsupportedInlineAssemblerNode.LLVMI32UnsupportedInlineAssemblerNode;
 import com.oracle.truffle.llvm.nodes.impl.vars.LLVMReadNodeFactory.LLVMI32ReadNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.vars.LLVMWriteNodeFactory.LLVMWriteI32NodeGen;
@@ -72,18 +73,26 @@ public class AsmFactory {
     private List<String> registers;
     private LLVMExpressionNode result;
     private String asmFlags;
+    private LLVMBaseType retType;
 
-    public AsmFactory(String asmFlags) {
+    public AsmFactory(String asmFlags, LLVMBaseType retType) {
         this.asmFlags = asmFlags;
         this.frameDescriptor = new FrameDescriptor();
         this.statements = new ArrayList<>();
         this.arguments = new ArrayList<>();
         this.registers = new ArrayList<>();
         this.registers.add("-");
+        this.retType = retType;
     }
 
     public LLVMInlineAssemblyRootNode finishInline() {
         getArguments();
+        switch (retType) {
+            case I32:
+                break;
+            default:
+                result = new LLVMUnsupportedInlineAssemblerNode();
+        }
         return new LLVMInlineAssemblyRootNode(null, frameDescriptor, statements.toArray(new LLVMNode[statements.size()]), arguments, result);
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64IdivlNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64IdivlNode.java
@@ -39,8 +39,8 @@ public abstract class LLVMAMD64IdivlNode extends LLVMI32Node {
 
     @Specialization
     public int executeI32(int left, int rightAX, int rightDX) {
-        long divident = (long) rightDX << LLVMI32Node.BYTE_SIZE * Byte.SIZE;
-        divident = divident | rightAX;
-        return (int) (divident / left);
+        long dividend = (long) rightDX << LLVMI32Node.BYTE_SIZE * Byte.SIZE;
+        dividend = dividend | rightAX;
+        return (int) (dividend / left);
     }
 }

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64ModNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64ModNode.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.asm;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI32Node;
+
+@NodeChildren({@NodeChild("left"), @NodeChild("rightAX"), @NodeChild("rightDX")})
+public abstract class LLVMAMD64ModNode extends LLVMI32Node {
+
+    @Specialization
+    public int executeI32(int left, int rightAX, int rightDX) {
+        long divident = (long) rightDX << LLVMI32Node.BYTE_SIZE * Byte.SIZE;
+        divident = divident | rightAX;
+        return (int) (divident % left);
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64ModNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64ModNode.java
@@ -39,8 +39,8 @@ public abstract class LLVMAMD64ModNode extends LLVMI32Node {
 
     @Specialization
     public int executeI32(int left, int rightAX, int rightDX) {
-        long divident = (long) rightDX << LLVMI32Node.BYTE_SIZE * Byte.SIZE;
-        divident = divident | rightAX;
-        return (int) (divident % left);
+        long dividend = (long) rightDX << LLVMI32Node.BYTE_SIZE * Byte.SIZE;
+        dividend = dividend | rightAX;
+        return (int) (dividend % left);
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMNodeGenerator.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMNodeGenerator.java
@@ -211,6 +211,8 @@ public final class LLVMNodeGenerator {
                 return new LLVMUnsupportedInlineAssemblerNode.LLVMAddressUnsupportedInlineAssemblerNode();
             case FUNCTION_ADDRESS:
                 return new LLVMUnsupportedInlineAssemblerNode.LLVMFunctionUnsupportedInlineAssemblerNode();
+            case STRUCT:
+                return LLVMCallUnboxNodeFactory.LLVMStructCallUnboxNodeGen.create(new LLVMCallNode.LLVMResolvedDirectCallNode(callTarget, argNodes));
             default:
                 throw new AssertionError("Unknown Inline Assembly Return Type!");
         }

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -68,6 +68,7 @@ import com.oracle.truffle.llvm.nodes.impl.base.vector.LLVMVectorNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallNode.LLVMResolvedDirectCallNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVMI32CallUnboxNodeGen;
+import com.oracle.truffle.llvm.nodes.impl.func.LLVMCallUnboxNodeFactory.LLVMStructCallUnboxNodeGen;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMFunctionStartNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMGlobalRootNode;
 import com.oracle.truffle.llvm.nodes.impl.func.LLVMInlineAssemblyRootNode;
@@ -412,6 +413,8 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
                 return new LLVMAddressUnsupportedInlineAssemblerNode();
             case FUNCTION_ADDRESS:
                 return new LLVMFunctionUnsupportedInlineAssemblerNode();
+            case STRUCT:
+                return LLVMStructCallUnboxNodeGen.create(new LLVMResolvedDirectCallNode(target, args));
             default:
                 throw new AssertionError(retType);
         }


### PR DESCRIPTION
When multiple values/registers are returned from inline assembly then the inline assembly (represented as a function call) returns a struct combining necessary values. These values are extracted by the 'extractvalue' instructions in LLVM IR followed by the call to inline assembly.
Apart from support for struct return type this commit includes,
- Updates to parser, making type as `I32` explicitly for 32 bit registers. Previously it was using same value from return type which is now struct.
- Refactoring processing of inline assembly by bitcode parser. Now using same function as that of textual parser (`createInlineAssemblerExpression` function) to process inline assembly.

Please suggest,
- idivl is calculating 32 bit quotient and 32 bit remainder separately. Is it fine to calculate them by a single function (division) and writing 8 bytes from the start address of returned structure or relying on widths would be prone to error?