### PR TITLE
Fix su-pulldragonegg to either use LLVM-3.2 or LLVM-3.3

### DIFF
--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -256,7 +256,7 @@ def pullInstallDragonEgg(args=None):
     os.environ['CXX'] = getGPP()
     os.environ['CC'] = getGCC()
     pullLLVMBinaries()
-    os.environ['LLVM_CONFIG'] = findLLVMProgram('llvm-config')
+    os.environ['LLVM_CONFIG'] = findLLVMProgram('llvm-config', ['3.2', '3.3'])
     mx.log(os.environ['LLVM_CONFIG'])
     compileCommand = ['make']
     return mx.run(compileCommand, cwd=_toolDir + 'dragonegg/dragonegg-3.2.src')


### PR DESCRIPTION
Otherwise, the command would fail when there is LLVM-3.8 or greater
installed on the system