### PR TITLE
Unify the creation of @truffle, @llvm, and other parse-time intrinsic…

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacade.java
@@ -99,17 +99,18 @@ public interface NodeFactoryFacade {
     LLVMExpressionNode createVectorLiteralNode(List<LLVMExpressionNode> listValues, LLVMExpressionNode target, LLVMBaseType type);
 
     /**
-     * Creates an intrinsic for a <code>@llvm.*</code> function.
+     * This method allows to substitute calls to functions with nodes. The implementer is either
+     * expected to return <code>null</code> when not intrinsifying this method, or the node with
+     * which the function call should be substituted with.
      *
-     * @param declaration the function declaration of the function from which the intrinsic is
-     *            called
-     * @param argNodes the arguments to the intrinsic function
-     * @param numberOfExplicitArguments number of explicite arguments passed to function
+     * This method is also called for <code>@llvm.*</code> and <code>@truffle_*</code> intrinsics.
+     *
+     * @param declaration the function declaration of the function that could be intrinsified
+     * @param argNodes the arguments to the function
+     * @param numberOfExplicitArguments number of explicit arguments passed to function
      * @return the created intrinsic
      */
-    LLVMNode createLLVMIntrinsic(FunctionType declaration, Object[] argNodes, int numberOfExplicitArguments);
-
-    LLVMNode createTruffleIntrinsic(String functionName, LLVMExpressionNode[] argNodes);
+    LLVMNode tryCreateFunctionSubstitution(FunctionType declaration, LLVMExpressionNode[] argNodes, int numberOfExplicitArguments);
 
     LLVMNode createRetVoid();
 

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/facade/NodeFactoryFacadeAdapter.java
@@ -128,16 +128,6 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMNode createLLVMIntrinsic(FunctionType declaration, Object[] argNodes, int numberOfExplicitArguments) {
-        return null;
-    }
-
-    @Override
-    public LLVMNode createTruffleIntrinsic(String functionName, LLVMExpressionNode[] argNodes) {
-        return null;
-    }
-
-    @Override
     public LLVMNode createRetVoid() {
         return null;
     }
@@ -358,6 +348,11 @@ public class NodeFactoryFacadeAdapter implements NodeFactoryFacade {
 
     @Override
     public LLVMFunction createAndRegisterFunctionDescriptor(String name, LLVMRuntimeType convertType, boolean varArgs, LLVMRuntimeType[] convertTypes) {
+        return null;
+    }
+
+    @Override
+    public LLVMNode tryCreateFunctionSubstitution(FunctionType declaration, LLVMExpressionNode[] argNodes, int numberOfExplicitArguments) {
         return null;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NodeFactoryFacadeImpl.java
@@ -183,13 +183,15 @@ public class NodeFactoryFacadeImpl implements NodeFactoryFacade {
     }
 
     @Override
-    public LLVMNode createLLVMIntrinsic(FunctionType declaration, Object[] argNodes, int numberOfExplicitArguments) {
-        return LLVMIntrinsicFactory.create(declaration, argNodes, numberOfExplicitArguments, runtime);
-    }
-
-    @Override
-    public LLVMNode createTruffleIntrinsic(String functionName, LLVMExpressionNode[] argNodes) {
-        return LLVMTruffleIntrinsicFactory.create(functionName, argNodes);
+    public LLVMNode tryCreateFunctionSubstitution(FunctionType declaration, LLVMExpressionNode[] argNodes, int numberOfExplicitArguments) {
+        String functionName = declaration.getName();
+        if (functionName.startsWith("@llvm")) {
+            return LLVMIntrinsicFactory.create(declaration, argNodes, numberOfExplicitArguments, runtime);
+        } else if (functionName.startsWith("@truffle")) {
+            return LLVMTruffleIntrinsicFactory.create(functionName, argNodes);
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.impl/src/com/oracle/truffle/llvm/parser/impl/LLVMVisitor.java
@@ -654,17 +654,11 @@ public final class LLVMVisitor implements LLVMParserRuntimeTextual {
         LLVMExpressionNode[] finalArgs = argNodes.toArray(new LLVMExpressionNode[argNodes.size()]);
         if (callee instanceof GlobalValueRef && ((GlobalValueRef) callee).getConstant().getRef() instanceof FunctionHeader) {
             FunctionHeader functionHeader = (FunctionHeader) ((GlobalValueRef) callee).getConstant().getRef();
-            String functionName = functionHeader.getName();
-            if (functionName.startsWith("@llvm.")) {
-                return factoryFacade.createLLVMIntrinsic(LLVMToBitcodeAdapter.resolveFunctionHeader(this, functionHeader), finalArgs,
-                                LLVMToBitcodeAdapter.resolveFunctionDef(this, containingFunctionDef).getArgumentTypes().length);
-            } else if (functionName.startsWith("@truffle_")) {
-                LLVMNode truffleIntrinsic = factoryFacade.createTruffleIntrinsic(functionName, finalArgs);
-                if (truffleIntrinsic != null) {
-                    return truffleIntrinsic;
-                }
+            LLVMNode optionalSubstitutionNode = factoryFacade.tryCreateFunctionSubstitution(LLVMToBitcodeAdapter.resolveFunctionHeader(this, functionHeader), finalArgs,
+                            LLVMToBitcodeAdapter.resolveFunctionDef(this, containingFunctionDef).getArgumentTypes().length);
+            if (optionalSubstitutionNode != null) {
+                return optionalSubstitutionNode;
             }
-
         } else if (callee instanceof InlineAssembler) {
             String asmSnippet = ((InlineAssembler) callee).getAssembler();
             String asmFlags = ((InlineAssembler) callee).getFlags();


### PR DESCRIPTION
…s in the factory facade

Previously, there were two different methods for creating parse-time substitutions of @truffle and @llvm functions in the factory facade.
This restricts the extensibility of intrinsic functions, since we would have to create (or remove) additional methods for intrinsics with a new (or deprecated) prefix.
Thus, this change unifies the two methods and also allows the substitution of other functions.