### PR TITLE
Add rdtsc instruction to inline assembly

### DIFF
--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
@@ -128,7 +128,7 @@ MoveOperation<> =						(.String op; String left = null, right = null;.)
 RdtscInstruction<> =					(.String op;.)
 	RdtscOp <out op> ";"				(.factory.addFrameSlot("%eax", LLVMBaseType.I32);
 										  factory.addFrameSlot("%edx", LLVMBaseType.I32);
-										  factory.createCustomOperation(op);.)
+										  factory.createMiscOperation(op);.)
    .
 
 AddSubOp<out String op> 				(.op = la.val;.)

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
@@ -61,12 +61,15 @@ PRODUCTIONS
 InlineAssembly<> =
 										(..)
   "\""
-  (AddSubOperation<> | IncDecOperation<> | LogicOperation<> | ShiftOperation<> | MoveOperation<> | MulOperation<> | DivOperation<> | RdtscInstruction<>)
-  {AddSubOperation<> | IncDecOperation<> | LogicOperation<> | ShiftOperation<> | MoveOperation<> | MulOperation<> | DivOperation<> | RdtscInstruction<>}
+  (Instruction<>)
+  {Instruction<>}
   "\""
   										(.root = factory.finishInline();.)
   .
 
+Instruction<> =
+  AddSubOperation<> | IncDecOperation<> | LogicOperation<> | ShiftOperation<> | MoveOperation<> | MulOperation<> | DivOperation<> | RdtscInstruction<>
+.
 AddSubOperation<> =						(.String op; String left = null, right = null;.)
   AddSubOp<out op>
   ((Register<out left> "," Register<out right>)

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
@@ -61,8 +61,8 @@ PRODUCTIONS
 InlineAssembly<> =
 										(..)
   "\""
-  (AddSubOperation<> | IncDecOperation<> | LogicOperation<> | ShiftOperation<> | MoveOperation<> | MulOperation<> | DivOperation<>)
-  {AddSubOperation<> | IncDecOperation<> | LogicOperation<> | ShiftOperation<> | MoveOperation<> | MulOperation<> | DivOperation<>}
+  (AddSubOperation<> | IncDecOperation<> | LogicOperation<> | ShiftOperation<> | MoveOperation<> | MulOperation<> | DivOperation<> | RdtscInstruction<>)
+  {AddSubOperation<> | IncDecOperation<> | LogicOperation<> | ShiftOperation<> | MoveOperation<> | MulOperation<> | DivOperation<> | RdtscInstruction<>}
   "\""
   										(.root = factory.finishInline();.)
   .
@@ -91,7 +91,7 @@ DivOperation<> =						(.String op; String left = null;.)
   ((Register<out left> ["," "%eax"])
   )";"									(.	factory.addFrameSlot("%eax", LLVMBaseType.I32);
 											factory.addFrameSlot("%edx", LLVMBaseType.I32);
-											factory.createDivisionOperatoin(op, left);
+											factory.createDivisionOperation(op, left);
 										.)
   .
 
@@ -124,7 +124,13 @@ MoveOperation<> =						(.String op; String left = null, right = null;.)
   (Immediate<out left> "," Register<out right>)
    )";"									(.factory.createBinaryOperation(op, left, right);.)
    .
-  
+
+RdtscInstruction<> =					(.String op;.)
+	RdtscOp <out op> ";"				(.factory.addFrameSlot("%eax", LLVMBaseType.I32);
+										  factory.addFrameSlot("%edx", LLVMBaseType.I32);
+										  factory.createCustomOperation(op);.)
+   .
+
 AddSubOp<out String op> 				(.op = la.val;.)
   = "addl"
   | "subl"
@@ -163,6 +169,10 @@ DivOp<out String op>					(.op = la.val;.)
 MoveOp<out String op>					(.op = la.val;.)
   = "movl"
   .  
+
+RdtscOp<out String op>					(.op = la.val;.)
+  = "rdtsc"
+  .
 
 Register<out String reg> =
   ( "%eax"

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64I32BinaryNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64I32BinaryNode.java
@@ -53,6 +53,11 @@ public abstract class LLVMAMD64I32BinaryNode extends LLVMI32Node {
             return left & right;
         }
 
+        @Specialization
+        protected long executeI64(long left, long right) {
+            return left & right;
+        }
+
     }
 
     public abstract static class LLVMAMD64OrlNode extends LLVMAMD64I32BinaryNode {

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64I64BinaryNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64I64BinaryNode.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.asm;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.base.LLVMExpressionNode;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
+
+@NodeChildren({@NodeChild(type = LLVMExpressionNode.class, value = "leftNode"), @NodeChild(type = LLVMExpressionNode.class, value = "rightNode")})
+public abstract class LLVMAMD64I64BinaryNode extends LLVMI64Node {
+
+    public abstract static class LLVMAMD64I64ShrlNode extends LLVMAMD64I64BinaryNode {
+
+        @Specialization
+        protected long executeI64(int left, long right) {
+            return right >>> left;
+        }
+    }
+
+    public abstract static class LLVMAMD64I64AndlNode extends LLVMAMD64I64BinaryNode {
+
+        @Specialization
+        protected long executeI64(long left, int right) {
+            return left & right;
+        }
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64RdtscNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64RdtscNode.java
@@ -29,11 +29,13 @@
  */
 package com.oracle.truffle.llvm.nodes.impl.asm;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
 
 public abstract class LLVMAMD64RdtscNode extends LLVMI64Node {
 
+    @TruffleBoundary
     @Specialization
     public long executeRdtsc() {
         return System.nanoTime();

--- a/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64RdtscNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes.impl/src/com/oracle/truffle/llvm/nodes/impl/asm/LLVMAMD64RdtscNode.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.impl.asm;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.impl.base.integers.LLVMI64Node;
+
+public abstract class LLVMAMD64RdtscNode extends LLVMI64Node {
+
+    @Specialization
+    public long executeRdtsc() {
+        return System.nanoTime();
+    }
+}

--- a/tests/inlineassemblytests/inlineassembly025.c
+++ b/tests/inlineassemblytests/inlineassembly025.c
@@ -1,0 +1,7 @@
+#include<stdint.h>
+
+int main() {
+  uint64_t rax, rdx;
+   __asm__ ("rdtsc;" : "=a"(rax), "=d"(rdx) : :);
+  return 0;
+}


### PR DESCRIPTION
This PR is to add support for rdtsc instruction in inline assembly. It shall also address the issue #375 .
This PR includes the following changes
- Changes to inline assembly parser generation file to incorporate detecting rdtsc instruction and little refactoring
- Implementation of rdtsc using `System.nanoTime()` routine
- Little refactoring to handle struct return types. Moved creation of nodes to allocate structure and populate with appropriate result at a single place (useful for `idivl` and `rdtsc` instructions)
- Add test to ensure correct parsing of `rdtsc` instruction

Implementation of RDTSC instruction returns current nanotime value instead of reading value stored in TSC register. I could not find any simpler way to retrieve this information in Java. Also some of the aricles encouraged using nanotime value to do elapsed time measurements [1][2]. 
As the idea of using rdtsc is to identify elapsed time this alternative can be acceptable. Therefore the test `inlineassembly025.c` only checks for correct parsing of rdtsc instruction, it does not compare the value with the c execution as they will not be the same.
Please let me know if this is alright.

[1] http://btorpey.github.io/blog/2014/02/18/clock-sources-in-linux/
[2] https://blogs.oracle.com/dholmes/entry/inside_the_hotspot_vm_clocks