### PR TITLE
Small Bitcode Parser Fixes

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMModelVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMModelVisitor.java
@@ -39,6 +39,7 @@ import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.nodes.NodeUtil;
 import com.oracle.truffle.api.nodes.RootNode;
+import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 import com.oracle.truffle.llvm.nodes.api.LLVMExpressionNode;
 import com.oracle.truffle.llvm.parser.model.functions.FunctionDeclaration;
@@ -94,7 +95,9 @@ final class LLVMModelVisitor implements ModelVisitor {
         LLVMExpressionNode[] beforeFunction = parameters.toArray(new LLVMExpressionNode[parameters.size()]);
         LLVMExpressionNode[] afterFunction = new LLVMExpressionNode[0];
 
-        final SourceSection sourceSection = visitor.getSource().createSection(1);
+        final String sourceText = String.format("%s:%s", visitor.getSource().getName(), method.getName());
+        final Source irSource = Source.newBuilder(sourceText).mimeType("text/plain").name(sourceText).build();
+        final SourceSection sourceSection = irSource.createSection(1);
         RootNode rootNode = visitor.getNodeFactoryFacade().createFunctionStartNode(visitor, body, beforeFunction, afterFunction, sourceSection, frame, method);
 
         final String astPrintTarget = LLVMOptions.DEBUG.printFunctionASTs();


### PR DESCRIPTION
Implement Sulong SourceSections with the content <filename>:<functionname> rather than trying to interpret bitcode as strings.