### PR TITLE
Change some toString to getIrString method, to be clear about it's behaviour

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/enums/Flag.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/enums/Flag.java
@@ -42,12 +42,12 @@ public enum Flag {
     FP_ALLOW_RECIPROCAL("arcp", 16),
     FP_FAST("fast", 31);
 
-    private final String name;
+    private final String irString;
 
     private final int mask;
 
-    Flag(String name, int mask) {
-        this.name = name;
+    Flag(String irString, int mask) {
+        this.irString = irString;
         this.mask = mask;
     }
 
@@ -55,9 +55,8 @@ public enum Flag {
         return (flags & mask) == mask;
     }
 
-    @Override
-    public String toString() {
-        return name;
+    public String getIrString() {
+        return irString;
     }
 
     /*

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/enums/Linkage.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/enums/Linkage.java
@@ -70,8 +70,7 @@ public enum Linkage {
         return EXTERNAL;
     }
 
-    @Override
-    public String toString() {
+    public String getIrString() {
         return irString;
     }
 }


### PR DESCRIPTION
```toString()``` should not be used to output the LLVM IR name of the entry, so I changed it to the ```getIrString``` method which is also used for the other enums