### PR TITLE
Fix Parsing Type of Global Alias

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/module/ModuleVersionHelper.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/module/ModuleVersionHelper.java
@@ -29,46 +29,26 @@
  */
 package com.oracle.truffle.llvm.parser.listeners.module;
 
-import com.oracle.truffle.llvm.parser.model.enums.Visibility;
 import com.oracle.truffle.llvm.runtime.types.FunctionType;
 import com.oracle.truffle.llvm.runtime.types.PointerType;
 import com.oracle.truffle.llvm.runtime.types.Type;
 
 public abstract class ModuleVersionHelper {
 
-    public abstract void createFunction(Module m, long[] args);
+    public abstract Type getGlobalType(Module m, long typeIndex);
 
-    public abstract void createGlobalVariable(Module m, long[] args);
+    public abstract FunctionType getFunctionType(Module m, long typeIndex);
 
     public static final class ModuleV32 extends ModuleVersionHelper {
 
         @Override
-        public void createFunction(Module m, long[] args) {
-            FunctionType type = (FunctionType) ((PointerType) m.types.get(args[0])).getPointeeType();
-            boolean isPrototype = args[2] != 0;
-
-            m.generator.createFunction(type, isPrototype);
-            m.symbols.add(type);
-            if (!isPrototype) {
-                m.functions.add(type);
-            }
+        public Type getGlobalType(Module m, long typeIndex) {
+            return m.types.get(typeIndex);
         }
 
         @Override
-        public void createGlobalVariable(Module m, long[] args) {
-            Type type = m.types.get(args[0]);
-            boolean isConstant = (args[1] & 1) == 1;
-            int initialiser = (int) args[2];
-            long linkage = args[3];
-            int align = (int) args[4];
-
-            long visibility = Visibility.DEFAULT.getEncodedValue();
-            if (args.length >= 7) {
-                visibility = args[6];
-            }
-
-            m.generator.createGlobal(type, isConstant, initialiser, align, linkage, visibility);
-            m.symbols.add(type);
+        public FunctionType getFunctionType(Module m, long typeIndex) {
+            return (FunctionType) ((PointerType) m.types.get(typeIndex)).getPointeeType();
         }
 
     }
@@ -76,32 +56,13 @@ public abstract class ModuleVersionHelper {
     public static final class ModuleV38 extends ModuleVersionHelper {
 
         @Override
-        public void createFunction(Module m, long[] args) {
-            FunctionType type = (FunctionType) m.types.get(args[0]);
-            boolean isPrototype = args[2] != 0;
-
-            m.generator.createFunction(type, isPrototype);
-            m.symbols.add(type);
-            if (!isPrototype) {
-                m.functions.add(type);
-            }
+        public Type getGlobalType(Module m, long typeIndex) {
+            return new PointerType(m.types.get(typeIndex));
         }
 
         @Override
-        public void createGlobalVariable(Module m, long[] args) {
-            Type type = new PointerType(m.types.get(args[0]));
-            boolean isConstant = (args[1] & 1) == 1;
-            int initialiser = (int) args[2];
-            long linkage = args[3];
-            int align = (int) args[4];
-
-            long visibility = Visibility.DEFAULT.getEncodedValue();
-            if (args.length >= 7) {
-                visibility = args[6];
-            }
-
-            m.generator.createGlobal(type, isConstant, initialiser, align, linkage, visibility);
-            m.symbols.add(type);
+        public FunctionType getFunctionType(Module m, long typeIndex) {
+            return (FunctionType) m.types.get(typeIndex);
         }
 
     }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/globals/GlobalAlias.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/globals/GlobalAlias.java
@@ -38,7 +38,7 @@ public final class GlobalAlias extends GlobalValueSymbol {
 
     private static final int ALIGN = 0;
 
-    public GlobalAlias(Type type, int aliasedValue, Linkage linkage, Visibility visibility) {
+    private GlobalAlias(Type type, int aliasedValue, Linkage linkage, Visibility visibility) {
         super(type, aliasedValue, ALIGN, linkage, visibility);
     }
 


### PR DESCRIPTION
In LLVM 3.8 and later the type of all globals is pointer.