### PR TITLE
Extend usage of LLVMParserRuntime

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/datalayout/DataLayoutConverter.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/datalayout/DataLayoutConverter.java
@@ -52,10 +52,6 @@ public class DataLayoutConverter {
             }
         }
 
-        public int getBitSize(LLVMBaseType baseType) {
-            return getDataTypeSpecification(baseType).getValues()[0];
-        }
-
         DataLayoutParser.DataTypeSpecification getDataTypeSpecification(LLVMBaseType baseType) {
             // Checkstyle: stop magic number name check
             switch (baseType) {
@@ -99,10 +95,6 @@ public class DataLayoutConverter {
                 }
             }
             throw new AssertionError(dataLayoutType + " " + Arrays.toString(values));
-        }
-
-        public int getByteSize(LLVMBaseType baseType) {
-            return getBitSize(baseType) / Byte.SIZE;
         }
 
     }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
@@ -76,12 +76,6 @@ public interface NodeFactoryFacade {
     // also update {@link NodeFactoryFacadeComposite} when changing or removing this name
     void setUpFacade(LLVMParserRuntime runtime);
 
-    /**
-     * Get Parser runtime (a temporary required method until we use the new Bitcode Type exclusive).
-     *
-     * @return runtime
-     */
-    @Deprecated
     LLVMParserRuntime getRuntime();
 
     LLVMExpressionNode createInsertElement(LLVMBaseType resultType, LLVMExpressionNode vector, Object type, LLVMExpressionNode element, LLVMExpressionNode index);

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
@@ -71,9 +71,7 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     public void setUpFacade(LLVMParserRuntime runtime) {
     }
 
-    @SuppressWarnings("deprecation")
     @Override
-    @Deprecated
     public LLVMParserRuntime getRuntime() {
         return null;
     }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/util/LLVMBitcodeTypeHelper.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/util/LLVMBitcodeTypeHelper.java
@@ -33,18 +33,11 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMArithmeticInstructionType
 import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionType;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor;
-import com.oracle.truffle.llvm.parser.base.datalayout.DataLayoutConverter;
 import com.oracle.truffle.llvm.parser.base.model.enums.BinaryOperator;
 import com.oracle.truffle.llvm.parser.base.model.enums.CastOperator;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 
 public class LLVMBitcodeTypeHelper {
-
-    private final DataLayoutConverter.DataSpecConverter targetDataLayout;
-
-    public LLVMBitcodeTypeHelper(DataLayoutConverter.DataSpecConverter targetDataLayout) {
-        this.targetDataLayout = targetDataLayout;
-    }
 
     public static LLVMArithmeticInstructionType toArithmeticInstructionType(BinaryOperator operator) {
         switch (operator) {
@@ -122,10 +115,6 @@ public class LLVMBitcodeTypeHelper {
             llvmtypes[i] = types[i].getType().getRuntimeType();
         }
         return llvmtypes;
-    }
-
-    public DataLayoutConverter.DataSpecConverter getTargetDataLayout() {
-        return targetDataLayout;
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/util/LLVMParserRuntime.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/util/LLVMParserRuntime.java
@@ -75,6 +75,8 @@ public interface LLVMParserRuntime {
 
     int getBitAlignment(LLVMBaseType type);
 
+    int getByteAlignment(Type type);
+
     int getByteSize(Type type);
 
     FrameDescriptor getGlobalFrameDescriptor();

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/util/LLVMParserRuntime.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/util/LLVMParserRuntime.java
@@ -79,6 +79,10 @@ public interface LLVMParserRuntime {
 
     int getByteSize(Type type);
 
+    int getBytePadding(int offset, Type type);
+
+    int getIndexOffset(int index, Type type);
+
     FrameDescriptor getGlobalFrameDescriptor();
 
     /**
@@ -89,8 +93,6 @@ public interface LLVMParserRuntime {
     void addDestructor(LLVMNode destructorNode);
 
     long getNativeHandle(String name);
-
-    LLVMTypeHelper getTypeHelper();
 
     Map<String, Type> getVariableNameTypesMapping();
 

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/util/LLVMTypeHelper.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/util/LLVMTypeHelper.java
@@ -63,10 +63,6 @@ public class LLVMTypeHelper {
         this.runtime = runtime;
     }
 
-    public int getByteSize(Type type) {
-        return getByteSize(LLVMToBitcodeAdapter.unresolveType(type));
-    }
-
     public int getByteSize(ResolvedType type) {
         int bits = type.getBits().intValue();
         if (type instanceof ResolvedIntegerType || type instanceof ResolvedFloatingType) {
@@ -287,10 +283,6 @@ public class LLVMTypeHelper {
         return ((ResolvedStructType) currentType).isPacked();
     }
 
-    public int computePaddingByte(int currentOffset, Type type) {
-        return computePaddingByte(currentOffset, LLVMToBitcodeAdapter.unresolveType(type));
-    }
-
     public int computePaddingByte(int currentOffset, ResolvedType type) {
         int alignmentByte = getAlignmentByte(type);
         if (alignmentByte == 0) {
@@ -302,10 +294,6 @@ public class LLVMTypeHelper {
 
     interface LayoutConverter {
         int getBitAlignment(LLVMBaseType type);
-    }
-
-    public int getAlignmentByte(Type field) {
-        return getAlignmentByte(LLVMToBitcodeAdapter.unresolveType(field));
     }
 
     public int getAlignmentByte(ResolvedType field) {

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/util/LLVMTypeHelper.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/util/LLVMTypeHelper.java
@@ -306,8 +306,4 @@ public class LLVMTypeHelper {
         }
     }
 
-    public static boolean isCompoundType(LLVMBaseType type) {
-        return type == LLVMBaseType.ARRAY || type == LLVMBaseType.STRUCT || isVectorType(type);
-    }
-
 }

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeFunctionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeFunctionVisitor.java
@@ -41,7 +41,6 @@ import com.oracle.truffle.llvm.nodes.base.LLVMNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMBasicBlockNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMContext;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMTerminatorNode;
-import com.oracle.truffle.llvm.parser.base.datalayout.DataLayoutConverter;
 import com.oracle.truffle.llvm.parser.base.facade.NodeFactoryFacade;
 import com.oracle.truffle.llvm.parser.bc.impl.LLVMPhiManager.Phi;
 import com.oracle.truffle.llvm.parser.bc.impl.nodes.LLVMNodeGenerator;
@@ -80,10 +79,6 @@ public class LLVMBitcodeFunctionVisitor implements FunctionVisitor {
         this.symbolResolver = new LLVMNodeGenerator(this);
         this.factoryFacade = factoryFacade;
         this.argCount = argCount;
-    }
-
-    public DataLayoutConverter.DataSpecConverter getTargetDataLayout() {
-        return module.getTargetDataLayout();
     }
 
     public void addInstruction(LLVMNode node) {

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeInstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeInstructionVisitor.java
@@ -98,8 +98,6 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
 
     private final LLVMNodeGenerator symbols;
 
-    private final LLVMBitcodeTypeHelper typeHelper;
-
     private final NodeFactoryFacade factoryFacade;
 
     private final LLVMParserRuntime runtime;
@@ -108,7 +106,6 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
         this.method = method;
         this.block = block;
         this.symbols = method.getSymbolResolver();
-        this.typeHelper = method.getModule().getTypeHelper();
         this.factoryFacade = factoryFacade;
         this.runtime = method.getModule().getParserRuntime();
     }
@@ -326,11 +323,11 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
 
         final AggregateType aggregateType = (AggregateType) baseType;
 
-        int offset = aggregateType.getIndexOffset(targetIndex, typeHelper.getTargetDataLayout());
+        int offset = runtime.getIndexOffset(targetIndex, aggregateType);
 
         final Type targetType = aggregateType.getElementType(targetIndex);
         if (targetType != null && !((targetType instanceof StructureType) && (((StructureType) targetType).isPacked()))) {
-            offset += Type.getPadding(offset, targetType, typeHelper.getTargetDataLayout());
+            offset += runtime.getBytePadding(offset, targetType);
         }
 
         if (offset != 0) {
@@ -386,7 +383,7 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
 
         final LLVMExpressionNode resultAggregate = factoryFacade.createAlloc(sourceType, size, alignment, null, null);
 
-        final int offset = sourceType.getIndexOffset(targetIndex, typeHelper.getTargetDataLayout());
+        final int offset = runtime.getIndexOffset(targetIndex, sourceType);
         final LLVMExpressionNode result = factoryFacade.createInsertValue(resultAggregate, sourceAggregate,
                         runtime.getByteSize(sourceType), offset, valueToInsert, valueType);
 

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeInstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeInstructionVisitor.java
@@ -42,6 +42,7 @@ import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.bc.impl.LLVMPhiManager.Phi;
 import com.oracle.truffle.llvm.parser.bc.impl.nodes.LLVMNodeGenerator;
 import com.oracle.truffle.llvm.parser.base.util.LLVMBitcodeTypeHelper;
+import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.bc.impl.util.LLVMFrameIDs;
 import com.oracle.truffle.llvm.parser.instructions.LLVMArithmeticInstructionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
@@ -101,12 +102,15 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
 
     private final NodeFactoryFacade factoryFacade;
 
+    private final LLVMParserRuntime runtime;
+
     public LLVMBitcodeInstructionVisitor(LLVMBitcodeFunctionVisitor method, InstructionBlock block, NodeFactoryFacade factoryFacade) {
         this.method = method;
         this.block = block;
         this.symbols = method.getSymbolResolver();
         this.typeHelper = method.getModule().getTypeHelper();
         this.factoryFacade = factoryFacade;
+        this.runtime = method.getModule().getParserRuntime();
     }
 
     private LLVMNode[] getPhiWriteNodes() {
@@ -129,7 +133,7 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
         final Type type = allocate.getPointeeType();
         int alignment = 0;
         if (allocate.getAlign() == 0) {
-            alignment = type.getAlignment(method.getTargetDataLayout());
+            alignment = runtime.getByteAlignment(type);
         } else {
             alignment = 1 << (allocate.getAlign() - 1);
         }
@@ -137,7 +141,7 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
             alignment = LLVMStack.NO_ALIGNMENT_REQUIREMENTS;
         }
 
-        final int size = type.getSize(typeHelper.getTargetDataLayout());
+        final int size = runtime.getByteSize(type);
         final Symbol count = allocate.getCount();
         final LLVMExpressionNode result;
         if (count instanceof NullConstant) {
@@ -160,8 +164,8 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
         LLVMExpressionNode target = null;
         if (operation.getType() instanceof VectorType) {
             Type operationType = operation.getType();
-            final int size = operationType.getSize(typeHelper.getTargetDataLayout());
-            final int alignment = operationType.getAlignment(method.getTargetDataLayout());
+            final int size = runtime.getByteSize(operationType);
+            final int alignment = runtime.getByteAlignment(operationType);
             target = factoryFacade.createAlloc(operationType, size, alignment, null, null);
         }
 
@@ -198,8 +202,8 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
         int argIndex = 0;
         argNodes[argIndex++] = factoryFacade.createFrameRead(LLVMBaseType.ADDRESS, method.getStackSlot());
         if (targetType instanceof StructureType) {
-            final int size = targetType.getSize(typeHelper.getTargetDataLayout());
-            final int align = targetType.getAlignment(method.getTargetDataLayout());
+            final int size = runtime.getByteSize(targetType);
+            final int align = runtime.getByteAlignment(targetType);
             argNodes[argIndex++] = factoryFacade.createAlloc(targetType, size, align, null, null);
         }
         for (int i = 0; argIndex < argumentCount; i++, argIndex++) {
@@ -245,8 +249,8 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
 
         if (compare.getType() instanceof VectorType) {
             Type type = compare.getType();
-            final int size = type.getSize(typeHelper.getTargetDataLayout());
-            final int alignment = type.getAlignment(method.getTargetDataLayout());
+            final int size = runtime.getByteSize(type);
+            final int alignment = runtime.getByteAlignment(type);
             LLVMAddressNode target = (LLVMAddressNode) factoryFacade.createAlloc(type, size, alignment, null, null);
 
             result = LLVMNodeGenerator.toCompareVectorNode(
@@ -377,14 +381,14 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
         final LLVMExpressionNode valueToInsert = symbols.resolve(insert.getValue());
         final LLVMBaseType valueType = insert.getValue().getType().getLLVMBaseType();
         final int targetIndex = insert.getIndex();
-        final int size = sourceType.getSize(method.getTargetDataLayout());
-        final int alignment = sourceType.getAlignment(method.getTargetDataLayout());
+        final int size = runtime.getByteSize(sourceType);
+        final int alignment = runtime.getByteAlignment(sourceType);
 
         final LLVMExpressionNode resultAggregate = factoryFacade.createAlloc(sourceType, size, alignment, null, null);
 
         final int offset = sourceType.getIndexOffset(targetIndex, typeHelper.getTargetDataLayout());
         final LLVMExpressionNode result = factoryFacade.createInsertValue(resultAggregate, sourceAggregate,
-                        sourceType.getSize(method.getTargetDataLayout()), offset, valueToInsert, valueType);
+                        runtime.getByteSize(sourceType), offset, valueToInsert, valueType);
 
         createFrameWrite(result, insert);
     }
@@ -433,8 +437,8 @@ public final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
         final LLVMExpressionNode mask = symbols.resolve(shuffle.getMask());
 
         final Type type = shuffle.getType();
-        final int size = type.getSize(method.getTargetDataLayout());
-        final int alignment = type.getAlignment(method.getTargetDataLayout());
+        final int size = runtime.getByteSize(type);
+        final int alignment = runtime.getByteAlignment(type);
         final LLVMAddressNode destination = (LLVMAddressNode) factoryFacade.createAlloc(type, size, alignment, null, null);
 
         final LLVMExpressionNode result = factoryFacade.createShuffleVector(type.getLLVMBaseType(), destination, vector1, vector2, mask);

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
@@ -203,8 +203,6 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
 
     private final DataLayoutConverter.DataSpecConverter targetDataLayout;
 
-    private final LLVMBitcodeTypeHelper typeHelper;
-
     private final NodeFactoryFacade factoryFacade;
 
     private final LLVMBitcodeVisitorParserRuntime parserRuntime;
@@ -221,7 +219,6 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
         this.labels = labels;
         this.phis = phis;
         this.targetDataLayout = layout;
-        this.typeHelper = new LLVMBitcodeTypeHelper(targetDataLayout);
         this.factoryFacade = factoryFacade;
         this.parserRuntime = new LLVMBitcodeVisitorParserRuntime();
         this.factoryFacade.setUpFacade(this.parserRuntime);
@@ -347,10 +344,6 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
 
     public LLVMParserRuntime getParserRuntime() {
         return parserRuntime;
-    }
-
-    public LLVMBitcodeTypeHelper getTypeHelper() {
-        return typeHelper;
     }
 
     public LLVMNode[] getDeallocations() {

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
@@ -606,6 +606,11 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
         }
 
         @Override
+        public int getByteAlignment(Type type) {
+            return type.getAlignment(targetDataLayout);
+        }
+
+        @Override
         public int getByteSize(Type type) {
             return type.getSize(targetDataLayout);
         }

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
@@ -314,7 +314,7 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
             return null;
         }
 
-        LLVMExpressionNode constant = LLVMConstantGenerator.toConstantNode(global.getValue(), global.getAlign(), this::getGlobalVariable, context, stackSlot, labels, typeHelper);
+        LLVMExpressionNode constant = LLVMConstantGenerator.toConstantNode(global.getValue(), global.getAlign(), this::getGlobalVariable, context, stackSlot, labels, parserRuntime);
         if (constant != null) {
             final Type type = ((PointerType) global.getType()).getPointeeType();
             final LLVMBaseType baseType = type.getLLVMBaseType();
@@ -343,6 +343,10 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
 
     public DataLayoutConverter.DataSpecConverter getTargetDataLayout() {
         return targetDataLayout;
+    }
+
+    public LLVMParserRuntime getParserRuntime() {
+        return parserRuntime;
     }
 
     public LLVMBitcodeTypeHelper getTypeHelper() {
@@ -382,7 +386,7 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
             }
             return address;
         } else {
-            return LLVMConstantGenerator.toConstantNode(g, 0, this::getGlobalVariable, context, null, labels, typeHelper);
+            return LLVMConstantGenerator.toConstantNode(g, 0, this::getGlobalVariable, context, null, labels, parserRuntime);
         }
     }
 
@@ -616,6 +620,16 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
         }
 
         @Override
+        public int getBytePadding(int offset, Type type) {
+            return Type.getPadding(offset, type, targetDataLayout);
+        }
+
+        @Override
+        public int getIndexOffset(int index, Type type) {
+            return type.getIndexOffset(index, targetDataLayout);
+        }
+
+        @Override
         public FrameDescriptor getGlobalFrameDescriptor() {
             return stack.getRootFrame();
         }
@@ -628,11 +642,6 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
         @Override
         public long getNativeHandle(String name) {
             return nativeLookup.getNativeHandle(name);
-        }
-
-        @Override
-        public LLVMTypeHelper getTypeHelper() {
-            throw new UnsupportedOperationException("Not implemented!");
         }
 
         @Override

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
@@ -315,7 +315,7 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
         if (constant != null) {
             final Type type = ((PointerType) global.getType()).getPointeeType();
             final LLVMBaseType baseType = type.getLLVMBaseType();
-            final int size = type.getSize(targetDataLayout);
+            final int size = parserRuntime.getByteSize(type);
 
             final LLVMAddressNode globalVarAddress = (LLVMAddressNode) getGlobalVariable(global);
 
@@ -336,10 +336,6 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
 
     public LLVMContext getContext() {
         return context;
-    }
-
-    public DataLayoutConverter.DataSpecConverter getTargetDataLayout() {
-        return targetDataLayout;
     }
 
     public LLVMParserRuntime getParserRuntime() {
@@ -402,10 +398,10 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
         final int elemCount = arrayConstant.getElementCount();
 
         final StructureType elementType = (StructureType) arrayConstant.getType().getElementType();
-        final int structSize = elementType.getSize(targetDataLayout);
+        final int structSize = parserRuntime.getByteSize(elementType);
 
         final FunctionType functionType = (FunctionType) ((PointerType) elementType.getElementType(1)).getPointeeType();
-        final int indexedTypeLength = functionType.getAlignment(targetDataLayout);
+        final int indexedTypeLength = parserRuntime.getByteAlignment(functionType);
 
         final LLVMNode[] structors = new LLVMNode[elemCount];
         for (int i = 0; i < elemCount; i++) {
@@ -446,7 +442,7 @@ public class LLVMBitcodeVisitor implements ModelVisitor {
         // this case we assume memory has already been allocated elsewhere
         final boolean allocateMemory = !descriptor.isDeclared() && global.getValue() != null;
         if (allocateMemory) {
-            final int byteSize = ((PointerType) global.getType()).getPointeeType().getSize(targetDataLayout);
+            final int byteSize = parserRuntime.getByteSize(((PointerType) global.getType()).getPointeeType());
             final LLVMAddress nativeStorage = LLVMHeap.allocateMemory(byteSize);
             final LLVMAddressNode addressLiteralNode = new LLVMAddressLiteralNode(nativeStorage);
             deallocations.add(LLVMFreeFactory.create(addressLiteralNode));

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMConstantGenerator.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMConstantGenerator.java
@@ -54,6 +54,7 @@ import com.oracle.truffle.llvm.nodes.impl.vars.StructLiteralNode;
 import com.oracle.truffle.llvm.parser.LLVMBaseType;
 import com.oracle.truffle.llvm.parser.bc.impl.LLVMLabelList;
 import com.oracle.truffle.llvm.parser.base.util.LLVMBitcodeTypeHelper;
+import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.factories.LLVMCastsFactory;
 import com.oracle.truffle.llvm.parser.factories.LLVMGetElementPtrFactory;
 import com.oracle.truffle.llvm.parser.factories.LLVMLiteralFactory;
@@ -104,7 +105,7 @@ public final class LLVMConstantGenerator {
     }
 
     public static LLVMExpressionNode toConstantNode(Symbol value, int align, Function<GlobalValueSymbol, LLVMExpressionNode> variables, LLVMContext context, FrameSlot stackSlot, LLVMLabelList labels,
-                    LLVMBitcodeTypeHelper typeHelper) {
+                    LLVMParserRuntime runtime) {
         if (value instanceof GlobalValueSymbol) {
             return variables.apply((GlobalValueSymbol) value);
 
@@ -128,45 +129,45 @@ public final class LLVMConstantGenerator {
                 values.add(new LLVMSimpleLiteralNode.LLVMI8LiteralNode((byte) 0));
             }
 
-            final int size = IntegerType.BYTE.getSize(typeHelper.getTargetDataLayout()) * values.size();
+            final int size = runtime.getByteSize(IntegerType.BYTE) * values.size();
             final LLVMAllocInstruction.LLVMAllocaInstruction target = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(size, 1, context, stackSlot);
-            return LLVMStoreNodeFactory.LLVMI8ArrayLiteralNodeGen.create(values.toArray(new LLVMI8Node[values.size()]), IntegerType.BYTE.getSize(typeHelper.getTargetDataLayout()), target);
+            return LLVMStoreNodeFactory.LLVMI8ArrayLiteralNodeGen.create(values.toArray(new LLVMI8Node[values.size()]), runtime.getByteSize(IntegerType.BYTE), target);
 
         } else if (value instanceof ArrayConstant) {
-            return toArrayConstant((ArrayConstant) value, align, variables, context, stackSlot, labels, typeHelper);
+            return toArrayConstant((ArrayConstant) value, align, variables, context, stackSlot, labels, runtime);
 
         } else if (value instanceof StructureConstant) {
-            return toStructureConstant((StructureConstant) value, align, variables, context, stackSlot, labels, typeHelper);
+            return toStructureConstant((StructureConstant) value, align, variables, context, stackSlot, labels, runtime);
 
         } else if (value instanceof NullConstant) {
-            return LLVMConstantGenerator.toConstantZeroNode(value.getType(), context, stackSlot, typeHelper);
+            return LLVMConstantGenerator.toConstantZeroNode(value.getType(), context, stackSlot, runtime);
 
         } else if (value instanceof UndefinedConstant) {
-            return LLVMConstantGenerator.toConstantZeroNode(value.getType(), context, stackSlot, typeHelper);
+            return LLVMConstantGenerator.toConstantZeroNode(value.getType(), context, stackSlot, runtime);
 
         } else if (value instanceof BinaryOperationConstant) {
             final BinaryOperationConstant operation = (BinaryOperationConstant) value;
-            final LLVMExpressionNode lhs = toConstantNode(operation.getLHS(), align, variables, context, stackSlot, labels, typeHelper);
-            final LLVMExpressionNode rhs = toConstantNode(operation.getRHS(), align, variables, context, stackSlot, labels, typeHelper);
+            final LLVMExpressionNode lhs = toConstantNode(operation.getLHS(), align, variables, context, stackSlot, labels, runtime);
+            final LLVMExpressionNode rhs = toConstantNode(operation.getRHS(), align, variables, context, stackSlot, labels, runtime);
             final LLVMBaseType type = operation.getType().getLLVMBaseType();
             return LLVMNodeGenerator.generateBinaryOperatorNode(operation.getOperator(), type, lhs, rhs);
 
         } else if (value instanceof CastConstant) {
             final CastConstant cast = (CastConstant) value;
             final LLVMConversionType type = LLVMBitcodeTypeHelper.toConversionType(cast.getOperator());
-            final LLVMExpressionNode fromNode = toConstantNode(cast.getValue(), align, variables, context, stackSlot, labels, typeHelper);
+            final LLVMExpressionNode fromNode = toConstantNode(cast.getValue(), align, variables, context, stackSlot, labels, runtime);
             final LLVMBaseType from = cast.getValue().getType().getLLVMBaseType();
             final LLVMBaseType to = cast.getType().getLLVMBaseType();
             return LLVMCastsFactory.cast(fromNode, to, from, type);
 
         } else if (value instanceof CompareConstant) {
             final CompareConstant compare = (CompareConstant) value;
-            final LLVMExpressionNode lhs = toConstantNode(compare.getLHS(), align, variables, context, stackSlot, labels, typeHelper);
-            final LLVMExpressionNode rhs = toConstantNode(compare.getRHS(), align, variables, context, stackSlot, labels, typeHelper);
+            final LLVMExpressionNode lhs = toConstantNode(compare.getLHS(), align, variables, context, stackSlot, labels, runtime);
+            final LLVMExpressionNode rhs = toConstantNode(compare.getRHS(), align, variables, context, stackSlot, labels, runtime);
             return LLVMNodeGenerator.toCompareNode(compare.getOperator(), compare.getLHS().getType(), lhs, rhs);
 
         } else if (value instanceof GetElementPointerConstant) {
-            return toGetElementPointerConstant((GetElementPointerConstant) value, align, variables, context, stackSlot, labels, typeHelper);
+            return toGetElementPointerConstant((GetElementPointerConstant) value, align, variables, context, stackSlot, labels, runtime);
 
         } else if (value instanceof IntegerConstant) {
             final IntegerConstant constant = (IntegerConstant) value;
@@ -193,7 +194,7 @@ public final class LLVMConstantGenerator {
             return toBlockAddressConstant((BlockAddressConstant) value, labels);
 
         } else if (value instanceof VectorConstant) {
-            return toVectorConstant((VectorConstant) value, align, variables, context, stackSlot, labels, typeHelper);
+            return toVectorConstant((VectorConstant) value, align, variables, context, stackSlot, labels, runtime);
 
         } else {
             throw new UnsupportedOperationException("Unsupported Constant: " + value);
@@ -202,14 +203,14 @@ public final class LLVMConstantGenerator {
 
     private static LLVMExpressionNode toVectorConstant(VectorConstant constant, int align, Function<GlobalValueSymbol, LLVMExpressionNode> variables, LLVMContext context, FrameSlot stackSlot,
                     LLVMLabelList labels,
-                    LLVMBitcodeTypeHelper typeHelper) {
+                    LLVMParserRuntime runtime) {
         final List<LLVMExpressionNode> values = new ArrayList<>();
         for (int i = 0; i < constant.getLength(); i++) {
-            values.add(toConstantNode(constant.getElement(i), align, variables, context, stackSlot, labels, typeHelper));
+            values.add(toConstantNode(constant.getElement(i), align, variables, context, stackSlot, labels, runtime));
         }
 
-        final LLVMAddressNode target = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(constant.getType().getSize(typeHelper.getTargetDataLayout()),
-                        constant.getType().getAlignment(typeHelper.getTargetDataLayout()),
+        final LLVMAddressNode target = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(runtime.getByteSize(constant.getType()),
+                        runtime.getByteAlignment(constant.getType()),
                         context,
                         stackSlot);
 
@@ -217,52 +218,52 @@ public final class LLVMConstantGenerator {
     }
 
     private static LLVMExpressionNode toArrayConstant(ArrayConstant array, int align, Function<GlobalValueSymbol, LLVMExpressionNode> variables, LLVMContext context, FrameSlot stackSlot,
-                    LLVMLabelList labels, LLVMBitcodeTypeHelper typeHelper) {
+                    LLVMLabelList labels, LLVMParserRuntime runtime) {
         final Type elementType = array.getType().getElementType();
         final LLVMBaseType llvmElementType = elementType.getLLVMBaseType();
-        final int stride = elementType.getSize(typeHelper.getTargetDataLayout());
-        final LLVMAllocInstruction.LLVMAllocaInstruction allocation = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(array.getType().getSize(typeHelper.getTargetDataLayout()),
-                        array.getType().getAlignment(typeHelper.getTargetDataLayout()), context, stackSlot);
+        final int stride = runtime.getByteSize(elementType);
+        final LLVMAllocInstruction.LLVMAllocaInstruction allocation = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(runtime.getByteSize(array.getType()),
+                        runtime.getByteAlignment(array.getType()), context, stackSlot);
         switch (llvmElementType) {
             case I8: {
                 final LLVMI8Node[] elements = new LLVMI8Node[array.getElementCount()];
                 for (int i = 0; i < elements.length; i++) {
-                    elements[i] = (LLVMI8Node) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, typeHelper);
+                    elements[i] = (LLVMI8Node) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, runtime);
                 }
                 return LLVMStoreNodeFactory.LLVMI8ArrayLiteralNodeGen.create(elements, stride, allocation);
             }
             case I16: {
                 final LLVMI16Node[] elements = new LLVMI16Node[array.getElementCount()];
                 for (int i = 0; i < elements.length; i++) {
-                    elements[i] = (LLVMI16Node) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, typeHelper);
+                    elements[i] = (LLVMI16Node) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, runtime);
                 }
                 return LLVMStoreNodeFactory.LLVMI16ArrayLiteralNodeGen.create(elements, stride, allocation);
             }
             case I32: {
                 final LLVMI32Node[] elements = new LLVMI32Node[array.getElementCount()];
                 for (int i = 0; i < elements.length; i++) {
-                    elements[i] = (LLVMI32Node) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, typeHelper);
+                    elements[i] = (LLVMI32Node) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, runtime);
                 }
                 return LLVMStoreNodeFactory.LLVMI32ArrayLiteralNodeGen.create(elements, stride, allocation);
             }
             case I64: {
                 final LLVMI64Node[] elements = new LLVMI64Node[array.getElementCount()];
                 for (int i = 0; i < elements.length; i++) {
-                    elements[i] = (LLVMI64Node) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, typeHelper);
+                    elements[i] = (LLVMI64Node) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, runtime);
                 }
                 return LLVMStoreNodeFactory.LLVMI64ArrayLiteralNodeGen.create(elements, stride, allocation);
             }
             case FLOAT: {
                 final LLVMFloatNode[] elements = new LLVMFloatNode[array.getElementCount()];
                 for (int i = 0; i < elements.length; i++) {
-                    elements[i] = (LLVMFloatNode) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, typeHelper);
+                    elements[i] = (LLVMFloatNode) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, runtime);
                 }
                 return LLVMStoreNodeFactory.LLVMFloatArrayLiteralNodeGen.create(elements, stride, allocation);
             }
             case DOUBLE: {
                 final LLVMDoubleNode[] elements = new LLVMDoubleNode[array.getElementCount()];
                 for (int i = 0; i < elements.length; i++) {
-                    elements[i] = (LLVMDoubleNode) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, typeHelper);
+                    elements[i] = (LLVMDoubleNode) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, runtime);
                 }
                 return LLVMStoreNodeFactory.LLVMDoubleArrayLiteralNodeGen.create(elements, stride, allocation);
             }
@@ -270,21 +271,21 @@ public final class LLVMConstantGenerator {
             case STRUCT: {
                 final LLVMAddressNode[] elements = new LLVMAddressNode[array.getElementCount()];
                 for (int i = 0; i < elements.length; i++) {
-                    elements[i] = (LLVMAddressNode) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, typeHelper);
+                    elements[i] = (LLVMAddressNode) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, runtime);
                 }
                 return LLVMStoreNodeFactory.LLVMAddressArrayCopyNodeGen.create(elements, stride, allocation);
             }
             case ADDRESS: {
                 final LLVMAddressNode[] elements = new LLVMAddressNode[array.getElementCount()];
                 for (int i = 0; i < elements.length; i++) {
-                    elements[i] = (LLVMAddressNode) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, typeHelper);
+                    elements[i] = (LLVMAddressNode) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, runtime);
                 }
                 return LLVMStoreNodeFactory.LLVMAddressArrayLiteralNodeGen.create(elements, stride, allocation);
             }
             case FUNCTION_ADDRESS: {
                 final LLVMFunctionNode[] elements = new LLVMFunctionNode[array.getElementCount()];
                 for (int i = 0; i < elements.length; i++) {
-                    elements[i] = (LLVMFunctionNode) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, typeHelper);
+                    elements[i] = (LLVMFunctionNode) toConstantNode(array.getElement(i), align, variables, context, stackSlot, labels, runtime);
                 }
                 return LLVMStoreNodeFactory.LLVMFunctionArrayLiteralNodeGen.create(elements, stride, allocation);
             }
@@ -323,8 +324,8 @@ public final class LLVMConstantGenerator {
     }
 
     private static LLVMExpressionNode toGetElementPointerConstant(GetElementPointerConstant constant, int align, Function<GlobalValueSymbol, LLVMExpressionNode> variables, LLVMContext context,
-                    FrameSlot stackSlot, LLVMLabelList labels, LLVMBitcodeTypeHelper typeHelper) {
-        LLVMAddressNode currentAddress = (LLVMAddressNode) toConstantNode(constant.getBasePointer(), align, variables, context, stackSlot, labels, typeHelper);
+                    FrameSlot stackSlot, LLVMLabelList labels, LLVMParserRuntime runtime) {
+        LLVMAddressNode currentAddress = (LLVMAddressNode) toConstantNode(constant.getBasePointer(), align, variables, context, stackSlot, labels, runtime);
         Type currentType = constant.getBasePointer().getType();
         Type parentType = null;
         int currentOffset = 0;
@@ -335,13 +336,13 @@ public final class LLVMConstantGenerator {
                 throw new IllegalStateException("Invalid index: " + index);
             }
 
-            currentOffset += currentType.getIndexOffset(indexVal, typeHelper.getTargetDataLayout());
+            currentOffset += runtime.getIndexOffset(indexVal, currentType);
             parentType = currentType;
             currentType = currentType.getIndexType(indexVal);
         }
 
         if (currentType != null && !((parentType instanceof StructureType) && (((StructureType) parentType).isPacked()))) {
-            currentOffset += Type.getPadding(currentOffset, currentType, typeHelper.getTargetDataLayout());
+            currentOffset += runtime.getBytePadding(currentOffset, currentType);
         }
 
         if (currentOffset != 0) {
@@ -386,7 +387,7 @@ public final class LLVMConstantGenerator {
     }
 
     private static LLVMExpressionNode toStructureConstant(StructureConstant constant, int align, Function<GlobalValueSymbol, LLVMExpressionNode> variables, LLVMContext context, FrameSlot stackSlot,
-                    LLVMLabelList labels, LLVMBitcodeTypeHelper typeHelper) {
+                    LLVMLabelList labels, LLVMParserRuntime runtime) {
 
         final int elementCount = constant.getElementCount();
 
@@ -395,19 +396,19 @@ public final class LLVMConstantGenerator {
         final LLVMStructWriteNode[] nodes = new LLVMStructWriteNode[elementCount];
 
         final StructureType structureType = (StructureType) constant.getType();
-        final int structSize = structureType.getSize(typeHelper.getTargetDataLayout());
-        final int structAlignment = structureType.getAlignment(typeHelper.getTargetDataLayout());
+        final int structSize = runtime.getByteSize(structureType);
+        final int structAlignment = runtime.getByteAlignment(structureType);
         final LLVMAddressNode allocation = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(structSize, structAlignment, context, stackSlot);
 
         int currentOffset = 0;
         for (int i = 0; i < elementCount; i++) {
             final Type elementType = constant.getElementType(i);
             if (!packed) {
-                currentOffset += Type.getPadding(currentOffset, elementType, typeHelper.getTargetDataLayout());
+                currentOffset += runtime.getBytePadding(currentOffset, elementType);
             }
             offsets[i] = currentOffset;
-            final int byteSize = elementType.getSize(typeHelper.getTargetDataLayout());
-            final LLVMExpressionNode resolvedConstant = toConstantNode(constant.getElement(i), align, variables, context, stackSlot, labels, typeHelper);
+            final int byteSize = runtime.getByteSize(elementType);
+            final LLVMExpressionNode resolvedConstant = toConstantNode(constant.getElement(i), align, variables, context, stackSlot, labels, runtime);
             nodes[i] = createStructWriteNode(resolvedConstant, elementType.getLLVMBaseType(), byteSize);
             currentOffset += byteSize;
 
@@ -416,30 +417,30 @@ public final class LLVMConstantGenerator {
         return new StructLiteralNode(offsets, nodes, allocation);
     }
 
-    private static LLVMExpressionNode toStructZeroNode(StructureType structureType, LLVMContext context, FrameSlot stackSlot, LLVMBitcodeTypeHelper typeHelper) {
-        final int size = structureType.getSize(typeHelper.getTargetDataLayout());
+    private static LLVMExpressionNode toStructZeroNode(StructureType structureType, LLVMContext context, FrameSlot stackSlot, LLVMParserRuntime runtime) {
+        final int size = runtime.getByteSize(structureType);
         if (size == 0) {
             final LLVMAddress minusOneNode = LLVMAddress.fromLong(-1);
             return new LLVMSimpleLiteralNode.LLVMAddressLiteralNode(minusOneNode);
         } else {
-            final int alignment = structureType.getAlignment(typeHelper.getTargetDataLayout());
+            final int alignment = runtime.getByteAlignment(structureType);
             final LLVMAddressNode addressNode = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(size, alignment, context, stackSlot);
             return new LLVMAddressZeroNode(addressNode, size);
         }
     }
 
-    private static LLVMExpressionNode toArrayZeroNode(ArrayType type, LLVMContext context, FrameSlot stack, LLVMBitcodeTypeHelper typeHelper) {
-        final int size = type.getSize(typeHelper.getTargetDataLayout());
+    private static LLVMExpressionNode toArrayZeroNode(ArrayType type, LLVMContext context, FrameSlot stack, LLVMParserRuntime runtime) {
+        final int size = runtime.getByteSize(type);
         if (size == 0) {
             return null;
         } else {
-            final int alignment = type.getAlignment(typeHelper.getTargetDataLayout());
+            final int alignment = runtime.getByteAlignment(type);
             final LLVMAddressNode allocation = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(size, alignment, context, stack);
             return new LLVMAddressZeroNode(allocation, size);
         }
     }
 
-    public static LLVMExpressionNode toConstantZeroNode(Type type, LLVMContext context, FrameSlot stack, LLVMBitcodeTypeHelper typeHelper) {
+    public static LLVMExpressionNode toConstantZeroNode(Type type, LLVMContext context, FrameSlot stack, LLVMParserRuntime runtime) {
         if (type instanceof IntegerType) {
             final int vbr = ((IntegerType) type).getBits();
             switch (vbr) {
@@ -479,15 +480,15 @@ public final class LLVMConstantGenerator {
             }
 
         } else if (type instanceof ArrayType) {
-            return toArrayZeroNode((ArrayType) type, context, stack, typeHelper);
+            return toArrayZeroNode((ArrayType) type, context, stack, runtime);
 
         } else if (type instanceof VectorType) {
             final VectorType vectorType = (VectorType) type.getType();
-            final LLVMAddressNode target = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(type.getType().getSize(typeHelper.getTargetDataLayout()),
-                            type.getType().getAlignment(typeHelper.getTargetDataLayout()), context,
+            final LLVMAddressNode target = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(runtime.getByteSize(type.getType()),
+                            runtime.getByteAlignment(type.getType()), context,
                             stack);
             final LLVMExpressionNode[] zeroes = new LLVMExpressionNode[vectorType.getLength()];
-            Arrays.fill(zeroes, toConstantZeroNode(vectorType.getElementType(), context, stack, typeHelper));
+            Arrays.fill(zeroes, toConstantZeroNode(vectorType.getElementType(), context, stack, runtime));
             return LLVMLiteralFactory.createVectorLiteralNode(Arrays.asList(zeroes), target, vectorType.getLLVMBaseType());
 
         } else if (type instanceof FunctionType) {
@@ -498,7 +499,7 @@ public final class LLVMConstantGenerator {
 
         } else if (type instanceof StructureType) {
             final StructureType structureType = (StructureType) type;
-            return toStructZeroNode(structureType, context, stack, typeHelper);
+            return toStructZeroNode(structureType, context, stack, runtime);
 
         } else {
             throw new AssertionError("Unsupported Type for Zero Constant: " + type);

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMNodeGenerator.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMNodeGenerator.java
@@ -356,7 +356,7 @@ public final class LLVMNodeGenerator {
 
         final int baseTypeSize = runtime.getByteSize(constant.getType().getElementType());
         final LLVMAddressNode arrayAlloc = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(constant.getElementCount() * baseTypeSize,
-                        constant.getType().getAlignment(method.getTargetDataLayout()),
+                        runtime.getByteAlignment(constant.getType()),
                         method.getContext(), method.getStackSlot());
 
         final List<LLVMExpressionNode> arrayValues = new ArrayList<>(constant.getElementCount());
@@ -393,7 +393,7 @@ public final class LLVMNodeGenerator {
 
     private LLVMExpressionNode resolveStructureConstant(StructureConstant constant) {
         final int structSize = runtime.getByteSize(constant.getType());
-        final int structAlignment = constant.getType().getAlignment(method.getTargetDataLayout());
+        final int structAlignment = runtime.getByteAlignment(constant.getType());
         final LLVMExpressionNode alloc = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(structSize, structAlignment, method.getContext(), method.getStackSlot());
 
         final int[] offsets = new int[constant.getElementCount()];
@@ -520,7 +520,7 @@ public final class LLVMNodeGenerator {
         }
 
         final LLVMAddressNode target = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(runtime.getByteSize(constant.getType()),
-                        constant.getType().getAlignment(method.getTargetDataLayout()),
+                        runtime.getByteAlignment(constant.getType()),
                         method.getContext(),
                         method.getStackSlot());
 

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMNodeGenerator.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/nodes/LLVMNodeGenerator.java
@@ -79,6 +79,7 @@ import com.oracle.truffle.llvm.parser.base.model.types.IntegerType;
 import com.oracle.truffle.llvm.parser.base.model.types.StructureType;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
 import com.oracle.truffle.llvm.parser.base.util.LLVMBitcodeTypeHelper;
+import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.base.util.LLVMTypeHelper;
 import com.oracle.truffle.llvm.parser.bc.impl.LLVMBitcodeFunctionVisitor;
 import com.oracle.truffle.llvm.parser.factories.LLVMArithmeticFactory;
@@ -102,11 +103,11 @@ public final class LLVMNodeGenerator {
 
     private final LLVMBitcodeFunctionVisitor method;
 
-    private final LLVMBitcodeTypeHelper typeHelper;
+    private final LLVMParserRuntime runtime;
 
     public LLVMNodeGenerator(LLVMBitcodeFunctionVisitor method) {
         this.method = method;
-        this.typeHelper = method.getModule().getTypeHelper();
+        this.runtime = method.getModule().getParserRuntime();
     }
 
     public static Integer evaluateIntegerConstant(Symbol constant) {
@@ -268,13 +269,13 @@ public final class LLVMNodeGenerator {
 
             final Integer constantIndex = LLVMNodeGenerator.evaluateIntegerConstant(symbol);
             if (constantIndex == null) {
-                final int indexedTypeLength = currentType.getIndexOffset(1, typeHelper.getTargetDataLayout());
+                final int indexedTypeLength = runtime.getIndexOffset(1, currentType);
                 currentType = currentType.getIndexType(1);
                 final LLVMExpressionNode valueref = resolve(symbol);
                 currentAddress = LLVMGetElementPtrFactory.create(type.getLLVMBaseType(), (LLVMAddressNode) currentAddress, valueref, indexedTypeLength);
 
             } else {
-                final int indexedTypeLength = currentType.getIndexOffset(constantIndex, typeHelper.getTargetDataLayout());
+                final int indexedTypeLength = runtime.getIndexOffset(constantIndex, currentType);
                 currentType = currentType.getIndexType(constantIndex);
                 if (indexedTypeLength != 0) {
                     final LLVMExpressionNode constantNode;
@@ -332,7 +333,7 @@ public final class LLVMNodeGenerator {
             return LLVMConstantGenerator.toFloatingPointConstant((FloatingPointConstant) symbol);
 
         } else if (symbol instanceof NullConstant || symbol instanceof UndefinedConstant) {
-            return LLVMConstantGenerator.toConstantZeroNode(symbol.getType(), method.getContext(), method.getStackSlot(), typeHelper);
+            return LLVMConstantGenerator.toConstantZeroNode(symbol.getType(), method.getContext(), method.getStackSlot(), runtime);
 
         } else if (symbol instanceof StructureConstant) {
             return resolveStructureConstant((StructureConstant) symbol);
@@ -353,7 +354,7 @@ public final class LLVMNodeGenerator {
 
     private LLVMExpressionNode resolveArrayConstant(ArrayConstant constant) {
 
-        final int baseTypeSize = constant.getType().getElementType().getSize(typeHelper.getTargetDataLayout());
+        final int baseTypeSize = runtime.getByteSize(constant.getType().getElementType());
         final LLVMAddressNode arrayAlloc = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(constant.getElementCount() * baseTypeSize,
                         constant.getType().getAlignment(method.getTargetDataLayout()),
                         method.getContext(), method.getStackSlot());
@@ -391,7 +392,7 @@ public final class LLVMNodeGenerator {
     }
 
     private LLVMExpressionNode resolveStructureConstant(StructureConstant constant) {
-        final int structSize = constant.getType().getSize(typeHelper.getTargetDataLayout());
+        final int structSize = runtime.getByteSize(constant.getType());
         final int structAlignment = constant.getType().getAlignment(method.getTargetDataLayout());
         final LLVMExpressionNode alloc = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(structSize, structAlignment, method.getContext(), method.getStackSlot());
 
@@ -402,12 +403,12 @@ public final class LLVMNodeGenerator {
             final Type elemType = constant.getElementType(i);
 
             if (!constant.isPacked()) {
-                currentOffset += Type.getPadding(currentOffset, elemType, typeHelper.getTargetDataLayout());
+                currentOffset += runtime.getBytePadding(currentOffset, elemType);
             }
 
             offsets[i] = currentOffset;
             nodes[i] = createStructWriteNode(resolve(constant.getElement(i)), elemType);
-            currentOffset += elemType.getSize(typeHelper.getTargetDataLayout());
+            currentOffset += runtime.getByteSize(elemType);
         }
 
         return new StructLiteralNode(offsets, nodes, (LLVMAddressNode) alloc);
@@ -434,7 +435,7 @@ public final class LLVMNodeGenerator {
                 return new StructLiteralNode.LLVM80BitFloatStructWriteNode((LLVM80BitFloatNode) parsedConstant);
             case ARRAY:
             case STRUCT:
-                final int byteSize = type.getSize(typeHelper.getTargetDataLayout());
+                final int byteSize = runtime.getByteSize(type);
                 if (byteSize == 0) {
                     return new StructLiteralNode.LLVMEmptyStructWriteNode();
                 } else {
@@ -496,13 +497,13 @@ public final class LLVMNodeGenerator {
                 throw new IllegalStateException("Invalid index: " + index);
             }
 
-            currentOffset += currentType.getIndexOffset(indexVal, typeHelper.getTargetDataLayout());
+            currentOffset += runtime.getIndexOffset(indexVal, currentType);
             parentType = currentType;
             currentType = currentType.getIndexType(indexVal);
         }
 
         if (currentType != null && !((parentType instanceof StructureType) && (((StructureType) parentType).isPacked()))) {
-            currentOffset += Type.getPadding(currentOffset, currentType, typeHelper.getTargetDataLayout());
+            currentOffset += runtime.getBytePadding(currentOffset, currentType);
         }
 
         if (currentOffset != 0) {
@@ -518,7 +519,7 @@ public final class LLVMNodeGenerator {
             values.add(resolve(constant.getElement(i)));
         }
 
-        final LLVMAddressNode target = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(constant.getType().getSize(typeHelper.getTargetDataLayout()),
+        final LLVMAddressNode target = LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen.create(runtime.getByteSize(constant.getType()),
                         constant.getType().getAlignment(method.getTargetDataLayout()),
                         method.getContext(),
                         method.getStackSlot());

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAggregateFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAggregateFactory.java
@@ -124,7 +124,7 @@ public final class LLVMAggregateFactory {
         for (int i = 0; i < types.length; i++) {
             Type resolvedType = types[i];
             if (!packed) {
-                currentOffset += runtime.getTypeHelper().computePaddingByte(currentOffset, resolvedType);
+                currentOffset += runtime.getBytePadding(currentOffset, resolvedType);
             }
             offsets[i] = currentOffset;
             int byteSize = runtime.getByteSize(resolvedType);

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAggregateFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMAggregateFactory.java
@@ -119,7 +119,7 @@ public final class LLVMAggregateFactory {
         LLVMStructWriteNode[] nodes = new LLVMStructWriteNode[types.length];
         int currentOffset = 0;
         int structSize = runtime.getByteSize(structType);
-        int structAlignment = runtime.getTypeHelper().getAlignmentByte(structType);
+        int structAlignment = runtime.getByteAlignment(structType);
         LLVMExpressionNode alloc = runtime.allocateFunctionLifetime(LLVMToBitcodeAdapter.unresolveType(structType), structSize, structAlignment);
         for (int i = 0; i < types.length; i++) {
             Type resolvedType = types[i];

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLiteralFactory.java
@@ -381,7 +381,7 @@ public final class LLVMLiteralFactory {
         int baseTypeSize = runtime.getByteSize(elementType);
         int size = nrElements * baseTypeSize;
         LLVMAddressNode arrayAlloc = (LLVMAddressNode) runtime.allocateFunctionLifetime(LLVMToBitcodeAdapter.unresolveType(arrayType), size,
-                        runtime.getTypeHelper().getAlignmentByte(arrayType));
+                        runtime.getByteAlignment(arrayType));
         int byteLength = runtime.getByteSize(elementType);
         if (size == 0) {
             throw new AssertionError(llvmElementType + " has size of 0!");

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -129,9 +129,7 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
         this.runtime = runtime;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
-    @Deprecated
     public LLVMParserRuntime getRuntime() {
         return this.runtime;
     }

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -439,7 +439,6 @@ public final class LLVMVisitor implements LLVMParserRuntime {
     private final List<LLVMNode> globalDeallocations = new ArrayList<>();
     private boolean isGlobalScope;
 
-    @SuppressWarnings("deprecation")
     private Object findOrAllocateGlobal(GlobalVariable globalVariable) {
         return factoryFacade.allocateGlobalVariable(LLVMToBitcodeAdapter.resolveGlobalVariable(factoryFacade.getRuntime(), globalVariable));
     }
@@ -1498,6 +1497,16 @@ public final class LLVMVisitor implements LLVMParserRuntime {
     }
 
     @Override
+    public int getBytePadding(int offset, com.oracle.truffle.llvm.parser.base.model.types.Type type) {
+        return com.oracle.truffle.llvm.parser.base.model.types.Type.getPadding(offset, type, layoutConverter);
+    }
+
+    @Override
+    public int getIndexOffset(int index, com.oracle.truffle.llvm.parser.base.model.types.Type type) {
+        return type.getIndexOffset(index, layoutConverter);
+    }
+
+    @Override
     public FrameDescriptor getGlobalFrameDescriptor() {
         return globalFrameDescriptor;
     }
@@ -1510,11 +1519,6 @@ public final class LLVMVisitor implements LLVMParserRuntime {
     @Override
     public long getNativeHandle(String name) {
         return nativeLookup.getNativeHandle(name);
-    }
-
-    @Override
-    public LLVMTypeHelper getTypeHelper() {
-        return typeHelper;
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -1488,6 +1488,11 @@ public final class LLVMVisitor implements LLVMParserRuntime {
     }
 
     @Override
+    public int getByteAlignment(com.oracle.truffle.llvm.parser.base.model.types.Type type) {
+        return type.getAlignment(layoutConverter);
+    }
+
+    @Override
     public int getByteSize(com.oracle.truffle.llvm.parser.base.model.types.Type type) {
         return type.getSize(layoutConverter);
     }


### PR DESCRIPTION
Based on the PR of @jkreindl #527 (I will rebase this PR when the other one is merged).

I extend the usage of ```LLVMParserRuntime``` into ```LLVMBitcodeInstructionVisitor```, ... which allows us to remove those repetitive ```method.getTargetDataLayout()``` which are required when calculating size, alignment, padding,...

This is also necessary work, because there are currently multiple (similar) functions which calculate alignment, size,... . With this PR I started unifying those code parts to use the calculation methods declared inside the different Types. Which means we can remove the duplicated ones currently declared inside Type Helper,...