### PR TITLE
Use binary version identifiers instead of textual

### DIFF
--- a/mx.sulong/mx_testsuites.py
+++ b/mx.sulong/mx_testsuites.py
@@ -77,10 +77,10 @@ def run(vmArgs, unittest, versionFolder, extraOption=None):
         return mx_unittest.unittest(command)
 
 def run32(vmArgs, unittest, extraOption=None):
-    run(vmArgs + ['-Dsulong.LLVM=3.2'], unittest, 'v32', extraOption)
+    run(vmArgs, unittest, 'v32', extraOption)
 
 def run38(vmArgs, unittest, extraOption=None):
-    run(vmArgs + ['-Dsulong.LLVM=3.8'], unittest, 'v38', extraOption)
+    run(vmArgs, unittest, 'v38', extraOption)
 
 def runSulongSuite(vmArgs):
     """runs the Sulong test suite"""

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Identification.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Identification.java
@@ -29,22 +29,10 @@
  */
 package com.oracle.truffle.llvm.parser.listeners;
 
-import com.oracle.truffle.llvm.parser.records.Records;
-
 public final class Identification implements ParserListener {
-
-    private final IRVersionController versionController;
-
-    public Identification(IRVersionController versionController) {
-        this.versionController = versionController;
-    }
 
     @Override
     public void record(long id, long[] args) {
-        if (id == 1) {
-            String version = Records.toString(args);
-            versionController.setVersion(version);
-        }
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/constants/ConstantsVersion.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/constants/ConstantsVersion.java
@@ -37,9 +37,9 @@ import com.oracle.truffle.llvm.runtime.types.Type;
 
 public final class ConstantsVersion {
 
-    public static class ConstantsV32 extends Constants {
+    public static class ConstantsV1 extends Constants {
 
-        public ConstantsV32(Types types, List<Type> symbols, ConstantGenerator generator) {
+        public ConstantsV1(Types types, List<Type> symbols, ConstantGenerator generator) {
             super(types, symbols, generator);
         }
 
@@ -56,9 +56,9 @@ public final class ConstantsVersion {
 
     }
 
-    public static class ConstantsV38 extends Constants {
+    public static class ConstantsV2 extends Constants {
 
-        public ConstantsV38(Types types, List<Type> symbols, ConstantGenerator generator) {
+        public ConstantsV2(Types types, List<Type> symbols, ConstantGenerator generator) {
             super(types, symbols, generator);
         }
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/function/FunctionVersion.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/function/FunctionVersion.java
@@ -42,8 +42,8 @@ import com.oracle.truffle.llvm.runtime.types.VoidType;
 
 public final class FunctionVersion {
 
-    public static class FunctionV38 extends Function {
-        public FunctionV38(IRVersionController version, Types types, List<Type> symbols, FunctionGenerator generator, int mode) {
+    public static class FunctionV2 extends Function {
+        public FunctionV2(IRVersionController version, Types types, List<Type> symbols, FunctionGenerator generator, int mode) {
             super(version, types, symbols, generator, mode);
         }
 
@@ -175,9 +175,9 @@ public final class FunctionVersion {
 
     }
 
-    public static class FunctionV32 extends Function {
+    public static class FunctionV1 extends Function {
 
-        public FunctionV32(IRVersionController version, Types types, List<Type> symbols, FunctionGenerator generator, int mode) {
+        public FunctionV1(IRVersionController version, Types types, List<Type> symbols, FunctionGenerator generator, int mode) {
             super(version, types, symbols, generator, mode);
         }
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/metadata/MetadataVersion.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/metadata/MetadataVersion.java
@@ -61,9 +61,9 @@ import com.oracle.truffle.llvm.runtime.types.metadata.MetadataTemplateTypeParame
 
 public final class MetadataVersion {
 
-    public static final class MetadataV38 extends Metadata {
+    public static final class MetadataV2 extends Metadata {
 
-        public MetadataV38(Types types, List<Type> symbols, SymbolGenerator generator) {
+        public MetadataV2(Types types, List<Type> symbols, SymbolGenerator generator) {
             super(types, symbols, generator);
         }
 
@@ -81,9 +81,9 @@ public final class MetadataVersion {
 
     }
 
-    public static final class MetadataV32 extends Metadata {
+    public static final class MetadataV1 extends Metadata {
 
-        public MetadataV32(Types types, List<Type> symbols, SymbolGenerator generator) {
+        public MetadataV1(Types types, List<Type> symbols, SymbolGenerator generator) {
             super(types, symbols, generator);
         }
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/module/Module.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/module/Module.java
@@ -145,8 +145,9 @@ public final class Module implements ParserListener {
 
                 return version.createFunction(types, sym, gen, mode);
             }
+
             case IDENTIFICATION:
-                return new Identification(version);
+                return new Identification();
 
             case TYPE:
                 return types;
@@ -174,6 +175,7 @@ public final class Module implements ParserListener {
         switch (record) {
             case VERSION:
                 mode = (int) args[0];
+                version.setVersion(mode);
                 break;
 
             case TARGET_TRIPLE:

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/module/ModuleVersionHelper.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/module/ModuleVersionHelper.java
@@ -39,7 +39,7 @@ public abstract class ModuleVersionHelper {
 
     public abstract FunctionType getFunctionType(Module m, long typeIndex);
 
-    public static final class ModuleV32 extends ModuleVersionHelper {
+    public static final class ModuleV1 extends ModuleVersionHelper {
 
         @Override
         public Type getGlobalType(Module m, long typeIndex) {
@@ -53,7 +53,7 @@ public abstract class ModuleVersionHelper {
 
     }
 
-    public static final class ModuleV38 extends ModuleVersionHelper {
+    public static final class ModuleV2 extends ModuleVersionHelper {
 
         @Override
         public Type getGlobalType(Module m, long typeIndex) {

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/options/SulongEngineOption.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/options/SulongEngineOption.java
@@ -36,9 +36,6 @@ import com.oracle.truffle.llvm.option.OptionCategory;
 @OptionCategory(name = "Base Options")
 abstract class SulongEngineOption {
 
-    @Option(commandLineName = "LLVM", help = "Version of the used LLVM File Format, e.g., 3.2 (default) or 3.8.", name = "llvmVersion") //
-    protected static final String LLVM_VERSION = "3.2";
-
     @Option(commandLineName = "NodeConfiguration", help = "The node configuration (node factory) to be used in Sulong.", name = "nodeConfiguration") //
     protected static final String NODE_CONFIGURATION = "default";
 


### PR DESCRIPTION
Hello!
I'm proposing a small step towards generalization of sulong so it can be used with more LLVM bitcode producers.
Originally, I've tried to use it with apple clang (which version string is different from original clang's) and it's failed to parse, while bitcode file was totally compatible.

So I've looked into http://llvm.org/docs/BitCodeFormat.html#module-code-version-record and I think version number from MODULE_BLOCK is more strict and reliable than version strings.

This change is also needed for stuff like #654 

I'm actually using sulong just for parsing, but I want to parse as many llvm based languages as possible, so more improvements toward generalization are to come (if you don't mind :) )

Changes overview:
- sulong.LLVM option is removed, as we now using correct version taken from bitcode file being parsed;
- version specific parsers are renamed to match bitcode format versions not clang versions;
- listeners.Identification now does nothing, but kept to prevent warning about ignored records.