### PR TITLE
recursive hashCode

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Types.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Types.java
@@ -32,6 +32,7 @@ package com.oracle.truffle.llvm.parser.listeners;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Set;
 
 import com.oracle.truffle.llvm.parser.model.generators.ModuleGenerator;
 import com.oracle.truffle.llvm.parser.records.Records;
@@ -248,7 +249,7 @@ public final class Types implements ParserListener, Iterable<Type> {
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode(Set<Type> visited) {
             final int prime = 31;
             int result = 1;
             result = prime * result + idx;
@@ -325,7 +326,7 @@ public final class Types implements ParserListener, Iterable<Type> {
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode(Set<Type> visited) {
             final int prime = 31;
             int result = 1;
             result = prime * result + ((name == null) ? 0 : name.hashCode());

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/ArrayType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/ArrayType.java
@@ -31,13 +31,15 @@ package com.oracle.truffle.llvm.runtime.types;
 
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
+import java.util.Set;
+
 public final class ArrayType extends AggregateType {
 
     @Override
-    public int hashCode() {
+    public int hashCode(Set<Type> visited) {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((elementType == null) ? 0 : elementType.hashCode());
+        result = prime * result + ((elementType == null) ? 0 : elementType.hashCodeSafe(visited));
         result = prime * result + length;
         return result;
     }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/FunctionType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/FunctionType.java
@@ -30,6 +30,7 @@
 package com.oracle.truffle.llvm.runtime.types;
 
 import java.util.Arrays;
+import java.util.Set;
 
 import com.oracle.truffle.llvm.runtime.memory.LLVMHeap;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
@@ -104,12 +105,12 @@ public final class FunctionType extends Type {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode(Set<Type> visited) {
         final int prime = 31;
         int result = 1;
-        result = prime * result + Arrays.hashCode(argumentTypes);
+        result = prime * result + hashCode(argumentTypes, visited);
         result = prime * result + (isVarargs ? 1231 : 1237);
-        result = prime * result + ((returnType == null) ? 0 : returnType.hashCode());
+        result = prime * result + ((returnType == null) ? 0 : returnType.hashCodeSafe(visited));
         return result;
     }
 

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/MetaType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/MetaType.java
@@ -31,6 +31,8 @@ package com.oracle.truffle.llvm.runtime.types;
 
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
+import java.util.Set;
+
 public final class MetaType extends Type {
     public static MetaType UNKNOWN = new MetaType();
     public static MetaType OPAQUE = new MetaType();
@@ -46,7 +48,7 @@ public final class MetaType extends Type {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode(Set<Type> visited) {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((identity == null) ? 0 : identity.hashCode());

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/PointerType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/PointerType.java
@@ -33,6 +33,8 @@ import com.oracle.truffle.llvm.runtime.LLVMAddress;
 import com.oracle.truffle.llvm.runtime.memory.LLVMHeap;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
+import java.util.Set;
+
 public final class PointerType extends AggregateType {
 
     private Type pointeeType;
@@ -98,10 +100,10 @@ public final class PointerType extends AggregateType {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode(Set<Type> visited) {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((pointeeType == null) ? 0 : pointeeType.hashCode());
+        result = prime * result + ((pointeeType == null) ? 0 : pointeeType.hashCodeSafe(visited));
         return result;
     }
 

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/PrimitiveType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/PrimitiveType.java
@@ -31,6 +31,8 @@ package com.oracle.truffle.llvm.runtime.types;
 
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
+import java.util.Set;
+
 public final class PrimitiveType extends Type {
 
     public static final PrimitiveType I1 = new PrimitiveType(PrimitiveKind.I1, null);
@@ -130,7 +132,7 @@ public final class PrimitiveType extends Type {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode(Set<Type> visited) {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((constant == null) ? 0 : constant.hashCode());

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/StructureType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/StructureType.java
@@ -30,6 +30,7 @@
 package com.oracle.truffle.llvm.runtime.types;
 
 import java.util.Arrays;
+import java.util.Set;
 
 import com.oracle.truffle.llvm.runtime.types.symbols.LLVMIdentifier;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
@@ -171,12 +172,12 @@ public final class StructureType extends AggregateType {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode(Set<Type> visited) {
         final int prime = 31;
         int result = 1;
         result = prime * result + (isPacked ? 1231 : 1237);
         result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + Arrays.hashCode(types);
+        result = prime * result + hashCode(types, visited);
         return result;
     }
 

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/VariableBitWidthType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/VariableBitWidthType.java
@@ -31,6 +31,8 @@ package com.oracle.truffle.llvm.runtime.types;
 
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
+import java.util.Set;
+
 public final class VariableBitWidthType extends Type {
 
     private final int bitWidth;
@@ -59,7 +61,7 @@ public final class VariableBitWidthType extends Type {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode(Set<Type> visited) {
         final int prime = 31;
         int result = 1;
         result = prime * result + bitWidth;

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/VectorType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/VectorType.java
@@ -31,6 +31,8 @@ package com.oracle.truffle.llvm.runtime.types;
 
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
+import java.util.Set;
+
 public class VectorType extends AggregateType {
 
     private final PrimitiveType elementType;
@@ -89,10 +91,10 @@ public class VectorType extends AggregateType {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode(Set<Type> visited) {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((elementType == null) ? 0 : elementType.hashCode());
+        result = prime * result + ((elementType == null) ? 0 : elementType.hashCodeSafe(visited));
         result = prime * result + length;
         return result;
     }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/VoidType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/VoidType.java
@@ -31,6 +31,8 @@ package com.oracle.truffle.llvm.runtime.types;
 
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
+import java.util.Set;
+
 public final class VoidType extends Type {
 
     public static final VoidType INSTANCE = new VoidType();
@@ -67,7 +69,7 @@ public final class VoidType extends Type {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode(Set<Type> visited) {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((identity == null) ? 0 : identity.hashCode());


### PR DESCRIPTION
Currently com.oracle.truffle.llvm.runtime.types.StructureType#hashCode may suffer from infinite recursion if type hierarchy contains cycles, this may occur for simple code like one below:
```
struct List {
    struct List *next;
} *PLIST;

static void switchToNext() {
    PLIST = PLIST->next;
}
```

It will be correctly parsed, but If I call .hashCode on 'struct List' or any type referencing it (pointer to it, array of this type, etc) then we will get StackoverflowError