### PR TITLE
Update graal and truffle import revisions

### DIFF
--- a/mx.sulong/suite.py
+++ b/mx.sulong/suite.py
@@ -7,7 +7,7 @@ suite = {
     "suites" : [
       {
         "name" : "truffle",
-        "version" : "8e9d13ac45286e4b4462c90b13e6eb9cdf2ff357",
+        "version" : "3895ff0232bbac9d1dfc8eac962906b5e73f6ece",
         "urls" : [
           {"url" : "https://github.com/graalvm/truffle", "kind" : "git"},
           {"url" : "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind" : "binary"},
@@ -15,7 +15,7 @@ suite = {
       },
       {
         "name" : "graal-core",
-        "version" : "31b94210b0282691e20a9d55a061089c7aad0c64",
+        "version" : "87b6ac064e1497442ac0e3125e31496fff517791",
         "urls" : [
           {"url" : "https://github.com/graalvm/graal-core", "kind" : "git"},
           {"url" : "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind" : "binary"},

--- a/projects/com.oracle.truffle.llvm.context/src/com/oracle/truffle/llvm/context/nativeint/NativeLookup.java
+++ b/projects/com.oracle.truffle.llvm.context/src/com/oracle/truffle/llvm/context/nativeint/NativeLookup.java
@@ -36,9 +36,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.WeakHashMap;
 
-import com.oracle.graal.truffle.hotspot.nfi.HotSpotNativeFunctionInterface;
-import com.oracle.graal.truffle.hotspot.nfi.HotSpotNativeFunctionPointer;
-import com.oracle.graal.truffle.hotspot.nfi.HotSpotNativeLibraryHandle;
 import com.oracle.nfi.NativeFunctionInterfaceRuntime;
 import com.oracle.nfi.api.NativeFunctionHandle;
 import com.oracle.nfi.api.NativeFunctionInterface;
@@ -52,6 +49,9 @@ import com.oracle.truffle.llvm.runtime.LLVMUnsupportedException.UnsupportedReaso
 import com.oracle.truffle.llvm.runtime.options.LLVMOptions;
 import com.oracle.truffle.llvm.types.LLVMFunction;
 import com.oracle.truffle.llvm.types.LLVMFunctionDescriptor.LLVMRuntimeType;
+import org.graalvm.compiler.truffle.hotspot.nfi.HotSpotNativeFunctionInterface;
+import org.graalvm.compiler.truffle.hotspot.nfi.HotSpotNativeFunctionPointer;
+import org.graalvm.compiler.truffle.hotspot.nfi.HotSpotNativeLibraryHandle;
 
 public class NativeLookup {
 


### PR DESCRIPTION
This is pulling in the rename from `com.oracle.graal` to `org.graalvm.compiler`, but there were only a few import fixes necessary.