### PR TITLE
Fix cyclic dependency in Sulong projects

### DIFF
--- a/mx.sulong/suite.py
+++ b/mx.sulong/suite.py
@@ -361,10 +361,10 @@ suite = {
       "subDir" : "projects",
       "sourceDirs" : ["src"],
       "dependencies" : [
+        "com.oracle.truffle.llvm.types",
         "LLVM_IR_PARSER",
         "EMF_COMMON", "ECORE", "INJECT", "XTEXT", "XTEXT_XBASE", "XTEXT_XBASE_LIB", "EMF_ECORE_XMI", "XTEXT_TYPES", "XTEXT_JAVAX_INJECT", "XTEXT_LOG4J", "XTEXT_GOOGLE_GUAVA", "XTEXT_ANTLR_RUNTIME", "XTEXT_UTIL", "ECLIPSE_EQUINOX"
        ],
-      "generatedDependencies" : ["com.oracle.truffle.llvm.nodes"],
       "checkstyle" : "com.oracle.truffle.llvm",
       "javaCompliance" : "1.8",
       "annotationProcessors" : ["truffle:TRUFFLE_DSL_PROCESSOR"],
@@ -376,7 +376,8 @@ suite = {
       "subDir" : "projects",
       "sourceDirs" : ["src"],
       "dependencies" : [
-        "com.oracle.truffle.llvm.parser"
+        "com.oracle.truffle.llvm.parser",
+        "com.oracle.truffle.llvm.nodes",
         ],
       "checkstyle" : "com.oracle.truffle.llvm",
       "javaCompliance" : "1.8",
@@ -389,7 +390,7 @@ suite = {
       "subDir" : "projects",
       "sourceDirs" : ["src"],
       "dependencies" : [
-        "com.oracle.truffle.llvm.parser.factories",
+        "com.oracle.truffle.llvm.nativeint",
       ],
       "checkstyle" : "com.oracle.truffle.llvm",
       "javaCompliance" : "1.8",
@@ -456,6 +457,8 @@ suite = {
       "subDir" : "projects",
       "sourceDirs" : ["src"],
       "dependencies" : [
+        # TODO: this is a temporary dependency.
+        # should be: llvm.nativeint
         "com.oracle.truffle.llvm.parser.factories",
        ],
       "checkstyle" : "com.oracle.truffle.llvm",

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLogicalFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMLogicalFactory.java
@@ -29,13 +29,6 @@
  */
 package com.oracle.truffle.llvm.parser.factories;
 
-import com.intel.llvm.ireditor.lLVM_IR.BitwiseBinaryInstruction;
-import com.intel.llvm.ireditor.lLVM_IR.Instruction_and;
-import com.intel.llvm.ireditor.lLVM_IR.Instruction_ashr;
-import com.intel.llvm.ireditor.lLVM_IR.Instruction_lshr;
-import com.intel.llvm.ireditor.lLVM_IR.Instruction_or;
-import com.intel.llvm.ireditor.lLVM_IR.Instruction_shl;
-import com.intel.llvm.ireditor.lLVM_IR.Instruction_xor;
 import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.impl.base.LLVMAddressNode;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI16Node;
@@ -256,24 +249,6 @@ public final class LLVMLogicalFactory {
                 return LLVMI64VectorXorNodeGen.create(target, left, right);
             default:
                 throw new AssertionError(type);
-        }
-    }
-
-    public static LLVMLogicalInstructionType getLogicalInstructionType(BitwiseBinaryInstruction instr) {
-        if (instr instanceof Instruction_and) {
-            return LLVMLogicalInstructionType.AND;
-        } else if (instr instanceof Instruction_or) {
-            return LLVMLogicalInstructionType.OR;
-        } else if (instr instanceof Instruction_shl) {
-            return LLVMLogicalInstructionType.SHIFT_LEFT;
-        } else if (instr instanceof Instruction_lshr) {
-            return LLVMLogicalInstructionType.LOGICAL_SHIFT_RIGHT;
-        } else if (instr instanceof Instruction_ashr) {
-            return LLVMLogicalInstructionType.ARITHMETIC_SHIFT_RIGHT;
-        } else if (instr instanceof Instruction_xor) {
-            return LLVMLogicalInstructionType.XOR;
-        } else {
-            throw new AssertionError(instr);
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -70,6 +70,8 @@ import com.intel.llvm.ireditor.lLVM_IR.InlineAsm;
 import com.intel.llvm.ireditor.lLVM_IR.InlineAssembler;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction_alloca;
+import com.intel.llvm.ireditor.lLVM_IR.Instruction_and;
+import com.intel.llvm.ireditor.lLVM_IR.Instruction_ashr;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction_atomicrmw;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction_br;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction_call_nonVoid;
@@ -84,12 +86,16 @@ import com.intel.llvm.ireditor.lLVM_IR.Instruction_indirectbr;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction_insertelement;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction_insertvalue;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction_load;
+import com.intel.llvm.ireditor.lLVM_IR.Instruction_lshr;
+import com.intel.llvm.ireditor.lLVM_IR.Instruction_or;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction_ret;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction_select;
+import com.intel.llvm.ireditor.lLVM_IR.Instruction_shl;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction_shufflevector;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction_store;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction_switch;
 import com.intel.llvm.ireditor.lLVM_IR.Instruction_unreachable;
+import com.intel.llvm.ireditor.lLVM_IR.Instruction_xor;
 import com.intel.llvm.ireditor.lLVM_IR.LocalValue;
 import com.intel.llvm.ireditor.lLVM_IR.LocalValueRef;
 import com.intel.llvm.ireditor.lLVM_IR.MiddleInstruction;
@@ -137,7 +143,6 @@ import com.oracle.truffle.llvm.parser.base.util.LLVMParserAsserts;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserResultImpl;
 import com.oracle.truffle.llvm.parser.base.util.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.base.util.LLVMTypeHelper;
-import com.oracle.truffle.llvm.parser.factories.LLVMLogicalFactory;
 import com.oracle.truffle.llvm.parser.impl.LLVMPhiVisitor.Phi;
 import com.oracle.truffle.llvm.parser.impl.lifetime.LLVMLifeTimeAnalysisResult;
 import com.oracle.truffle.llvm.parser.impl.lifetime.LLVMLifeTimeAnalysisVisitor;
@@ -816,7 +821,7 @@ public final class LLVMVisitor implements LLVMParserRuntime {
         LLVMExpressionNode right = visitValueRef(op2, instr.getType());
         LLVMBaseType llvmType = getLLVMType(instr.getType()).getType();
         LLVMExpressionNode target = allocateVectorResultIfVector(instr);
-        return factoryFacade.createLogicalOperation(left, right, LLVMLogicalFactory.getLogicalInstructionType(instr), llvmType, target);
+        return factoryFacade.createLogicalOperation(left, right, getLogicalInstructionType(instr), llvmType, target);
     }
 
     private LLVMExpressionNode allocateVectorResultIfVector(EObject type) {
@@ -828,6 +833,24 @@ public final class LLVMVisitor implements LLVMParserRuntime {
             target = null;
         }
         return target;
+    }
+
+    private static LLVMLogicalInstructionType getLogicalInstructionType(BitwiseBinaryInstruction instr) {
+        if (instr instanceof Instruction_and) {
+            return LLVMLogicalInstructionType.AND;
+        } else if (instr instanceof Instruction_or) {
+            return LLVMLogicalInstructionType.OR;
+        } else if (instr instanceof Instruction_shl) {
+            return LLVMLogicalInstructionType.SHIFT_LEFT;
+        } else if (instr instanceof Instruction_lshr) {
+            return LLVMLogicalInstructionType.LOGICAL_SHIFT_RIGHT;
+        } else if (instr instanceof Instruction_ashr) {
+            return LLVMLogicalInstructionType.ARITHMETIC_SHIFT_RIGHT;
+        } else if (instr instanceof Instruction_xor) {
+            return LLVMLogicalInstructionType.XOR;
+        } else {
+            throw new AssertionError(instr);
+        }
     }
 
     private LLVMExpressionNode visitSelectInstr(Instruction_select instr) {


### PR DESCRIPTION
This dependency was introduced in e32db and allowed to create node implementations in the parser.