### PR TITLE
Fix CompareInstruction return type, add some helper functions

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/ModelModule.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/ModelModule.java
@@ -109,6 +109,10 @@ public final class ModelModule implements ModuleGenerator {
         declares.forEach(visitor::visit);
     }
 
+    public int getSymbolCount() {
+        return symbols.getSize();
+    }
+
     @Override
     public void createAlias(Type type, int aliasedValue, long linkage, long visibility) {
         GlobalAlias alias = GlobalAlias.create(type, aliasedValue, linkage, visibility);

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/enums/CompareOperator.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/enums/CompareOperator.java
@@ -90,6 +90,18 @@ public enum CompareOperator {
     }
 
     /**
+     * Allows us to calculate llvm ir equivalent index of the enum.
+     */
+    public int getIrIndex() {
+        long fpops = FP_TRUE.ordinal() + 1;
+        if (this.ordinal() >= 0 && this.ordinal() < fpops) {
+            return this.ordinal();
+        } else {
+            return (int) (this.ordinal() + INTEGER_OPERATOR_FLAG - fpops);
+        }
+    }
+
+    /**
      * Useful to get the llvm ir equivalent string of the enum.
      */
     public String getIrString() {

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/symbols/instructions/CompareInstruction.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/symbols/instructions/CompareInstruction.java
@@ -32,25 +32,42 @@ package com.oracle.truffle.llvm.parser.model.symbols.instructions;
 import com.oracle.truffle.llvm.parser.model.enums.CompareOperator;
 import com.oracle.truffle.llvm.parser.model.symbols.Symbols;
 import com.oracle.truffle.llvm.parser.model.visitors.InstructionVisitor;
+import com.oracle.truffle.llvm.runtime.types.PrimitiveType;
 import com.oracle.truffle.llvm.runtime.types.Type;
+import com.oracle.truffle.llvm.runtime.types.VectorType;
 import com.oracle.truffle.llvm.runtime.types.symbols.Symbol;
 
 public final class CompareInstruction extends ValueInstruction {
 
     private final CompareOperator operator;
 
+    private Type baseType;
+
     private Symbol lhs;
 
     private Symbol rhs;
 
     private CompareInstruction(Type type, CompareOperator operator) {
-        super(type);
+        super(calculateResultType(type));
+        this.baseType = type;
         this.operator = operator;
+    }
+
+    private static Type calculateResultType(Type type) {
+        // The comparison performed always yields either an i1 or vector of i1 as result
+        if (type instanceof VectorType) {
+            return new VectorType(PrimitiveType.I1, ((VectorType) type).getNumberOfElements());
+        }
+        return PrimitiveType.I1;
     }
 
     @Override
     public void accept(InstructionVisitor visitor) {
         visitor.visit(this);
+    }
+
+    public Type getBaseType() {
+        return baseType;
     }
 
     public Symbol getLHS() {


### PR DESCRIPTION
According to the LLVM Documentation, the return type of a CompareInstruction is either of type i1, or a vector of i1.