### PR TITLE
Remove left-over JRuby dependencies in the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ addons:
     - clang-format-3.4
     - gobjc++-4.6
     - gcc-4.6-plugin-dev
-    - libxml2-dev
-    - libssl-dev
 install:
   - export MX_BINARY_SUITES="jvmci"
   - gem install mdl


### PR DESCRIPTION
The JRuby+Truffle gate was removed in `d30ec937b3519cc824d433a2b9c8322b8db555e6`.