### PR TITLE
Add LLVM 3.9.0 bitcode format support to a bitcode parser - Part #1

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/bc/Parser.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/bc/Parser.java
@@ -152,7 +152,7 @@ public class Parser {
         return new Parser(argStream, argBlock, argListener, argParent, argOperations, argIdSize, argOffset);
     }
 
-    private Parser alignInt() {
+    public Parser alignInt() {
         long mask = Integer.SIZE - 1;
         if ((offset & mask) != 0) {
             return offset((offset & ~mask) + Integer.SIZE);

--- a/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/bc/records/UserRecordBinaryOperand.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/bc/records/UserRecordBinaryOperand.java
@@ -31,6 +31,7 @@ package com.oracle.truffle.llvm.parser.bc.parser.bc.records;
 
 import com.oracle.truffle.llvm.parser.bc.parser.bc.Parser;
 import com.oracle.truffle.llvm.parser.bc.parser.bc.ParserResult;
+import com.oracle.truffle.llvm.parser.bc.parser.bc.Primitive;
 
 public final class UserRecordBinaryOperand extends UserRecordOperand {
 
@@ -40,7 +41,11 @@ public final class UserRecordBinaryOperand extends UserRecordOperand {
 
     @Override
     protected ParserResult get(Parser parser) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        ParserResult result = parser.read(Primitive.USER_OPERAND_BLOB_LENGTH);
+        long value = result.getValue();
+        Parser blobParser = result.getParser().alignInt();
+        result = blobParser.read(Primitive.USER_OPERAND_LITERAL.getBits() * value);
+        return result;
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/ir/module/records/MetadataRecord.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/ir/module/records/MetadataRecord.java
@@ -64,7 +64,9 @@ public enum MetadataRecord {
     IMPORTED_ENTITY,
     MODULE,
     MACRO,
-    MACRO_FILE;
+    MACRO_FILE,
+    STRINGS,
+    GLOBAL_DECL_ATTACHMENT;
 
     public static MetadataRecord decode(long id) {
         return values()[(int) id];

--- a/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/ir/module/records/ModuleRecord.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/ir/module/records/ModuleRecord.java
@@ -45,7 +45,10 @@ public enum ModuleRecord {
     COMDAT,
     VSTOFFSET,
     ALIAS,
-    METADATA_VALUES;
+    METADATA_VALUES,
+    SOURCE_FILENAME,
+    CODE_HASH,
+    CODE_IFUNC;
 
     public static ModuleRecord decode(long id) {
         return values()[(int) id];

--- a/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/listeners/ModuleVersion.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/listeners/ModuleVersion.java
@@ -38,15 +38,19 @@ import com.oracle.truffle.llvm.parser.api.model.generators.SymbolGenerator;
 import com.oracle.truffle.llvm.parser.bc.parser.listeners.constants.Constants;
 import com.oracle.truffle.llvm.parser.bc.parser.listeners.constants.ConstantsV32;
 import com.oracle.truffle.llvm.parser.bc.parser.listeners.constants.ConstantsV38;
+import com.oracle.truffle.llvm.parser.bc.parser.listeners.constants.ConstantsV39;
 import com.oracle.truffle.llvm.parser.bc.parser.listeners.function.Function;
 import com.oracle.truffle.llvm.parser.bc.parser.listeners.function.FunctionV32;
 import com.oracle.truffle.llvm.parser.bc.parser.listeners.function.FunctionV38;
+import com.oracle.truffle.llvm.parser.bc.parser.listeners.function.FunctionV39;
 import com.oracle.truffle.llvm.parser.bc.parser.listeners.metadata.Metadata;
 import com.oracle.truffle.llvm.parser.bc.parser.listeners.metadata.MetadataV32;
 import com.oracle.truffle.llvm.parser.bc.parser.listeners.metadata.MetadataV38;
+import com.oracle.truffle.llvm.parser.bc.parser.listeners.metadata.MetadataV39;
 import com.oracle.truffle.llvm.parser.bc.parser.listeners.module.Module;
 import com.oracle.truffle.llvm.parser.bc.parser.listeners.module.ModuleV32;
 import com.oracle.truffle.llvm.parser.bc.parser.listeners.module.ModuleV38;
+import com.oracle.truffle.llvm.parser.bc.parser.listeners.module.ModuleV39;
 import com.oracle.truffle.llvm.runtime.LLVMLogger;
 import com.oracle.truffle.llvm.runtime.types.Type;
 
@@ -54,6 +58,7 @@ public enum ModuleVersion {
 
     LLVM_3_2(ModuleV32::new, FunctionV32::new, ConstantsV32::new, MetadataV32::new),
     LLVM_3_8(ModuleV38::new, FunctionV38::new, ConstantsV38::new, MetadataV38::new),
+    LLVM_3_9(ModuleV39::new, FunctionV39::new, ConstantsV39::new, MetadataV39::new),
     DEFAULT(Module::new, Function::new, Constants::new, Metadata::new);
 
     @FunctionalInterface
@@ -100,6 +105,8 @@ public enum ModuleVersion {
             return LLVM_3_2;
         } else if (versionStr.contains("3.8")) {
             return LLVM_3_8;
+        } else if (versionStr.contains("3.9")) {
+            return LLVM_3_9;
         } else {
             LLVMLogger.unconditionalInfo("Couldn't parse LLVM Version, use default one");
             return DEFAULT;

--- a/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/listeners/constants/ConstantsV39.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/listeners/constants/ConstantsV39.java
@@ -27,44 +27,17 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.oracle.truffle.llvm.parser.bc.parser.bc;
+package com.oracle.truffle.llvm.parser.bc.parser.listeners.constants;
 
-public enum Primitive {
-    ALIGNMENT(true, Integer.SIZE),
-    DEAFULT_ID(true, 6),
-    CHAR6(true, 6),
+import com.oracle.truffle.llvm.parser.api.model.generators.ConstantGenerator;
+import com.oracle.truffle.llvm.runtime.types.Type;
+import com.oracle.truffle.llvm.parser.bc.parser.listeners.Types;
 
-    ABBREVIATED_RECORD_OPERANDS(false, 5),
-    SUBBLOCK_ID(false, 8),
-    SUBBLOCK_ID_SIZE(false, 4),
-    UNABBREVIATED_RECORD_ID(false, 6),
-    UNABBREVIATED_RECORD_OPERAND(false, 6),
-    UNABBREVIATED_RECORD_OPS(false, 6),
+import java.util.List;
 
-    USER_OPERAND_ARRAY_LENGTH(false, 6),
-    USER_OPERAND_BLOB_LENGTH(false, 6),
-    USER_OPERAND_DATA(false, 5),
-    USER_OPERAND_LITERAL(false, 8),
-    USER_OPERAND_TYPE(true, 3);
+public class ConstantsV39 extends Constants {
 
-    private final boolean isFixed;
-
-    private final int bits;
-
-    Primitive(boolean isFixed, int bits) {
-        this.isFixed = isFixed;
-        this.bits = bits;
-    }
-
-    public int getBits() {
-        return bits;
-    }
-
-    public boolean isFixed() {
-        return isFixed;
-    }
-
-    public boolean isVariableBitRate() {
-        return !isFixed();
+    public ConstantsV39(Types types, List<Type> symbols, ConstantGenerator generator) {
+        super(types, symbols, generator);
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/listeners/function/FunctionV39.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/listeners/function/FunctionV39.java
@@ -27,44 +27,18 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.oracle.truffle.llvm.parser.bc.parser.bc;
+package com.oracle.truffle.llvm.parser.bc.parser.listeners.function;
 
-public enum Primitive {
-    ALIGNMENT(true, Integer.SIZE),
-    DEAFULT_ID(true, 6),
-    CHAR6(true, 6),
+import com.oracle.truffle.llvm.parser.api.model.generators.FunctionGenerator;
+import com.oracle.truffle.llvm.runtime.types.Type;
+import com.oracle.truffle.llvm.parser.bc.parser.listeners.ModuleVersion;
+import com.oracle.truffle.llvm.parser.bc.parser.listeners.Types;
 
-    ABBREVIATED_RECORD_OPERANDS(false, 5),
-    SUBBLOCK_ID(false, 8),
-    SUBBLOCK_ID_SIZE(false, 4),
-    UNABBREVIATED_RECORD_ID(false, 6),
-    UNABBREVIATED_RECORD_OPERAND(false, 6),
-    UNABBREVIATED_RECORD_OPS(false, 6),
+import java.util.List;
 
-    USER_OPERAND_ARRAY_LENGTH(false, 6),
-    USER_OPERAND_BLOB_LENGTH(false, 6),
-    USER_OPERAND_DATA(false, 5),
-    USER_OPERAND_LITERAL(false, 8),
-    USER_OPERAND_TYPE(true, 3);
+public class FunctionV39 extends Function {
 
-    private final boolean isFixed;
-
-    private final int bits;
-
-    Primitive(boolean isFixed, int bits) {
-        this.isFixed = isFixed;
-        this.bits = bits;
-    }
-
-    public int getBits() {
-        return bits;
-    }
-
-    public boolean isFixed() {
-        return isFixed;
-    }
-
-    public boolean isVariableBitRate() {
-        return !isFixed();
+    public FunctionV39(ModuleVersion version, Types types, List<Type> symbols, FunctionGenerator generator, int mode) {
+        super(version, types, symbols, generator, mode);
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/listeners/metadata/MetadataV39.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/listeners/metadata/MetadataV39.java
@@ -27,44 +27,16 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.oracle.truffle.llvm.parser.bc.parser.bc;
+package com.oracle.truffle.llvm.parser.bc.parser.listeners.metadata;
 
-public enum Primitive {
-    ALIGNMENT(true, Integer.SIZE),
-    DEAFULT_ID(true, 6),
-    CHAR6(true, 6),
+import com.oracle.truffle.llvm.parser.api.model.generators.SymbolGenerator;
+import com.oracle.truffle.llvm.runtime.types.Type;
+import com.oracle.truffle.llvm.parser.bc.parser.listeners.Types;
 
-    ABBREVIATED_RECORD_OPERANDS(false, 5),
-    SUBBLOCK_ID(false, 8),
-    SUBBLOCK_ID_SIZE(false, 4),
-    UNABBREVIATED_RECORD_ID(false, 6),
-    UNABBREVIATED_RECORD_OPERAND(false, 6),
-    UNABBREVIATED_RECORD_OPS(false, 6),
+import java.util.List;
 
-    USER_OPERAND_ARRAY_LENGTH(false, 6),
-    USER_OPERAND_BLOB_LENGTH(false, 6),
-    USER_OPERAND_DATA(false, 5),
-    USER_OPERAND_LITERAL(false, 8),
-    USER_OPERAND_TYPE(true, 3);
-
-    private final boolean isFixed;
-
-    private final int bits;
-
-    Primitive(boolean isFixed, int bits) {
-        this.isFixed = isFixed;
-        this.bits = bits;
-    }
-
-    public int getBits() {
-        return bits;
-    }
-
-    public boolean isFixed() {
-        return isFixed;
-    }
-
-    public boolean isVariableBitRate() {
-        return !isFixed();
+public class MetadataV39 extends Metadata {
+    public MetadataV39(Types types, List<Type> symbols, SymbolGenerator generator) {
+        super(types, symbols, generator);
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/listeners/module/Module.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/listeners/module/Module.java
@@ -144,6 +144,7 @@ public class Module implements ParserListener {
                 createFunction(args);
                 break;
 
+            case ALIAS:
             case ALIAS_OLD:
                 createAliasOld(args);
                 break;

--- a/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/listeners/module/ModuleV39.java
+++ b/projects/com.oracle.truffle.llvm.parser.bc/src/com/oracle/truffle/llvm/parser/bc/parser/listeners/module/ModuleV39.java
@@ -27,44 +27,14 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.oracle.truffle.llvm.parser.bc.parser.bc;
+package com.oracle.truffle.llvm.parser.bc.parser.listeners.module;
 
-public enum Primitive {
-    ALIGNMENT(true, Integer.SIZE),
-    DEAFULT_ID(true, 6),
-    CHAR6(true, 6),
+import com.oracle.truffle.llvm.parser.api.model.generators.ModuleGenerator;
+import com.oracle.truffle.llvm.parser.bc.parser.listeners.ModuleVersion;
 
-    ABBREVIATED_RECORD_OPERANDS(false, 5),
-    SUBBLOCK_ID(false, 8),
-    SUBBLOCK_ID_SIZE(false, 4),
-    UNABBREVIATED_RECORD_ID(false, 6),
-    UNABBREVIATED_RECORD_OPERAND(false, 6),
-    UNABBREVIATED_RECORD_OPS(false, 6),
+public class ModuleV39 extends Module {
 
-    USER_OPERAND_ARRAY_LENGTH(false, 6),
-    USER_OPERAND_BLOB_LENGTH(false, 6),
-    USER_OPERAND_DATA(false, 5),
-    USER_OPERAND_LITERAL(false, 8),
-    USER_OPERAND_TYPE(true, 3);
-
-    private final boolean isFixed;
-
-    private final int bits;
-
-    Primitive(boolean isFixed, int bits) {
-        this.isFixed = isFixed;
-        this.bits = bits;
-    }
-
-    public int getBits() {
-        return bits;
-    }
-
-    public boolean isFixed() {
-        return isFixed;
-    }
-
-    public boolean isVariableBitRate() {
-        return !isFixed();
+    public ModuleV39(ModuleVersion version, ModuleGenerator generator) {
+        super(version, generator);
     }
 }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/Type.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/Type.java
@@ -78,14 +78,11 @@ public interface Type {
     }
 
     static int getPadding(int offset, int alignment) {
-        if (alignment == 0) {
-            throw new AssertionError();
-        }
-        return (alignment - (offset % alignment)) % alignment;
+        return alignment == 0 ? 0 : (alignment - (offset % alignment)) % alignment;
     }
 
     static int getPadding(int offset, Type type, DataSpecConverter targetDataLayout) {
         final int alignment = type.getAlignment(targetDataLayout);
-        return alignment == 0 ? 0 : getPadding(offset, alignment);
+        return getPadding(offset, alignment);
     }
 }


### PR DESCRIPTION
This PR contains the first set of changes to add support for LLVM bitcode format 3.9.0 to LLVM bitcode parser.
- This version is currently passing all the tests (134/134) out of `llvm` benchmark suite. They are tested by manually generating `.bc` files with a new version and comparing with the references output generated with existing LLVM version (3.3). Rest of the tests are not executed yet.

Following changes are made to add support for LLVM 3.9.0
- Boilerplate code and classes to handle version 3.9.0 (includes *V39 classes)
- New bitcode types types in LLVM 3.9.0 (can be seen in updates to enums storing bitcode types)
- Support for processing information stored in BLOB data type in a bitcode file. Metadata about clang version is stored in this blob format. e.g. extracted from a `.ll` file
```
!llvm.ident = !{!0}
!0 = !{!"clang version 3.9.0 (tags/RELEASE_390/final)"}
```
- Updated handling of padding for 128 bit integer types. This is required for `tests/llvm/test-suite-3.2.src/SingleSource/Regression/C/PR1386.c` where 
```
struct X {
  unsigned char pad : 4;
  uint64_t a : 64;
  uint64_t b : 60;
} __attribute__((packed));
```
 is represented as `%struct.X = type { i128 }` in bitcode file.
- Version 3.9.0 does not specify supported sizes of integer and floats explicitly in datalayout string as in version 3.2.0. e.g. datalayout string in
Version **3.2.0**:  `e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128`
Version **3.9.0**: `e-m:e-i64:64-f80:128-n8:16:32:64-S128`
Therefore mechanism to add missing (explicitly) data types is added.
- Currently `addIfMissing` function added to avoid duplication as currently supported version 3.2.0 specifies explicitly. However, this can be removed after switching to version 3.9.0 completely. Even now it can be removed as duplicate specifications would be added at the end of the list and we scan the list from the beginning whenever used.
- Changes to the datalayout processing are roughly based on the information at http://llvm.org/pre-releases/3.9.0/rc2/docs/LangRef.html#data-layout

Kindly provide suggestions on,
- changed handling of datalayout processing
- wherever code can be made elegant
- whether you would like to create a separate branch for the changes related to add support for version 3.9.0. This may require changes to build script to support testing both the versions. 
- LLVM bitcode 3.9.0 format file  also provides information about the version in the beginning of the file in IDENTIFICATION_BLOCK. This could be used to switch to bitcode parser for version 3.9.0. (can be seen by `llvm-bcanalyzer -dump <filename>.bc`  ). Would you like to have this feature? It is applicable for version 3.8.0 as well.