### PR TITLE
Add compileWithEcjStrict and finbugs to Sulong gate

### DIFF
--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -1156,7 +1156,9 @@ testCases = {
 checkCases = {
     'gitlog' : logCheck,
     'mdl' : mdlCheck,
+    'ecj' : compileWithEcjStrict,
     'checkstyle' : mx.checkstyle,
+    'findbugs' : findBugs,
     'canonicalizeprojects' : mx.canonicalizeprojects,
     'httpcheck' : checkNoHttp,
     'checkoverlap' : mx.checkoverlap,


### PR DESCRIPTION
These checks were removed during hunting a compilation issue but should be in the gate.