### PR TITLE
Fix Representation of Unprintable Characters in Symbol Identifiers

### DIFF
--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/symbols/LLVMIdentifier.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/symbols/LLVMIdentifier.java
@@ -104,12 +104,7 @@ public final class LLVMIdentifier {
             final char c = unescaped.charAt(i);
             if (c == '\"' || c < ' ' || c > '~') {
                 // use the format "\xx" where xx is the hex-value of c
-                builder.append("\\");
-                final String hexVal = Integer.toHexString(c);
-                for (int j = 0; j < hexVal.length() - 2; j++) {
-                    builder.append('0');
-                }
-                builder.append(hexVal);
+                builder.append(String.format("\\%02x", c & 0xff));
             } else {
                 builder.append(c);
             }


### PR DESCRIPTION
Any non-printable character in an llvm identifier is represented by '\xx' where xx is the hex value of the character. See [the LLVM Language Reference](http://llvm.org/docs/LangRef.html#identifiers) for more details.