### PR TITLE
Add pip and maven to travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 cache:
   directories:
   - cache/tools
+  - $HOME/.cache/pip
+  - $HOME/.m2
 dist: trusty
 sudo: required
 language: java


### PR DESCRIPTION
Especially maven sometimes causes travis to fail, because some file cannot be downloaded. Using a cache should mitigate such problems in the future.