### PR TITLE
Fix Resume Instruction implementation

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Function.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Function.java
@@ -307,7 +307,7 @@ public final class Function implements ParserListener {
         } else {
             type = types.get(args[i]);
         }
-        instructionBlock.createResume(type);
+        instructionBlock.createResume(type, val);
         isLastBlockTerminated = true;
     }
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/blocks/InstructionBlock.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/blocks/InstructionBlock.java
@@ -146,8 +146,8 @@ public final class InstructionBlock implements ValueSymbol {
         addInstruction(LandingpadInstruction.generate(function.getSymbols(), type, isCleanup, clauseTypes, clauseTODO));
     }
 
-    public void createResume(@SuppressWarnings("unused") Type type) {
-        addInstruction(ResumeInstruction.generate());
+    public void createResume(@SuppressWarnings("unused") Type type, int value) {
+        addInstruction(ResumeInstruction.fromSymbols(function.getSymbols(), value));
     }
 
     public void createCast(Type type, int opcode, int value) {

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/symbols/instructions/ResumeInstruction.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/symbols/instructions/ResumeInstruction.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.oracle.truffle.llvm.parser.model.blocks.InstructionBlock;
+import com.oracle.truffle.llvm.parser.model.symbols.Symbols;
 import com.oracle.truffle.llvm.parser.model.visitors.InstructionVisitor;
 import com.oracle.truffle.llvm.runtime.types.symbols.Symbol;
 
@@ -64,8 +65,9 @@ public final class ResumeInstruction extends VoidInstruction implements Terminat
         }
     }
 
-    public static Instruction generate() {
-        ResumeInstruction inst = new ResumeInstruction();
+    public static Instruction fromSymbols(Symbols symbols, int value) {
+        final ResumeInstruction inst = new ResumeInstruction();
+        inst.value = symbols.getSymbol(value, inst);
         return inst;
     }
 


### PR DESCRIPTION
Based on #687 

According to the LLVM code, this should be the correct implementation of the Resume instruction:
https://github.com/llvm-mirror/llvm/blob/release_38/lib/Bitcode/Writer/BitcodeWriter.cpp#L1976

The type declared in the resume instruction is ignored for now, because there doesn't seem to be much usefulness to store it. (The Symbol has already the correct type)