### PR TITLE
	Fix Parsing Forward Referenced Symbols

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Function.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Function.java
@@ -30,6 +30,7 @@
 package com.oracle.truffle.llvm.parser.listeners;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -53,8 +54,6 @@ import com.oracle.truffle.llvm.runtime.types.VectorType;
 import com.oracle.truffle.llvm.runtime.types.VoidType;
 
 public final class Function implements ParserListener {
-
-    private static final int INSERT_VALUE_MAX_ARGS = 3;
 
     private final FunctionGenerator generator;
 
@@ -273,7 +272,7 @@ public final class Function implements ParserListener {
 
         final int target = getIndex(args[i++]);
         final Type calleeType;
-        if (target <= symbols.size()) {
+        if (target < symbols.size()) {
             calleeType = symbols.get(target);
         } else {
             calleeType = types.get(args[i++]);
@@ -288,8 +287,12 @@ public final class Function implements ParserListener {
         }
 
         final int[] arguments = new int[args.length - i];
-        for (int j = 0; i < args.length; i++, j++) {
-            arguments[j] = getIndex(args[i]);
+        for (int j = 0; i < args.length; j++) {
+            int index = getIndex(args[i++]);
+            arguments[j] = index;
+            if (index >= symbols.size()) {
+                i++;
+            }
         }
         final Type returnType = functionType.getReturnType();
         instructionBlock.createInvoke(returnType, target, arguments, normalSuccessorBlock, unwindSuccessorBlock);
@@ -322,6 +325,9 @@ public final class Function implements ParserListener {
         for (int j = 0; j < numClauses; j++) {
             clauseKinds[j] = args[i++];
             clauseTypes[j] = getIndex(args[i++]);
+            if (clauseTypes[j] >= symbols.size()) {
+                i++;
+            }
         }
         symbols.add(type);
         instructionBlock.createLandingpad(type, isCleanup, clauseKinds, clauseTypes);
@@ -361,9 +367,22 @@ public final class Function implements ParserListener {
             }
         }
 
-        final int[] arguments = new int[args.length - i];
-        for (int j = 0; i < args.length; i++, j++) {
-            arguments[j] = getIndex(args[i]);
+        int[] arguments = new int[args.length - i];
+        int skipped = 0;
+        int j = 0;
+        while (j < functionType.getArgumentTypes().length && i < args.length) {
+            arguments[j++] = getIndex(args[i++]);
+        }
+        while (i < args.length) {
+            int index = getIndex(args[i++]);
+            arguments[j++] = index;
+            if (index >= symbols.size()) {
+                i++;
+                skipped++;
+            }
+        }
+        if (skipped > 0) {
+            arguments = Arrays.copyOf(arguments, arguments.length - skipped);
         }
 
         final Type returnType = functionType.getReturnType();
@@ -649,10 +668,17 @@ public final class Function implements ParserListener {
     }
 
     private void createExtractElement(long[] args) {
-        int vector = getIndex(args[0]);
-        int index = getIndex(args[1]);
+        int i = 0;
+        int vector = getIndex(args[i++]);
 
-        Type type = ((VectorType) symbols.get(vector)).getElementType();
+        Type type;
+        if (vector >= symbols.size()) {
+            type = types.get(i++);
+        } else {
+            type = ((VectorType) symbols.get(vector)).getElementType();
+        }
+
+        int index = getIndex(args[i]);
 
         instructionBlock.createExtractElement(type, vector, index);
 
@@ -660,15 +686,21 @@ public final class Function implements ParserListener {
     }
 
     private void createExtractValue(long[] args) {
-        int aggregate = getIndex(args[0]);
-        int index = (int) args[1];
+        int i = 0;
+        int aggregate = getIndex(args[i++]);
+        Type type = null;
+        if (aggregate >= symbols.size()) {
+            type = types.get(i++);
+        }
+        int index = (int) args[i++];
+        if (type == null) {
+            type = ((AggregateType) symbols.get(aggregate)).getElementType(index);
+        }
 
-        if (args.length != 2) {
+        if (i != args.length) {
             // This is supported in neither parser.
             throw new UnsupportedOperationException("Multiple indices are not yet supported!");
         }
-
-        Type type = ((AggregateType) symbols.get(aggregate)).getElementType(index);
 
         instructionBlock.createExtractValue(type, aggregate, index);
 
@@ -733,32 +765,50 @@ public final class Function implements ParserListener {
     }
 
     private void createInsertElement(long[] args) {
-        int vector = getIndex(args[0]);
-        int index = getIndex(args[2]);
-        int value = getIndex(args[1]);
+        int i = 0;
 
-        Type symbol = symbols.get(vector);
+        int vector = getIndex(args[i++]);
+        Type type;
+        if (vector >= symbols.size()) {
+            type = types.get(i++);
+        } else {
+            type = symbols.get(vector);
+        }
 
-        instructionBlock.createInsertElement(symbol, vector, index, value);
+        int value = getIndex(args[i++]);
+        int index = getIndex(args[i]);
 
-        symbols.add(symbol);
+        instructionBlock.createInsertElement(type, vector, index, value);
+
+        symbols.add(type);
     }
 
     private void createInsertValue(long[] args) {
-        int aggregate = getIndex(args[0]);
-        int index = (int) args[2];
-        int value = getIndex(args[1]);
+        int i = 0;
 
-        if (args.length != INSERT_VALUE_MAX_ARGS) {
+        int aggregate = getIndex(args[i++]);
+        Type type;
+        if (aggregate >= symbols.size()) {
+            type = types.get(i++);
+        } else {
+            type = symbols.get(aggregate);
+        }
+
+        int value = getIndex(args[i++]);
+        if (value >= symbols.size()) {
+            i++;
+        }
+
+        int index = (int) args[i++];
+
+        if (args.length != i) {
             // This is supported in neither parser.
             throw new UnsupportedOperationException("Multiple indices are not yet supported!");
         }
 
-        Type symbol = symbols.get(aggregate);
+        instructionBlock.createInsertValue(type, aggregate, index, value);
 
-        instructionBlock.createInsertValue(symbol, aggregate, index, value);
-
-        symbols.add(symbol);
+        symbols.add(type);
     }
 
     private void createPhi(long[] args) {
@@ -804,11 +854,20 @@ public final class Function implements ParserListener {
     }
 
     private void createShuffleVector(long[] args) {
-        int vector1 = getIndex(args[0]);
-        int vector2 = getIndex(args[1]);
-        int mask = getIndex(args[2]);
+        int i = 0;
 
-        PrimitiveType subtype = ((VectorType) symbols.get(vector1)).getElementType();
+        int vector1 = getIndex(args[i++]);
+        Type vectorType;
+        if (vector1 >= symbols.size()) {
+            vectorType = types.get(i++);
+        } else {
+            vectorType = symbols.get(vector1);
+        }
+
+        int vector2 = getIndex(args[i++]);
+        int mask = getIndex(args[i]);
+
+        PrimitiveType subtype = ((VectorType) vectorType).getElementType();
         int length = ((VectorType) symbols.get(mask)).getNumberOfElements();
         Type type = new VectorType(subtype, length);
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Function.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Function.java
@@ -30,6 +30,7 @@
 package com.oracle.truffle.llvm.parser.listeners;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.oracle.truffle.llvm.parser.model.blocks.InstructionBlock;
@@ -685,7 +686,7 @@ public final class Function implements ParserListener {
         } else {
             base = types.get(args[i++]);
         }
-        int[] indices = getIndices(args, i);
+        List<Integer> indices = getIndices(args, i);
         Type type = new PointerType(getElementPointerType(base, indices));
 
         instructionBlock.createGetElementPointer(
@@ -706,7 +707,7 @@ public final class Function implements ParserListener {
         } else {
             base = types.get(args[i++]);
         }
-        int[] indices = getIndices(args, i);
+        List<Integer> indices = getIndices(args, i);
 
         Type type = new PointerType(getElementPointerType(base, indices));
 
@@ -859,24 +860,26 @@ public final class Function implements ParserListener {
         return (int) argument & (Long.SIZE - 1);
     }
 
-    private Type getElementPointerType(Type type, int[] indices) {
+    private Type getElementPointerType(Type type, List<Integer> indices) {
         Type elementType = type;
-        for (int indice : indices) {
+        for (int indexIndex : indices) {
             if (elementType instanceof PointerType) {
                 elementType = ((PointerType) elementType).getPointeeType();
             } else if (elementType instanceof ArrayType) {
                 elementType = ((ArrayType) elementType).getElementType();
             } else if (elementType instanceof VectorType) {
                 elementType = ((VectorType) elementType).getElementType();
-            } else {
+            } else if (elementType instanceof StructureType) {
                 StructureType structure = (StructureType) elementType;
-                Type idx = symbols.get(indice);
-                if (!(idx instanceof PrimitiveType)) {
-                    throw new IllegalStateException("Cannot infer structure element from " + idx);
+                Type indexType = symbols.get(indexIndex);
+                if (!(indexType instanceof PrimitiveType)) {
+                    throw new IllegalStateException("Cannot infer structure element from " + indexType);
                 }
-                Number index = (Number) ((PrimitiveType) idx).getConstant();
-                assert ((PrimitiveType) idx).getPrimitiveKind() == PrimitiveKind.I32;
-                elementType = structure.getElementType(index.intValue());
+                Number indexNumber = (Number) ((PrimitiveType) indexType).getConstant();
+                assert ((PrimitiveType) indexType).getPrimitiveKind() == PrimitiveKind.I32;
+                elementType = structure.getElementType(indexNumber.intValue());
+            } else {
+                throw new IllegalStateException("Cannot index type: " + elementType);
             }
         }
         return elementType;
@@ -890,16 +893,18 @@ public final class Function implements ParserListener {
         }
     }
 
-    private int[] getIndices(long[] arguments, int from) {
-        return getIndices(arguments, from, arguments.length);
-    }
-
-    private int[] getIndices(long[] arguments, int from, int to) {
-        int[] indices = new int[to - from];
-        for (int i = 0; i < indices.length; i++) {
-            indices[i] = getIndex(arguments[from + i]);
+    private List<Integer> getIndices(long[] arguments, int from) {
+        List<Integer> indices = new ArrayList<>(arguments.length - from);
+        int i = from;
+        while (i < arguments.length) {
+            int index = getIndex(arguments[i++]);
+            if (index >= symbols.size()) {
+                // type of forward referenced index
+                i++;
+            }
+            indices.add(index);
         }
-        return indices;
+        return Collections.unmodifiableList(indices);
     }
 
     protected int getIndexAbsolute(long index) {

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/blocks/InstructionBlock.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/blocks/InstructionBlock.java
@@ -167,7 +167,7 @@ public final class InstructionBlock implements ValueSymbol {
         addInstruction(ExtractValueInstruction.fromSymbols(function.getSymbols(), type, aggregate, index));
     }
 
-    public void createGetElementPointer(Type type, int pointer, int[] indices, boolean isInbounds) {
+    public void createGetElementPointer(Type type, int pointer, List<Integer> indices, boolean isInbounds) {
         addInstruction(GetElementPointerInstruction.fromSymbols(function.getSymbols(), type, pointer, indices, isInbounds));
     }
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/symbols/instructions/GetElementPointerInstruction.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/symbols/instructions/GetElementPointerInstruction.java
@@ -48,8 +48,6 @@ public final class GetElementPointerInstruction extends ValueInstruction {
 
     private final boolean isInbounds;
 
-    private String referenceName = null;
-
     private GetElementPointerInstruction(Type type, boolean isInbounds) {
         super(type);
         this.indices = new ArrayList<>();
@@ -76,14 +74,6 @@ public final class GetElementPointerInstruction extends ValueInstruction {
         return base;
     }
 
-    public void setReferenceName(String referenceName) {
-        this.referenceName = referenceName;
-    }
-
-    public String getReferenceName() {
-        return referenceName;
-    }
-
     public List<Symbol> getIndices() {
         return Collections.unmodifiableList(indices);
     }
@@ -104,7 +94,7 @@ public final class GetElementPointerInstruction extends ValueInstruction {
         }
     }
 
-    public static GetElementPointerInstruction fromSymbols(Symbols symbols, Type type, int pointer, int[] indices, boolean isInbounds) {
+    public static GetElementPointerInstruction fromSymbols(Symbols symbols, Type type, int pointer, List<Integer> indices, boolean isInbounds) {
         final GetElementPointerInstruction inst = new GetElementPointerInstruction(type, isInbounds);
         inst.base = symbols.getSymbol(pointer, inst);
         for (int index : indices) {


### PR DESCRIPTION
LLVM Bitcode often contains type references for forward referenced symbols. These need to be parsed correctly.