### PR TITLE
Update Travis Build Environment to Trusty and add libc++

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 cache:
   directories:
   - cache/tools
+dist: trusty
 sudo: required
 language: java
 python:
@@ -19,6 +20,10 @@ addons:
     - clang-format-3.4
     - gobjc++-4.6
     - gcc-4.6-plugin-dev
+    - libc++1
+    - libc++abi1
+    - libc++-dev
+    - libc++abi-dev
 install:
   - export MX_BINARY_SUITES="jvmci"
   - gem install mdl


### PR DESCRIPTION
We update to the Ubuntu 14.04 Travis Environment since libc++, which is required since c++ support was added, is not available under Ubuntu 12.04.