### PR TITLE
Fix Failing Tests in LifetimeAnalysis

### DIFF
--- a/mx.sulong/mx_testsuites.py
+++ b/mx.sulong/mx_testsuites.py
@@ -116,6 +116,7 @@ def runInlineAssemblySuite(vmArgs):
 
 def runLifetimeAnalysisTests(vmArgs):
     """runs the LTA test suite"""
+    mx_sulong.ensureDragonEggExists()
     compileSuite(['gcc'])
     ensureLifetimeAnalysisReferenceExists()
     return run(vmArgs, "com.oracle.truffle.llvm.test.alpha.LifetimeAnalysisSuite")

--- a/mx.sulong/suite.py
+++ b/mx.sulong/suite.py
@@ -68,11 +68,11 @@ suite = {
       "sha1" : "2ab1825dc1f8bd5258204bab19e8fafad93fef26",
     },
     "LTA_REF" : {
-      "path" : "tests/lifetime-analysis-ref.tar.gz",
+      "path" : "tests/lifetime-analysis-ref-2.tar.gz",
       "urls" : [
-        "https://lafo.ssw.uni-linz.ac.at/pub/sulong-deps/lifetime-analysis-ref.tar.gz",
+        "https://lafo.ssw.uni-linz.ac.at/pub/sulong-deps/lifetime-analysis-ref-2.tar.gz",
       ],
-      "sha1" : "8bb0cd644b0dc9ec2f3000ad9cac50e9432d4e17",
+      "sha1" : "2205ed25c2ba390f54b32f7d86927cbd69414be4",
     },
     "COCO" : {
       "urls" : [

--- a/mx.sulong/suite.py
+++ b/mx.sulong/suite.py
@@ -72,7 +72,7 @@ suite = {
       "urls" : [
         "https://lafo.ssw.uni-linz.ac.at/pub/sulong-deps/lifetime-analysis-ref-2.tar.gz",
       ],
-      "sha1" : "2205ed25c2ba390f54b32f7d86927cbd69414be4",
+      "sha1" : "7dc0cda1b644a9c27464cf5ad3780ffd92097aa3",
     },
     "COCO" : {
       "urls" : [

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/LifetimeAnalysisSuite.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/LifetimeAnalysisSuite.java
@@ -69,12 +69,9 @@ public final class LifetimeAnalysisSuite {
     // TODO: after migration of LTA tests to new infrastructure, these 44 tests fail.
     // See issue #598
     // Fix issue and remove this this hard-coded ignore list.
-    private static final String[] ignore = new String[]{"gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr47541.C",
+    private static final String[] ignore = new String[]{
                     "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr49644.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/pr15054-2.C",
                     "gcc-5.2.0/gcc/testsuite/g++.dg/opt/nrv14.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/pr17697-1.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/pr43655.C",
                     "gcc-5.2.0/gcc/testsuite/g++.dg/template/sfinae17.C",
                     "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr49039.C",
                     "gcc-5.2.0/gcc/testsuite/g++.dg/template/condition1.C",
@@ -160,7 +157,12 @@ public final class LifetimeAnalysisSuite {
     }
 
     private static Path getTestFile(Path folder) throws IOException {
-        List<Path> collect = Files.walk(folder).filter(p -> p.toString().endsWith("_O0.bc")).collect(Collectors.toList());
+        List<Path> collect = Files.walk(folder).filter(p -> {
+            final String s = p.toString();
+            // we only support files compiled with optimizations enabled since sulong does not
+            // support the invoke instruction for exception handling
+            return s.endsWith("_OPT.bc") || s.endsWith("gfortran_O0.bc");
+        }).collect(Collectors.toList());
         if (collect.size() != 1) {
             throw new AssertionError("Found " + collect.size() + " matching files in " + folder);
         }

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/LifetimeAnalysisSuite.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/LifetimeAnalysisSuite.java
@@ -33,7 +33,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -66,59 +65,9 @@ public final class LifetimeAnalysisSuite {
         return collectTestCases(GCC_CONFIG_DIR, GCC_SUITE_DIR, GCC_LTA_DIR, GCC_LTA_GEN_DIR);
     }
 
-    // TODO: after migration of LTA tests to new infrastructure, these 44 tests fail.
-    // See issue #598
-    // Fix issue and remove this this hard-coded ignore list.
-    private static final String[] ignore = new String[]{
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr49644.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/nrv14.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/template/sfinae17.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr49039.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/template/condition1.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr37922.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/pr6713.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr42462.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/pr36187.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr40924.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/nrv6.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/pr16372-1.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/expect1.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/template/array25.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr40335.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr44069.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/range-test-2.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/template/partial10.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/pr7503-1.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/cond1.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr56837.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr30567.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr50189.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/strength-reduce.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/range-test-1.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr35634.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr59163.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/20100825.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/fold2.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/pr14029.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/dtor4.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/dtor1.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/template/explicit-args4.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/template/repo9.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/nrv13.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/bool1.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/opt/pr30590.C",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/torture/pr37146-2.C",
-                    "gcc-5.2.0/gcc/testsuite/gfortran.fortran-torture/execute/integer_select.f90",
-                    "gcc-5.2.0/gcc/testsuite/g++.dg/template/pretty1.C",
-                    "gcc-5.2.0/gcc/testsuite/gfortran.fortran-torture/execute/transfer2.f90"};
-    private final List<String> ignoreList = Arrays.asList(ignore);
-
     @Test
     public void test() throws Exception {
         try {
-            if (ignoreList.contains(testName)) {
-                return;
-            }
             LifetimeAnalysisTest.test(bcFile, ltaFile, ltaGenFile);
         } catch (Throwable e) {
             throw new AssertionError(e);

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/LifetimeAnalysisTest.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/alpha/LifetimeAnalysisTest.java
@@ -30,6 +30,7 @@
 package com.oracle.truffle.llvm.test.alpha;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -71,7 +72,16 @@ public final class LifetimeAnalysisTest {
         Map<String, LLVMLifetimeAnalysis> referenceResults = null;
         BufferedReader referenceFileReader;
         if (SulongTestOptions.TEST.generateLifetimeReferenceOutput()) {
-            fileWriter = new LifetimeFileFormat.Writer(new PrintStream(ltaGenDir.toFile()));
+            final File ltaGenDirFile = ltaGenDir.toFile();
+            if (!ltaGenDirFile.exists()) {
+                // noinspection ResultOfMethodCallIgnored
+                ltaGenDirFile.getParentFile().mkdirs();
+                final boolean fileCreated = ltaGenDirFile.createNewFile();
+                if (!fileCreated) {
+                    throw new AssertionError();
+                }
+            }
+            fileWriter = new LifetimeFileFormat.Writer(new PrintStream(ltaGenDirFile));
         } else {
             fileWriter = null;
             FileInputStream fis = new FileInputStream(ltaFile.toFile());


### PR DESCRIPTION
Closes #598.

There were two reasons for tests failing:
- Some tests used the 'invoke' instruction that is, as of yet, not supported by sulong. We solve this by only running the Lifetime Tests against files compiled with optimizations enabled.
- Some tests fail because the internal naming scheme of the new parser is different to that of the old one.

Both cases require that we rebuild the reference results.