### PR TITLE
Fix bitcode parser to consume Bitcode Wrapper Format prefix correctly

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/parser/bc/Parser.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/parser/bc/Parser.java
@@ -131,6 +131,10 @@ public class Parser {
         this(Objects.requireNonNull(stream), Objects.requireNonNull(block), Objects.requireNonNull(listener), null, new Operation[][]{DEFAULT_OPERATIONS}, 2, 0);
     }
 
+    public Parser(Bitstream stream, Block block, ParserListener listener, long offset) {
+        this(Objects.requireNonNull(stream), Objects.requireNonNull(block), Objects.requireNonNull(listener), null, new Operation[][]{DEFAULT_OPERATIONS}, 2, offset);
+    }
+
     protected Parser(Parser parser) {
         this(parser.stream, parser.block, parser.listener, parser.parent, parser.operations, parser.idsize, parser.offset);
     }

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/parser/bc/ParserResult.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/parser/bc/ParserResult.java
@@ -29,6 +29,9 @@
  */
 package com.oracle.truffle.llvm.parser.bc.impl.parser.bc;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 public final class ParserResult {
 
     private final Parser parser;
@@ -55,5 +58,10 @@ public final class ParserResult {
 
     public long[] getValues() {
         return values;
+    }
+
+    @Override
+    public String toString() {
+        return Arrays.stream(values).mapToObj(l -> String.format("%05X ", l)).collect(Collectors.joining(" "));
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/parser/ir/LLVMParser.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/parser/ir/LLVMParser.java
@@ -41,6 +41,7 @@ import com.oracle.truffle.llvm.parser.bc.impl.parser.listeners.ModuleVersion;
 public final class LLVMParser {
 
     private static final long MAGIC_WORD = 0xdec04342L; // 'BC' c0de
+    private static final long WRAPPER_MAGIC_WORD = 0x0B17C0DEL;
 
     private final ApplicationGenerator generator;
 
@@ -59,17 +60,68 @@ public final class LLVMParser {
 
         Parser parser = new Parser(stream, Block.ROOT, module);
 
-        ParserResult result = parser.read(Integer.SIZE);
-        parser = result.getParser();
+        BitcodeStreamInformation bcStreamInfo = getStreamInformation(stream, parser);
+        parser = new Parser(stream, Block.ROOT, module, bcStreamInfo.offset);
 
+        ParserResult result = parser.read(Integer.SIZE);
         if (result.getValue() != MAGIC_WORD) {
             generator.error("Illegal file (does not exist or contains no magic word)");
         }
+        parser = result.getParser();
 
-        while (parser.getOffset() < stream.size()) {
+        while (parser.getOffset() < bcStreamInfo.totalStreamSize()) {
             result = parser.readId();
             Operation operation = parser.getOperation(result.getValue());
             parser = operation.apply(result.getParser());
+        }
+    }
+
+    private static BitcodeStreamInformation getStreamInformation(Bitstream stream, Parser parser) {
+        ParserResult first32bit = parser.read(Integer.SIZE);
+        if (first32bit.getValue() == WRAPPER_MAGIC_WORD) {
+            // offset and size of bitcode stream are specified in bitcode wrapper
+            return parseWrapperFormatPrefix(first32bit.getParser());
+        } else {
+            return new BitcodeStreamInformation(0, stream.size());
+        }
+    }
+
+    /*
+     * Bitcode files can have a wrapper prefix: [Magic32, Version32, Offset32, Size32, CPUType32]
+     * see: http://llvm.org/docs/BitCodeFormat.html#bitcode-wrapper-format
+     */
+    private static BitcodeStreamInformation parseWrapperFormatPrefix(Parser parser) {
+        Parser p = parser;
+        // Version32
+        ParserResult value32Bit = p.read(Integer.SIZE);
+        p = value32Bit.getParser();
+        // Offset32
+        value32Bit = p.read(Integer.SIZE);
+        long offset = value32Bit.getValue() * Byte.SIZE;
+        p = value32Bit.getParser();
+        // Size32
+        value32Bit = p.read(Integer.SIZE);
+        long size = value32Bit.getValue() * Byte.SIZE;
+        p = value32Bit.getParser();
+        // CPUType32
+        value32Bit = p.read(Integer.SIZE);
+        p = value32Bit.getParser();
+        // End of Wrapper Prefix
+
+        return new BitcodeStreamInformation(offset, size);
+    }
+
+    private static class BitcodeStreamInformation {
+        private final long offset;
+        private final long size;
+
+        BitcodeStreamInformation(long offset, long size) {
+            this.offset = offset;
+            this.size = size;
+        }
+
+        private long totalStreamSize() {
+            return offset + size;
         }
     }
 }


### PR DESCRIPTION
BC files can have a bitcode wrapper format prefix of format [Magic32, Version32, Offset32, Size32, CPUType32]. This prefix is optional.