### PR TITLE
Add statistics output at the end of the big usites (GCC, LLVM, NWCC)

### DIFF
--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/BaseTestHarness.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/BaseTestHarness.java
@@ -50,6 +50,7 @@ public abstract class BaseTestHarness {
 
     public static final Predicate<? super Path> isExecutable = f -> f.getFileName().toString().endsWith(".out");
     public static final Predicate<? super Path> isIncludeFile = f -> f.getFileName().toString().endsWith(".include");
+    public static final Predicate<? super Path> isExcludeFile = f -> f.getFileName().toString().endsWith(".exclude");
     public static final Predicate<? super Path> isSulong = f -> f.getFileName().toString().endsWith(".bc");
     public static final Predicate<? super Path> isFile = f -> f.toFile().isFile();
 

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/GCCSuite.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/GCCSuite.java
@@ -31,9 +31,12 @@ package com.oracle.truffle.llvm.test.alpha;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.function.Predicate;
 
+import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -45,6 +48,7 @@ import com.oracle.truffle.llvm.runtime.options.LLVMOptions;
 public final class GCCSuite extends BaseSuiteHarness {
 
     private static final Path GCC_SUITE_DIR = new File(LLVMOptions.ENGINE.projectRoot() + "/../cache/tests/gcc").toPath();
+    private static final Path GCC_SOURCE_DIR = new File(LLVMOptions.ENGINE.projectRoot() + "/../tests/gcc/gcc-5.2.0").toPath();
     private static final Path GCC_CONFIG_DIR = new File(LLVMOptions.ENGINE.projectRoot() + "/../tests/gcc/configs").toPath();
 
     @Parameter(value = 0) public Path path;
@@ -68,6 +72,22 @@ public final class GCCSuite extends BaseSuiteHarness {
     @Override
     protected Path getSuiteDirectory() {
         return GCC_SUITE_DIR;
+    }
+
+    @AfterClass
+    public static void printStatistics() {
+        HashSet<Path> ignoredFolders = new HashSet<>();
+        ignoredFolders.add(Paths.get("gcc-5.2.0/gcc/testsuite/gcc.c-torture/compile"));
+        ignoredFolders.add(Paths.get("gcc-5.2.0/gcc/testsuite/gfortran.fortran-torture/compile"));
+        ignoredFolders.add(Paths.get("gcc-5.2.0/gcc/testsuite/objc/compile"));
+        ignoredFolders.add(Paths.get("gcc-5.2.0/gcc/testsuite/gcc.dg/noncompile"));
+
+        printStatistics("GCC", GCC_SOURCE_DIR, GCC_CONFIG_DIR, f -> !f.toString().contains("/compile/") && !f.toString().contains("/noncompile/"));
+
+        // gcc torture execute only
+        printStatistics("gcc.c-torture/execute", Paths.get(GCC_SOURCE_DIR.toAbsolutePath().toString() + "/gcc/testsuite/gcc.c-torture/execute"),
+                        Paths.get(GCC_CONFIG_DIR.toAbsolutePath().toString() + "/gcc.c-torture/execute"),
+                        t -> true);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/LLVMSuite.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/LLVMSuite.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Collection;
 
+import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -44,6 +45,7 @@ import com.oracle.truffle.llvm.runtime.options.LLVMOptions;
 public final class LLVMSuite extends BaseSuiteHarness {
 
     private static final Path LLVM_SUITE_DIR = new File(LLVMOptions.ENGINE.projectRoot() + "/../cache/tests/llvm").toPath();
+    private static final Path LLVM_SOURCE_DIR = new File(LLVMOptions.ENGINE.projectRoot() + "/../tests/llvm/test-suite-3.2.src/").toPath();
     private static final Path LLVM_CONFIG_DIR = new File(LLVMOptions.ENGINE.projectRoot() + "/../tests/llvm/configs").toPath();
 
     @Parameter(value = 0) public Path path;
@@ -64,4 +66,8 @@ public final class LLVMSuite extends BaseSuiteHarness {
         return LLVM_SUITE_DIR;
     }
 
+    @AfterClass
+    public static void printStatistics() {
+        printStatistics("LLVM", LLVM_SOURCE_DIR, LLVM_CONFIG_DIR, f -> true);
+    }
 }

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/NWCCSuite.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/NWCCSuite.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Collection;
 
+import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -44,6 +45,7 @@ import com.oracle.truffle.llvm.runtime.options.LLVMOptions;
 public final class NWCCSuite extends BaseSuiteHarness {
 
     private static final Path NWCC_SUITE_DIR = new File(LLVMOptions.ENGINE.projectRoot() + "/../cache/tests/nwcc").toPath();
+    private static final Path NWCC_SOURCE_DIR = new File(LLVMOptions.ENGINE.projectRoot() + "/../tests/nwcc/nwcc_0.8.3").toPath();
     private static final Path NWCC_CONFIG_DIR = new File(LLVMOptions.ENGINE.projectRoot() + "/../tests/nwcc/configs").toPath();
 
     @Parameter(value = 0) public Path path;
@@ -62,6 +64,11 @@ public final class NWCCSuite extends BaseSuiteHarness {
     @Override
     protected Path getSuiteDirectory() {
         return NWCC_SUITE_DIR;
+    }
+
+    @AfterClass
+    public static void printStatistics() {
+        printStatistics("NWCC", NWCC_SOURCE_DIR, NWCC_CONFIG_DIR, f -> true);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/SulongSuite.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/SulongSuite.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Collection;
 
+import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -44,6 +45,7 @@ import com.oracle.truffle.llvm.runtime.options.LLVMOptions;
 public final class SulongSuite extends BaseSuiteHarness {
 
     private static final Path SULONG_SUITE_DIR = new File(LLVMOptions.ENGINE.projectRoot() + "/../cache/tests/sulong").toPath();
+    private static final Path SULONG_SOURCE_DIR = new File(LLVMOptions.ENGINE.projectRoot() + "/../tests/sulong").toPath();
     private static final Path SULONG_CONFIG_DIR = new File(LLVMOptions.ENGINE.projectRoot() + "/../tests/sulong/configs").toPath();
 
     @Parameter(value = 0) public Path path;
@@ -64,4 +66,8 @@ public final class SulongSuite extends BaseSuiteHarness {
         return SULONG_SUITE_DIR;
     }
 
+    @AfterClass
+    public static void printStatistics() {
+        printStatistics("Sulong", SULONG_SOURCE_DIR, SULONG_CONFIG_DIR, f -> true);
+    }
 }


### PR DESCRIPTION
For example:

```
================================= Statistics for GCC suite ======================================
	FILE	|	ALL	|	RUNABLE	|	OK	|	OK/ALL	|	OK/RUNABLE	
===================================================================================================
	cc	|	114	|	8	|	1	|	0.9%	|	12.5%	
	cpp	|	15	|	14	|	0	|	0.0%	|	0.0%	
	c	|	21461	|	13399	|	2557	|	11.9%	|	19.1%	
	C	|	11289	|	2124	|	224	|	2.0%	|	10.5%	
	f	|	407	|	215	|	0	|	0.0%	|	0.0%	
	f03	|	430	|	148	|	0	|	0.0%	|	0.0%	
	f90	|	3813	|	1988	|	214	|	5.6%	|	10.8%	
	m	|	515	|	9	|	0	|	0.0%	|	0.0%	
---------------------------------------------------------------------------------------------------
	*.*	|	38044	|	17905	|	2996	|	7.9%	|	16.7%	
```