### PR TITLE
Improve equals and hashCode implementation of types to resolve most cycles

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/ArrayType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/ArrayType.java
@@ -115,6 +115,9 @@ public class ArrayType implements AggregateType {
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (obj instanceof ArrayType) {
             ArrayType other = (ArrayType) obj;
             return length == other.length && Objects.equals(elementType, other.elementType);

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/FunctionType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/FunctionType.java
@@ -120,6 +120,9 @@ public class FunctionType implements Type, ValueSymbol {
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (obj instanceof FunctionType) {
             FunctionType other = (FunctionType) obj;
             if (!Objects.equals(type, other.type)) {

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/PointerType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/PointerType.java
@@ -130,6 +130,9 @@ public final class PointerType implements Type {
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (obj instanceof PointerType) {
             return type.equals(((PointerType) obj).type);
         }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/StructureType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/StructureType.java
@@ -192,12 +192,24 @@ public final class StructureType implements AggregateType, ValueSymbol {
     public int hashCode() {
         int hash = 11;
         hash = 23 * hash + (isPacked ? 1231 : 1237);
-        hash = 23 * hash + Arrays.hashCode(types);
+        for (Type type : types) {
+            /*
+             * Those types could create cycles, so we ignore them for hashCode() calculation.
+             */
+            if (type instanceof StructureType || type instanceof PointerType) {
+                hash = 23 * hash + 47;
+                continue;
+            }
+            hash = 23 * hash + type.hashCode();
+        }
         return hash;
     }
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (obj instanceof StructureType) {
             StructureType other = (StructureType) obj;
             if (!Objects.equals(name, other.name)) {

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/VectorType.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/types/VectorType.java
@@ -149,6 +149,9 @@ public class VectorType implements AggregateType {
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (obj instanceof VectorType) {
             VectorType other = (VectorType) obj;
             return length == other.length && elementType.equals(other.getElementType());


### PR DESCRIPTION
It's possible to create Type cycles using structures.

This patch fixes the ```hashCode``` calculation of structures, as well as adding a reference comparison for some types to resolve most cycles when using ```equals```.