### PR TITLE
Use the factory facade's hasStackPointerArgument in the binary format parser

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/symbols/instructions/CallInstruction.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/symbols/instructions/CallInstruction.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import com.oracle.truffle.llvm.parser.base.model.enums.Linkage;
 import com.oracle.truffle.llvm.parser.base.model.enums.Visibility;
+import com.oracle.truffle.llvm.parser.base.model.functions.FunctionDeclaration;
 import com.oracle.truffle.llvm.parser.base.model.symbols.Symbol;
 import com.oracle.truffle.llvm.parser.base.model.symbols.Symbols;
 import com.oracle.truffle.llvm.parser.base.model.types.Type;
@@ -104,5 +105,24 @@ public final class CallInstruction extends ValueInstruction implements Call {
             inst.arguments.add(symbols.getSymbol(argument, inst));
         }
         return inst;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (target instanceof FunctionDeclaration) {
+            sb.append(((FunctionDeclaration) target).getName());
+        } else {
+            sb.append(target);
+        }
+        sb.append('(');
+        for (int i = 0; i < arguments.size(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            sb.append(arguments.get(i));
+        }
+        sb.append(')');
+        return sb.toString();
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/symbols/instructions/CastInstruction.java
+++ b/projects/com.oracle.truffle.llvm.parser.base/src/com/oracle/truffle/llvm/parser/base/model/symbols/instructions/CastInstruction.java
@@ -77,4 +77,9 @@ public final class CastInstruction extends ValueInstruction {
         inst.value = symbols.getSymbol(value, inst);
         return inst;
     }
+
+    @Override
+    public String toString() {
+        return String.format("(%s) %s", operator, value);
+    }
 }

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeFunctionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeFunctionVisitor.java
@@ -142,4 +142,5 @@ class LLVMBitcodeFunctionVisitor implements FunctionVisitor {
         this.instructions.clear();
         block.accept(new LLVMBitcodeInstructionVisitor(this, block, factoryFacade));
     }
+
 }

--- a/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc.impl/src/com/oracle/truffle/llvm/parser/bc/impl/LLVMBitcodeVisitor.java
@@ -272,12 +272,18 @@ public final class LLVMBitcodeVisitor implements ModelVisitor {
         return factoryFacade.createFrameNuller(identifier, type, slot);
     }
 
+    boolean needsStackPointerArgument() {
+        Optional<Boolean> hasStackPointerArgument = factoryFacade.hasStackPointerArgument();
+        return hasStackPointerArgument.isPresent() && hasStackPointerArgument.get();
+    }
+
     private List<LLVMNode> createParameters(FrameDescriptor frame, FunctionDefinition method) {
         final List<FunctionParameter> parameters = method.getParameters();
         final List<LLVMNode> formalParamInits = new ArrayList<>();
-
-        final LLVMExpressionNode stackPointerNode = factoryFacade.createFunctionArgNode(0, LLVMBaseType.ADDRESS);
-        formalParamInits.add(factoryFacade.createFrameWrite(LLVMBaseType.ADDRESS, stackPointerNode, frame.findFrameSlot(LLVMFrameIDs.STACK_ADDRESS_FRAME_SLOT_ID)));
+        if (needsStackPointerArgument()) {
+            final LLVMExpressionNode stackPointerNode = factoryFacade.createFunctionArgNode(0, LLVMBaseType.ADDRESS);
+            formalParamInits.add(factoryFacade.createFrameWrite(LLVMBaseType.ADDRESS, stackPointerNode, frame.findFrameSlot(LLVMFrameIDs.STACK_ADDRESS_FRAME_SLOT_ID)));
+        }
 
         final Optional<Integer> argStartIndex = factoryFacade.getArgStartIndex();
         if (!argStartIndex.isPresent()) {


### PR DESCRIPTION
This method is used by the textual parser to keep the node factory facade extensible, but has not been used by the binary parser yet.

This PR also adds a toString implementation for the `CallInstruction`.