### PR TITLE
Support the Binary Parser in the Lifetime Testsuite

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/blocks/InstructionBlock.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/blocks/InstructionBlock.java
@@ -257,7 +257,21 @@ public final class InstructionBlock implements InstructionGenerator, ValueSymbol
 
     @Override
     public void setName(String name) {
-        this.name = "%" + name;
+        // we align the naming to the textparser to make lifetime analysis tests work
+        if (isNumber(name)) {
+            this.name = String.format("%%\"%s\"", name);
+        } else {
+            this.name = String.format("%%%s", name);
+        }
+    }
+
+    private static boolean isNumber(String str) {
+        for (char c : str.toCharArray()) {
+            if (!Character.isDigit(c)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
@@ -94,7 +94,6 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
         for (int i = 0; i < count; i++) {
             blocks[i] = new InstructionBlock(this, i);
         }
-        blocks[0].setName("0");
     }
 
     @Override
@@ -106,13 +105,12 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
 
     @Override
     public void exitFunction() {
-        int valueSymbolIdentifier = 0;
-        int blockIdentifier = 1; // Zero clashes with entry block in sulong
+        int symbolIndex = 0;
 
         // in K&R style function declarations the parameters are not assigned names
         for (final FunctionParameter parameter : parameters) {
             if (ValueSymbol.UNKNOWN.equals(parameter.getName())) {
-                parameter.setName(String.valueOf(valueSymbolIdentifier++));
+                parameter.setName(String.valueOf(symbolIndex++));
             }
         }
 
@@ -120,14 +118,14 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
             if (block.getName().equals(ValueSymbol.UNKNOWN)) {
                 // compilers like to assign numbers as blocknames, we name unnamed blocks this way
                 // to prevent name clashes
-                block.setName(String.format("%s\"%d\"", ValueSymbol.UNKNOWN, blockIdentifier++));
+                block.setName(String.format("%s\"%d\"", ValueSymbol.UNKNOWN, symbolIndex++));
             }
             for (int i = 0; i < block.getInstructionCount(); i++) {
                 final Instruction instruction = block.getInstruction(i);
                 if (instruction instanceof ValueInstruction) {
                     final ValueInstruction value = (ValueInstruction) instruction;
                     if (value.getName().equals(ValueSymbol.UNKNOWN)) {
-                        value.setName(String.valueOf(valueSymbolIdentifier++));
+                        value.setName(String.valueOf(symbolIndex++));
                     }
                 }
             }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
@@ -116,8 +116,6 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
 
         for (final InstructionBlock block : blocks) {
             if (block.getName().equals(ValueSymbol.UNKNOWN)) {
-                // compilers like to assign numbers as blocknames, we name unnamed blocks this way
-                // to prevent name clashes
                 block.setName(String.valueOf(symbolIndex++));
             }
             for (int i = 0; i < block.getInstructionCount(); i++) {

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
@@ -118,7 +118,7 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
             if (block.getName().equals(ValueSymbol.UNKNOWN)) {
                 // compilers like to assign numbers as blocknames, we name unnamed blocks this way
                 // to prevent name clashes
-                block.setName(String.format("%s\"%d\"", ValueSymbol.UNKNOWN, symbolIndex++));
+                block.setName(String.valueOf(symbolIndex++));
             }
             for (int i = 0; i < block.getInstructionCount(); i++) {
                 final Instruction instruction = block.getInstruction(i);

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/functions/FunctionDefinition.java
@@ -33,6 +33,8 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.Objects;
 
 import com.oracle.truffle.llvm.parser.base.model.blocks.InstructionBlock;
@@ -114,9 +116,13 @@ public final class FunctionDefinition extends FunctionType implements Constant, 
             }
         }
 
+        final Set<String> explicitBlockNames = Arrays.stream(blocks).map(InstructionBlock::getName).filter(blockName -> !ValueSymbol.UNKNOWN.equals(blockName)).collect(Collectors.toSet());
         for (final InstructionBlock block : blocks) {
             if (block.getName().equals(ValueSymbol.UNKNOWN)) {
-                block.setName(String.valueOf(symbolIndex++));
+                do {
+                    block.setName(String.valueOf(symbolIndex++));
+                    // avoid name clashes
+                } while (explicitBlockNames.contains(block.getName()));
             }
             for (int i = 0; i < block.getInstructionCount(); i++) {
                 final Instruction instruction = block.getInstruction(i);

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/parser/bc/Parser.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/parser/bc/Parser.java
@@ -111,7 +111,7 @@ public class Parser {
                     UNABBREV_RECORD
     };
 
-    private static final String CHAR6 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXJZ0123456789._";
+    private static final String CHAR6 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._";
 
     protected final Bitstream stream;
 

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/parser/listeners/ValueSymbolTable.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/parser/listeners/ValueSymbolTable.java
@@ -47,15 +47,18 @@ public final class ValueSymbolTable implements ParserListener {
 
         switch (record) {
             case ENTRY:
-                generator.nameEntry((int) args[0], Records.toString(args, 1));
+                final String entryName = Records.toString(args, 1);
+                generator.nameEntry((int) args[0], entryName);
                 break;
 
             case BASIC_BLOCK_ENTRY:
-                generator.nameBlock((int) args[0], Records.toString(args, 1));
+                final String blockName = Records.toString(args, 1);
+                generator.nameBlock((int) args[0], blockName);
                 break;
 
             case FUNCTION_ENTRY:
-                generator.nameFunction((int) args[0], (int) args[1], Records.toString(args, 2));
+                final String functionName = Records.toString(args, 2);
+                generator.nameFunction((int) args[0], (int) args[1], functionName);
                 break;
 
             default:

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestHelper.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestHelper.java
@@ -129,7 +129,7 @@ public class TestHelper {
     public static TestCaseFiles compileLLVMIRToLLVMBC(TestCaseFiles caseFile) {
         File llvmBinaryCodeFile = TestHelper.getTempBCFile(caseFile.getBitCodeFile());
         LLVMAssembler.assembleToBitcodeFile(caseFile.getBitCodeFile(), llvmBinaryCodeFile);
-        return TestCaseFiles.createFromCompiledFile(caseFile.getBitCodeFile(), llvmBinaryCodeFile, caseFile.getExpectedResult(), caseFile.getFlags());
+        return TestCaseFiles.createFromCompiledFile(caseFile.getOriginalFile(), llvmBinaryCodeFile, caseFile.getExpectedResult(), caseFile.getFlags());
     }
 
     public static File getTempLLFile(File toBeCompiled, String optionName) {

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestLifetimeAnalysisGCC.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/TestLifetimeAnalysisGCC.java
@@ -86,7 +86,8 @@ public class TestLifetimeAnalysisGCC extends TestSuiteBase {
 
     // TODO in the long term we should replace this
     private static final String[] excludedFiles = new String[]{
-                    "projects/com.oracle.truffle.llvm.test/suites/gcc/gcc-5.2.0/gcc/testsuite/gcc.dg/pr43419.c"
+                    "projects/com.oracle.truffle.llvm.test/suites/gcc/gcc-5.2.0/gcc/testsuite/gcc.dg/pr43419.c",
+                    "projects/com.oracle.truffle.llvm.test/suites/gcc/gcc-5.2.0/gcc/testsuite/gfortran.fortran-torture/execute/integer_select.f90"
     };
 
     private static final String FUNCTION_INDENT = "";


### PR DESCRIPTION
This PR makes the Datastructures produced by both parsers comparable.

The reference output for the single test we excluded as part of this PR includes two basic blocks named %18 and %"18" as part of the same function block. This is an illegal situation since both names should be equivalent. This hints to either an error in the Textparser or a bug in Dragonegg.