### PR TITLE
Fix names of global variables when there is no special name attached to it

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/ModelModule.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/ModelModule.java
@@ -60,6 +60,7 @@ import com.oracle.truffle.llvm.parser.model.visitors.ModelVisitor;
 import com.oracle.truffle.llvm.runtime.types.FunctionType;
 import com.oracle.truffle.llvm.runtime.types.Type;
 import com.oracle.truffle.llvm.parser.metadata.MetadataList;
+import com.oracle.truffle.llvm.runtime.types.symbols.LLVMIdentifier;
 import com.oracle.truffle.llvm.runtime.types.symbols.Symbol;
 
 public final class ModelModule implements ModuleGenerator {
@@ -219,7 +220,12 @@ public final class ModelModule implements ModuleGenerator {
 
     @Override
     public void exitModule() {
+        int globalIndex = 0;
         for (GlobalValueSymbol variable : globals) {
+            if (variable.getName().equals(LLVMIdentifier.UNKNOWN)) {
+                variable.setName(String.valueOf(globalIndex++));
+            }
+
             variable.initialise(symbols);
         }
     }


### PR DESCRIPTION
As it was done for the name of unnamed instructions, global variables with no attached name have an implicit name based on their ordering.