### PR TITLE
Add mx option to compile tests with Debug Information

### DIFF
--- a/mx.sulong/mx_sulong.py
+++ b/mx.sulong/mx_sulong.py
@@ -450,7 +450,6 @@ def compilationSucceedsOption():
 def getBenchmarkOptions():
     return [
         '-Dgraal.TruffleBackgroundCompilation=false',
-        '-Dsulong.ExecutionCount=5',
         '-Dsulong.PerformanceWarningsAreFatal=true',
         '-Dgraal.TruffleTimeThreshold=1000000',
         '-Xms4g',
@@ -625,7 +624,11 @@ def getLLVMProgramPath(args=None):
 
 def compileWithClang(args=None, version=None, out=None, err=None):
     """runs Clang"""
-    return mx.run([findLLVMProgram('clang', version)] + args, out=out, err=err)
+    cmd = [findLLVMProgram('clang', version)]
+    if os.environ.get('SULONG_COMPILE_WITH_DEBUGINFO') in ['True', 'TRUE', 'true']:
+        cmd += ['-g']
+    cmd += args
+    return mx.run(cmd, out=out, err=err)
 
 def compileWithGCC(args=None):
     """runs GCC"""
@@ -643,7 +646,11 @@ def link(args=None):
 
 def compileWithClangPP(args=None, version=None, out=None, err=None):
     """runs Clang++"""
-    return mx.run([findLLVMProgram('clang++', version)] + args, out=out, err=err)
+    cmd = [findLLVMProgram('clang++', version)]
+    if os.environ.get('SULONG_COMPILE_WITH_DEBUGINFO') in ['True', 'TRUE', 'true']:
+        cmd += ['-g']
+    cmd += args
+    return mx.run(cmd, out=out, err=err)
 
 def getClasspathOptions():
     """gets the classpath of the Sulong distributions"""

--- a/mx.sulong/mx_tools.py
+++ b/mx.sulong/mx_tools.py
@@ -102,7 +102,12 @@ class ClangCompiler(Tool):
 
     def run(self, inputFile, outputFile, flags):
         tool = self.getTool(inputFile)
-        return self.runTool([mx_sulong.findLLVMProgram(tool, ['3.2']), '-c', '-emit-llvm', '-o', outputFile] + flags + [inputFile], errorMsg='Cannot compile %s with %s' % (inputFile, tool))
+        cmd = [mx_sulong.findLLVMProgram(tool, ['3.2'])]
+        if os.environ.get('SULONG_COMPILE_WITH_DEBUGINFO') in ['True', 'TRUE', 'true']:
+            cmd += ['-g']
+        cmd += ['-c', '-emit-llvm', '-o', outputFile] + flags + [inputFile]
+
+        return self.runTool(cmd, errorMsg='Cannot compile %s with %s' % (inputFile, tool))
 
     def compileReferenceFile(self, inputFile, outputFile, flags):
         tool = self.getTool(inputFile)
@@ -131,7 +136,11 @@ class ClangV38Compiler(Tool):
 
     def run(self, inputFile, outputFile, flags):
         tool = self.getTool(inputFile)
-        return self.runTool([mx_sulong.findLLVMProgram(tool, ['3.8', '3.9', '4.0']), '-c', '-emit-llvm', '-o', outputFile] + flags + [inputFile], errorMsg='Cannot compile %s with %s' % (inputFile, tool))
+        cmd = [mx_sulong.findLLVMProgram(tool, ['3.8', '3.9', '4.0'])]
+        if os.environ.get('SULONG_COMPILE_WITH_DEBUGINFO') in ['True', 'TRUE', 'true']:
+            cmd += ['-g']
+        cmd += ['-c', '-emit-llvm', '-o', outputFile] + flags + [inputFile]
+        return self.runTool(cmd, errorMsg='Cannot compile %s with %s' % (inputFile, tool))
 
     def compileReferenceFile(self, inputFile, outputFile, flags):
         tool = self.getTool(inputFile)
@@ -172,7 +181,11 @@ class GCCCompiler(Tool):
 
     def run(self, inputFile, outputFile, flags):
         tool, toolFlags = self.getTool(inputFile, outputFile)
-        ret = self.runTool([tool, '-S', '-fplugin=' + mx_sulong.dragonEggPath(), '-fplugin-arg-dragonegg-emit-ir', '-o', '%s.tmp.ll' % outputFile] + toolFlags + flags + [inputFile], errorMsg='Cannot compile %s with %s' % (inputFile, os.path.basename(tool)))
+        cmd = [tool]
+        if os.environ.get('SULONG_COMPILE_WITH_DEBUGINFO') in ['True', 'TRUE', 'true']:
+            cmd += ['-g']
+        cmd += ['-S', '-fplugin=' + mx_sulong.dragonEggPath(), '-fplugin-arg-dragonegg-emit-ir', '-o', '%s.tmp.ll' % outputFile] + toolFlags + flags + [inputFile]
+        ret = self.runTool(cmd, errorMsg='Cannot compile %s with %s' % (inputFile, os.path.basename(tool)))
         if ret == 0:
             ret = self.runTool([mx_sulong.findLLVMProgram('llvm-as', ['3.2']), '-o', outputFile, '%s.tmp.ll' % outputFile], errorMsg='Cannot assemble %s with llvm-as' % inputFile)
         return ret


### PR DESCRIPTION
Introduce the SULONG_COMPILE_WITH_DEBUGINFO environment variable. If set to 'TRUE', mx will compile the tests with the '-g' option to include debug information into the bitcode files.

We cannot use this as default since Truffle Source objects cannot correctly handle some file formats.
An example of this would be 'gcc-5.2.0/gcc/testsuite/gcc.dg/cpp/mac-eol-at-eof.c'. It uses only single '\r' characters as line endings.