### PR TITLE
Remove sporadically failing unittest from GCC suite

### DIFF
--- a/tests/gcc/configs/gcc.c-torture/execute/working.include
+++ b/tests/gcc/configs/gcc.c-torture/execute/working.include
@@ -617,7 +617,6 @@ gcc-5.2.0/gcc/testsuite/gcc.c-torture/execute/20010329-1.c
 gcc-5.2.0/gcc/testsuite/gcc.c-torture/execute/931102-1.c
 gcc-5.2.0/gcc/testsuite/gcc.c-torture/execute/struct-ret-1.c
 gcc-5.2.0/gcc/testsuite/gcc.c-torture/execute/20011008-3.c
-gcc-5.2.0/gcc/testsuite/gcc.c-torture/execute/941014-2.c
 gcc-5.2.0/gcc/testsuite/gcc.c-torture/execute/scope-1.c
 gcc-5.2.0/gcc/testsuite/gcc.c-torture/execute/20000422-1.c
 gcc-5.2.0/gcc/testsuite/gcc.c-torture/execute/990527-1.c


### PR DESCRIPTION
The test fails with non-deterministic output differences.