### PR TITLE
Implement some of the LLVM Arithmetic builtins

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/arith/LLVMSAddWithOverflow.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/arith/LLVMSAddWithOverflow.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.LLVMBuiltin;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+public class LLVMSAddWithOverflow {
+
+    private static boolean signedAddWithOverflowI8(byte left, byte right, LLVMAddress addr) {
+        final int res = left + right;
+        final boolean overflow = (((res ^ left) & (res ^ right)) & (1 << (Byte.SIZE - 1))) != 0;
+
+        LLVMMemory.putI8(addr, (byte) (res));
+        return overflow;
+    }
+
+    private static boolean signedAddWithOverflowI16(short left, short right, LLVMAddress addr) {
+        final int res = left + right;
+        final boolean overflow = (((res ^ left) & (res ^ right)) & (1 << (Short.SIZE - 1))) != 0;
+
+        LLVMMemory.putI16(addr, (short) (res));
+        return overflow;
+    }
+
+    private static boolean signedAddWithOverflowI32(int left, int right, LLVMAddress addr) {
+        final int res = left + right;
+        final boolean overflow = ((res ^ left) & (res ^ right)) < 0;
+
+        LLVMMemory.putI32(addr, res);
+        return overflow;
+    }
+
+    private static boolean signedAddWithOverflowI64(long left, long right, LLVMAddress addr) {
+        final long res = left + right;
+        final boolean overflow = ((res ^ left) & (res ^ right)) < 0;
+
+        LLVMMemory.putI64(addr, res);
+        return overflow;
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class GCCAddWithOverflow extends LLVMBuiltin {
+
+        @Specialization
+        public byte executeIntrinsic(byte left, byte right, LLVMAddress addr) {
+            return (byte) (signedAddWithOverflowI8(left, right, addr) ? 1 : 0);
+        }
+
+        @Specialization
+        public byte executeIntrinsic(short left, short right, LLVMAddress addr) {
+            return (byte) (signedAddWithOverflowI16(left, right, addr) ? 1 : 0);
+        }
+
+        @Specialization
+        public byte executeIntrinsic(int left, int right, LLVMAddress addr) {
+            return (byte) (signedAddWithOverflowI32(left, right, addr) ? 1 : 0);
+        }
+
+        @Specialization
+        public byte executeIntrinsic(long left, long right, LLVMAddress addr) {
+            return (byte) (signedAddWithOverflowI64(left, right, addr) ? 1 : 0);
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMSAddWithOverflowI8 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMSAddWithOverflowI8(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(byte left, byte right, LLVMAddress addr) {
+            final boolean overflow = signedAddWithOverflowI8(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMSAddWithOverflowI16 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMSAddWithOverflowI16(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(short left, short right, LLVMAddress addr) {
+            final boolean overflow = signedAddWithOverflowI16(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMSAddWithOverflowI32 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMSAddWithOverflowI32(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(int left, int right, LLVMAddress addr) {
+            final boolean overflow = signedAddWithOverflowI32(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMSAddWithOverflowI64 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMSAddWithOverflowI64(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(long left, long right, LLVMAddress addr) {
+            final boolean overflow = signedAddWithOverflowI64(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/arith/LLVMSMulWithOverflow.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/arith/LLVMSMulWithOverflow.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.LLVMBuiltin;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+public class LLVMSMulWithOverflow {
+
+    private static boolean signedMulWithOverflowI8(byte left, byte right, LLVMAddress addr) {
+        final int res = left * right;
+        final boolean overflow = (byte) res != res;
+
+        LLVMMemory.putI8(addr, (byte) (res));
+        return overflow;
+    }
+
+    private static boolean signedMulWithOverflowI16(short left, short right, LLVMAddress addr) {
+        final int res = left * right;
+        final boolean overflow = (short) res != res;
+
+        LLVMMemory.putI16(addr, (short) (res));
+        return overflow;
+    }
+
+    private static boolean signedMulWithOverflowI32(int left, int right, LLVMAddress addr) {
+        final long res = (long) left * (long) right;
+        final boolean overflow = (int) res != res;
+
+        LLVMMemory.putI32(addr, (int) res);
+        return overflow;
+    }
+
+    private static boolean signedMulWithOverflowI64(long left, long right, LLVMAddress addr) {
+        final long res = left * right;
+
+        // Look into Math.multiplyExact(long, long) for implementation details
+        long aLeft = Math.abs(left);
+        long aRight = Math.abs(right);
+        boolean overflow = false;
+        if (((aLeft | aRight) >>> 31 != 0)) {
+            if (((right != 0) && (res / right != left)) || (left == Long.MIN_VALUE && right == -1)) {
+                overflow = true;
+            }
+        }
+
+        LLVMMemory.putI64(addr, res);
+        return overflow;
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class GCCSMulWithOverflow extends LLVMBuiltin {
+
+        @Specialization
+        public byte executeIntrinsic(byte left, byte right, LLVMAddress addr) {
+            return (byte) (signedMulWithOverflowI8(left, right, addr) ? 1 : 0);
+        }
+
+        @Specialization
+        public byte executeIntrinsic(short left, short right, LLVMAddress addr) {
+            return (byte) (signedMulWithOverflowI16(left, right, addr) ? 1 : 0);
+        }
+
+        @Specialization
+        public byte executeIntrinsic(int left, int right, LLVMAddress addr) {
+            return (byte) (signedMulWithOverflowI32(left, right, addr) ? 1 : 0);
+        }
+
+        @Specialization
+        public byte executeIntrinsic(long left, long right, LLVMAddress addr) {
+            return (byte) (signedMulWithOverflowI64(left, right, addr) ? 1 : 0);
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMSMulWithOverflowI8 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMSMulWithOverflowI8(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(byte left, byte right, LLVMAddress addr) {
+            final boolean overflow = signedMulWithOverflowI8(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMSMulWithOverflowI16 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMSMulWithOverflowI16(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(short left, short right, LLVMAddress addr) {
+            final boolean overflow = signedMulWithOverflowI16(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMSMulWithOverflowI32 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMSMulWithOverflowI32(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(int left, int right, LLVMAddress addr) {
+            final boolean overflow = signedMulWithOverflowI32(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMSMulWithOverflowI64 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMSMulWithOverflowI64(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(long left, long right, LLVMAddress addr) {
+            final boolean overflow = signedMulWithOverflowI64(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/arith/LLVMSSubWithOverflow.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/arith/LLVMSSubWithOverflow.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.LLVMBuiltin;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+public class LLVMSSubWithOverflow {
+
+    private static boolean signedSubWithOverflowI8(byte left, byte right, LLVMAddress addr) {
+        final int res = left - right;
+        final boolean overflow = (((left ^ right) & (left ^ res)) & (1 << (Byte.SIZE - 1))) != 0;
+
+        LLVMMemory.putI8(addr, (byte) (res));
+        return overflow;
+    }
+
+    private static boolean signedSubWithOverflowI16(short left, short right, LLVMAddress addr) {
+        final int res = left - right;
+        final boolean overflow = (((left ^ right) & (left ^ res)) & (1 << (Short.SIZE - 1))) != 0;
+
+        LLVMMemory.putI16(addr, (short) (res));
+        return overflow;
+    }
+
+    private static boolean signedSubWithOverflowI32(int left, int right, LLVMAddress addr) {
+        final int res = left - right;
+        final boolean overflow = ((left ^ right) & (left ^ res)) < 0;
+
+        LLVMMemory.putI32(addr, res);
+        return overflow;
+    }
+
+    private static boolean signedSubWithOverflowI64(long left, long right, LLVMAddress addr) {
+        final long res = left - right;
+        final boolean overflow = ((left ^ right) & (left ^ res)) < 0;
+
+        LLVMMemory.putI64(addr, res);
+        return overflow;
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class GCCSubWithOverflow extends LLVMBuiltin {
+
+        @Specialization
+        public byte executeIntrinsic(byte left, byte right, LLVMAddress addr) {
+            return (byte) (signedSubWithOverflowI8(left, right, addr) ? 1 : 0);
+        }
+
+        @Specialization
+        public byte executeIntrinsic(short left, short right, LLVMAddress addr) {
+            return (byte) (signedSubWithOverflowI16(left, right, addr) ? 1 : 0);
+        }
+
+        @Specialization
+        public byte executeIntrinsic(int left, int right, LLVMAddress addr) {
+            return (byte) (signedSubWithOverflowI32(left, right, addr) ? 1 : 0);
+        }
+
+        @Specialization
+        public byte executeIntrinsic(long left, long right, LLVMAddress addr) {
+            return (byte) (signedSubWithOverflowI64(left, right, addr) ? 1 : 0);
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMSSubWithOverflowI8 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMSSubWithOverflowI8(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(byte left, byte right, LLVMAddress addr) {
+            final boolean overflow = signedSubWithOverflowI8(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMSSubWithOverflowI16 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMSSubWithOverflowI16(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(short left, short right, LLVMAddress addr) {
+            final boolean overflow = signedSubWithOverflowI16(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMSSubWithOverflowI32 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMSSubWithOverflowI32(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(int left, int right, LLVMAddress addr) {
+            final boolean overflow = signedSubWithOverflowI32(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMSSubWithOverflowI64 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMSSubWithOverflowI64(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(long left, long right, LLVMAddress addr) {
+            final boolean overflow = signedSubWithOverflowI64(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/arith/LLVMUMulWithOverflow.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/arith/LLVMUMulWithOverflow.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.LLVMBuiltin;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+public class LLVMUMulWithOverflow {
+
+    private static boolean unsignedMulWithOverflowI8(byte left, byte right, LLVMAddress addr) {
+        final int res = (left & LLVMExpressionNode.I8_MASK) * (right & LLVMExpressionNode.I8_MASK);
+        final boolean overflow = (res & LLVMExpressionNode.I8_MASK) != res;
+
+        LLVMMemory.putI8(addr, (byte) (res));
+        return overflow;
+    }
+
+    private static boolean unsignedMulWithOverflowI16(short left, short right, LLVMAddress addr) {
+        final int res = (left & LLVMExpressionNode.I16_MASK) * (right & LLVMExpressionNode.I16_MASK);
+        final boolean overflow = (res & LLVMExpressionNode.I16_MASK) != res;
+
+        LLVMMemory.putI16(addr, (short) (res));
+        return overflow;
+    }
+
+    private static boolean unsignedMulWithOverflowI32(int left, int right, LLVMAddress addr) {
+        final long res = (left & LLVMExpressionNode.I32_MASK) * (right & LLVMExpressionNode.I32_MASK);
+        final boolean overflow = (res & LLVMExpressionNode.I32_MASK) != res;
+
+        LLVMMemory.putI32(addr, (int) res);
+        return overflow;
+    }
+
+    private static boolean unsignedMulWithOverflowI64(long left, long right, LLVMAddress addr) {
+        final long res = left * right;
+        boolean overflow = false;
+        if ((left | right) >>> 31 != 0) {
+            if (right != 0 && Long.divideUnsigned(res, right) != left) {
+                overflow = true;
+            }
+        }
+
+        LLVMMemory.putI64(addr, res);
+        return overflow;
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class GCCUMulWithOverflow extends LLVMBuiltin {
+
+        @Specialization
+        public byte executeIntrinsic(byte left, byte right, LLVMAddress addr) {
+            return (byte) (unsignedMulWithOverflowI8(left, right, addr) ? 1 : 0);
+        }
+
+        @Specialization
+        public byte executeIntrinsic(short left, short right, LLVMAddress addr) {
+            return (byte) (unsignedMulWithOverflowI16(left, right, addr) ? 1 : 0);
+        }
+
+        @Specialization
+        public byte executeIntrinsic(int left, int right, LLVMAddress addr) {
+            return (byte) (unsignedMulWithOverflowI32(left, right, addr) ? 1 : 0);
+        }
+
+        @Specialization
+        public byte executeIntrinsic(long left, long right, LLVMAddress addr) {
+            return (byte) (unsignedMulWithOverflowI64(left, right, addr) ? 1 : 0);
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMUMulWithOverflowI8 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMUMulWithOverflowI8(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(byte left, byte right, LLVMAddress addr) {
+            final boolean overflow = unsignedMulWithOverflowI8(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMUMulWithOverflowI16 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMUMulWithOverflowI16(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(short left, short right, LLVMAddress addr) {
+            final boolean overflow = unsignedMulWithOverflowI16(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMUMulWithOverflowI32 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMUMulWithOverflowI32(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(int left, int right, LLVMAddress addr) {
+            final boolean overflow = unsignedMulWithOverflowI32(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "target", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMUMulWithOverflowI64 extends LLVMBuiltin {
+
+        private final int secondValueOffset;
+
+        public LLVMUMulWithOverflowI64(int secondValueOffset) {
+            this.secondValueOffset = secondValueOffset;
+        }
+
+        @Specialization
+        public LLVMAddress executeIntrinsic(long left, long right, LLVMAddress addr) {
+            final boolean overflow = unsignedMulWithOverflowI64(left, right, addr);
+            LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
+            return addr;
+        }
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/arith/LLVMUSubWithOverflow.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/arith/LLVMUSubWithOverflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2017, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -37,22 +37,22 @@ import com.oracle.truffle.llvm.runtime.LLVMAddress;
 import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
-public class LLVMUAddWithOverflow {
+public class LLVMUSubWithOverflow {
 
     @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
                     @NodeChild(value = "target", type = LLVMExpressionNode.class)})
-    public abstract static class LLVMUAddWithOverflowI8 extends LLVMBuiltin {
+    public abstract static class LLVMUSubWithOverflowI8 extends LLVMBuiltin {
 
         private final int secondValueOffset;
 
-        public LLVMUAddWithOverflowI8(int secondValueOffset) {
+        public LLVMUSubWithOverflowI8(int secondValueOffset) {
             this.secondValueOffset = secondValueOffset;
         }
 
         @Specialization
         public LLVMAddress executeIntrinsic(byte left, byte right, LLVMAddress addr) {
-            final int res = (left & LLVMExpressionNode.I8_MASK) + (right & LLVMExpressionNode.I8_MASK);
-            final boolean overflow = (res & (1 << Byte.SIZE)) != 0;
+            final int res = (left & LLVMExpressionNode.I8_MASK) - (right & LLVMExpressionNode.I8_MASK);
+            boolean overflow = res < 0;
 
             LLVMMemory.putI8(addr, (byte) (res));
             LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
@@ -63,12 +63,12 @@ public class LLVMUAddWithOverflow {
 
     @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
                     @NodeChild(value = "cin", type = LLVMExpressionNode.class), @NodeChild(value = "cout", type = LLVMExpressionNode.class)})
-    public abstract static class LLVMUAddWithOverflowAndCarryI8 extends LLVMBuiltin {
+    public abstract static class LLVMUSubWithOverflowAndCarryI8 extends LLVMBuiltin {
 
         @Specialization
         public byte executeIntrinsic(byte left, byte right, byte cin, LLVMAddress cout) {
-            final int res = (left & LLVMExpressionNode.I8_MASK) + (right & LLVMExpressionNode.I8_MASK) + (cin & LLVMExpressionNode.I8_MASK);
-            final boolean overflow = (res & (1 << Byte.SIZE)) != 0;
+            final int res = (left & LLVMExpressionNode.I8_MASK) - (right & LLVMExpressionNode.I8_MASK) - (cin & LLVMExpressionNode.I8_MASK);
+            final boolean overflow = res < 0;
 
             LLVMMemory.putI8(cout, (byte) (overflow ? 1 : 0));
             return (byte) res;
@@ -78,18 +78,18 @@ public class LLVMUAddWithOverflow {
 
     @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
                     @NodeChild(value = "target", type = LLVMExpressionNode.class)})
-    public abstract static class LLVMUAddWithOverflowI16 extends LLVMBuiltin {
+    public abstract static class LLVMUSubWithOverflowI16 extends LLVMBuiltin {
 
         private final int secondValueOffset;
 
-        public LLVMUAddWithOverflowI16(int secondValueOffset) {
+        public LLVMUSubWithOverflowI16(int secondValueOffset) {
             this.secondValueOffset = secondValueOffset;
         }
 
         @Specialization
         public LLVMAddress executeIntrinsic(short left, short right, LLVMAddress addr) {
-            final int res = (left & LLVMExpressionNode.I16_MASK) + (right & LLVMExpressionNode.I16_MASK);
-            final boolean overflow = (res & (1 << Short.SIZE)) != 0;
+            final int res = (left & LLVMExpressionNode.I16_MASK) - (right & LLVMExpressionNode.I16_MASK);
+            final boolean overflow = res < 0;
 
             LLVMMemory.putI16(addr, (short) (res));
             LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
@@ -99,12 +99,12 @@ public class LLVMUAddWithOverflow {
 
     @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
                     @NodeChild(value = "cin", type = LLVMExpressionNode.class), @NodeChild(value = "cout", type = LLVMExpressionNode.class)})
-    public abstract static class LLVMUAddWithOverflowAndCarryI16 extends LLVMBuiltin {
+    public abstract static class LLVMUSubWithOverflowAndCarryI16 extends LLVMBuiltin {
 
         @Specialization
         public short executeIntrinsic(short left, short right, short cin, LLVMAddress cout) {
-            final int res = (left & LLVMExpressionNode.I16_MASK) + (right & LLVMExpressionNode.I16_MASK) + (cin & LLVMExpressionNode.I16_MASK);
-            final boolean overflow = (res & (1 << Short.SIZE)) != 0;
+            final int res = (left & LLVMExpressionNode.I16_MASK) - (right & LLVMExpressionNode.I16_MASK) - (cin & LLVMExpressionNode.I16_MASK);
+            final boolean overflow = res < 0;
 
             LLVMMemory.putI16(cout, (short) (overflow ? 1 : 0));
             return (short) res;
@@ -114,18 +114,18 @@ public class LLVMUAddWithOverflow {
 
     @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
                     @NodeChild(value = "target", type = LLVMExpressionNode.class)})
-    public abstract static class LLVMUAddWithOverflowI32 extends LLVMBuiltin {
+    public abstract static class LLVMUSubWithOverflowI32 extends LLVMBuiltin {
 
         private final int secondValueOffset;
 
-        public LLVMUAddWithOverflowI32(int secondValueOffset) {
+        public LLVMUSubWithOverflowI32(int secondValueOffset) {
             this.secondValueOffset = secondValueOffset;
         }
 
         @Specialization
         public LLVMAddress executeIntrinsic(int left, int right, LLVMAddress addr) {
-            final int res = left + right;
-            final boolean overflow = ((~res & left) | (~res & right) | (left & right)) < 0;
+            final int res = left - right;
+            final boolean overflow = Integer.compareUnsigned(left, right) < 0;
 
             LLVMMemory.putI32(addr, res);
             LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
@@ -135,15 +135,15 @@ public class LLVMUAddWithOverflow {
 
     @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
                     @NodeChild(value = "cin", type = LLVMExpressionNode.class), @NodeChild(value = "cout", type = LLVMExpressionNode.class)})
-    public abstract static class LLVMUAddWithOverflowAndCarryI32 extends LLVMBuiltin {
+    public abstract static class LLVMUSubWithOverflowAndCarryI32 extends LLVMBuiltin {
 
         @Specialization
         public int executeIntrinsic(int left, int right, int cin, LLVMAddress cout) {
-            final int res1 = left + right;
-            final boolean overflow1 = ((~res1 & left) | (~res1 & right) | (left & right)) < 0;
+            final int res1 = left - right;
+            final boolean overflow1 = Integer.compareUnsigned(left, right) < 0;
 
-            final int res2 = res1 + cin;
-            final boolean overflow2 = ((~res2 & res1) | (~res2 & cin) | (res1 & cin)) < 0;
+            final int res2 = res1 - cin;
+            final boolean overflow2 = Integer.compareUnsigned(res1, cin) < 0;
 
             LLVMMemory.putI32(cout, (overflow1 | overflow2) ? 1 : 0);
             return res2;
@@ -152,18 +152,18 @@ public class LLVMUAddWithOverflow {
 
     @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
                     @NodeChild(value = "target", type = LLVMExpressionNode.class)})
-    public abstract static class LLVMUAddWithOverflowI64 extends LLVMBuiltin {
+    public abstract static class LLVMUSubWithOverflowI64 extends LLVMBuiltin {
 
         private final int secondValueOffset;
 
-        public LLVMUAddWithOverflowI64(int secondValueOffset) {
+        public LLVMUSubWithOverflowI64(int secondValueOffset) {
             this.secondValueOffset = secondValueOffset;
         }
 
         @Specialization
         public LLVMAddress executeIntrinsic(long left, long right, LLVMAddress addr) {
-            final long res = left + right;
-            final boolean overflow = ((~res & left) | (~res & right) | (left & right)) < 0;
+            final long res = left - right;
+            final boolean overflow = Long.compareUnsigned(left, right) < 0;
 
             LLVMMemory.putI64(addr, res);
             LLVMMemory.putI1(addr.getVal() + secondValueOffset, overflow);
@@ -173,15 +173,15 @@ public class LLVMUAddWithOverflow {
 
     @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class),
                     @NodeChild(value = "cin", type = LLVMExpressionNode.class), @NodeChild(value = "cout", type = LLVMExpressionNode.class)})
-    public abstract static class LLVMUAddWithOverflowAndCarryI64 extends LLVMBuiltin {
+    public abstract static class LLVMUSubWithOverflowAndCarryI64 extends LLVMBuiltin {
 
         @Specialization
         public long executeIntrinsic(long left, long right, long cin, LLVMAddress cout) {
-            final long res1 = left + right;
-            final boolean overflow1 = ((~res1 & left) | (~res1 & right) | (left & right)) < 0;
+            final long res1 = left - right;
+            final boolean overflow1 = Long.compareUnsigned(left, right) < 0;
 
-            final long res2 = res1 + cin;
-            final boolean overflow2 = ((~res2 & res1) | (~res2 & cin) | (res1 & cin)) < 0;
+            final long res2 = res1 - cin;
+            final boolean overflow2 = Long.compareUnsigned(res1, cin) < 0;
 
             LLVMMemory.putI64(cout, (overflow1 | overflow2) ? 1 : 0);
             return res2;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/bit/CountLeadingZeroesNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/bit/CountLeadingZeroesNode.java
@@ -38,6 +38,24 @@ import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 public abstract class CountLeadingZeroesNode {
 
     @NodeChildren({@NodeChild(type = LLVMExpressionNode.class), @NodeChild(type = LLVMExpressionNode.class)})
+    public abstract static class CountLeadingZeroesI8Node extends LLVMBuiltin {
+
+        @Specialization
+        public byte executeI8(byte val, @SuppressWarnings("unused") boolean isZeroUndefined) {
+            return (byte) (Integer.numberOfLeadingZeros(val & 0xFF) - Integer.SIZE + Byte.SIZE);
+        }
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMExpressionNode.class), @NodeChild(type = LLVMExpressionNode.class)})
+    public abstract static class CountLeadingZeroesI16Node extends LLVMBuiltin {
+
+        @Specialization
+        public short executeI16(short val, @SuppressWarnings("unused") boolean isZeroUndefined) {
+            return (byte) (Integer.numberOfLeadingZeros(val & 0xFFFF) - Integer.SIZE + Short.SIZE);
+        }
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMExpressionNode.class), @NodeChild(type = LLVMExpressionNode.class)})
     public abstract static class CountLeadingZeroesI32Node extends LLVMBuiltin {
 
         @Specialization

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/bit/CountTrailingZeroesNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/bit/CountTrailingZeroesNode.java
@@ -38,6 +38,26 @@ import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 public abstract class CountTrailingZeroesNode {
 
     @NodeChildren({@NodeChild(type = LLVMExpressionNode.class), @NodeChild(type = LLVMExpressionNode.class)})
+    public abstract static class CountTrailingZeroesI8Node extends LLVMBuiltin {
+
+        @Specialization
+        public byte executeI8(byte val, @SuppressWarnings("unused") boolean isZeroUndefined) {
+            final int trailingZeroes = Integer.numberOfTrailingZeros(val);
+            return (byte) (trailingZeroes > Byte.SIZE ? Byte.SIZE : trailingZeroes);
+        }
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMExpressionNode.class), @NodeChild(type = LLVMExpressionNode.class)})
+    public abstract static class CountTrailingZeroesI16Node extends LLVMBuiltin {
+
+        @Specialization
+        public short executeI16(short val, @SuppressWarnings("unused") boolean isZeroUndefined) {
+            final int trailingZeroes = Integer.numberOfTrailingZeros(val);
+            return (short) (trailingZeroes > Short.SIZE ? Short.SIZE : trailingZeroes);
+        }
+    }
+
+    @NodeChildren({@NodeChild(type = LLVMExpressionNode.class), @NodeChild(type = LLVMExpressionNode.class)})
     public abstract static class CountTrailingZeroesI32Node extends LLVMBuiltin {
 
         @Specialization

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
@@ -88,7 +88,42 @@ import com.oracle.truffle.llvm.nodes.intrinsics.llvm.LLVMTrapNodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMComplexDivSC;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMCopySignFactory.LLVMCopySignDoubleFactory;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMCopySignFactory.LLVMCopySignFloatFactory;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSAddWithOverflowFactory.GCCAddWithOverflowNodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSAddWithOverflowFactory.LLVMSAddWithOverflowI16NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSAddWithOverflowFactory.LLVMSAddWithOverflowI32NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSAddWithOverflowFactory.LLVMSAddWithOverflowI64NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSAddWithOverflowFactory.LLVMSAddWithOverflowI8NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSMulWithOverflowFactory.GCCSMulWithOverflowNodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSMulWithOverflowFactory.LLVMSMulWithOverflowI16NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSMulWithOverflowFactory.LLVMSMulWithOverflowI32NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSMulWithOverflowFactory.LLVMSMulWithOverflowI64NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSMulWithOverflowFactory.LLVMSMulWithOverflowI8NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSSubWithOverflowFactory.GCCSubWithOverflowNodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSSubWithOverflowFactory.LLVMSSubWithOverflowI16NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSSubWithOverflowFactory.LLVMSSubWithOverflowI32NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSSubWithOverflowFactory.LLVMSSubWithOverflowI64NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMSSubWithOverflowFactory.LLVMSSubWithOverflowI8NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUAddWithOverflowFactory.LLVMUAddWithOverflowI16NodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUAddWithOverflowFactory.LLVMUAddWithOverflowI32NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUAddWithOverflowFactory.LLVMUAddWithOverflowI64NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUAddWithOverflowFactory.LLVMUAddWithOverflowI8NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUMulWithOverflowFactory.LLVMUMulWithOverflowI16NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUMulWithOverflowFactory.LLVMUMulWithOverflowI32NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUMulWithOverflowFactory.LLVMUMulWithOverflowI64NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUMulWithOverflowFactory.LLVMUMulWithOverflowI8NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUMulWithOverflowFactory.GCCUMulWithOverflowNodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUSubWithOverflowFactory.LLVMUSubWithOverflowAndCarryI16NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUSubWithOverflowFactory.LLVMUSubWithOverflowAndCarryI32NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUSubWithOverflowFactory.LLVMUSubWithOverflowAndCarryI64NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUSubWithOverflowFactory.LLVMUSubWithOverflowAndCarryI8NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUSubWithOverflowFactory.LLVMUSubWithOverflowI16NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUSubWithOverflowFactory.LLVMUSubWithOverflowI32NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUSubWithOverflowFactory.LLVMUSubWithOverflowI64NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUSubWithOverflowFactory.LLVMUSubWithOverflowI8NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUAddWithOverflowFactory.LLVMUAddWithOverflowAndCarryI8NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUAddWithOverflowFactory.LLVMUAddWithOverflowAndCarryI16NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUAddWithOverflowFactory.LLVMUAddWithOverflowAndCarryI32NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUAddWithOverflowFactory.LLVMUAddWithOverflowAndCarryI64NodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.bit.CountLeadingZeroesNodeFactory.CountLeadingZeroesI32NodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.bit.CountLeadingZeroesNodeFactory.CountLeadingZeroesI64NodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.bit.CountSetBitsNodeFactory.CountSetBitsI32NodeGen;
@@ -118,6 +153,9 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMArithmeticInstructionType
 import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionKind;
 import com.oracle.truffle.llvm.parser.metadata.DebugInfoGenerator;
+import com.oracle.truffle.llvm.parser.model.attributes.Attribute;
+import com.oracle.truffle.llvm.parser.model.attributes.Attribute.KnownAttribute;
+import com.oracle.truffle.llvm.parser.model.attributes.AttributesGroup;
 import com.oracle.truffle.llvm.parser.model.enums.CompareOperator;
 import com.oracle.truffle.llvm.parser.model.enums.Flag;
 import com.oracle.truffle.llvm.parser.model.enums.Linkage;
@@ -520,7 +558,7 @@ public class BasicNodeFactory implements NodeFactory {
     }
 
     @Override
-    public LLVMExpressionNode createLLVMBuiltin(Symbol target, LLVMExpressionNode[] args, int callerArgumentCount, SourceSection sourceSection) {
+    public LLVMExpressionNode createLLVMBuiltin(LLVMParserRuntime runtime, Symbol target, LLVMExpressionNode[] args, int callerArgumentCount, SourceSection sourceSection) {
         /*
          * This LLVM Builtins are *not* function intrinsics. Builtins replace statements that look
          * like function calls but are actually LLVM intrinsics. An example is llvm.stackpointer.
@@ -531,7 +569,9 @@ public class BasicNodeFactory implements NodeFactory {
         if (target instanceof FunctionDeclaration) {
             FunctionDeclaration declaration = (FunctionDeclaration) target;
             if (declaration.getName().startsWith("@llvm.")) {
-                return getLLVMBuiltin(declaration.getName(), args, callerArgumentCount, sourceSection);
+                return getLLVMBuiltin(runtime, declaration, args, callerArgumentCount, sourceSection);
+            } else if (declaration.getName().startsWith("@__builtin_")) {
+                return getGccBuiltin(declaration, args, sourceSection);
             } else if (declaration.getName().equals("@truffle_get_arg")) {
                 // this function accesses the frame directly
                 // it must therefore not be hidden behind a call target
@@ -544,8 +584,9 @@ public class BasicNodeFactory implements NodeFactory {
         return null;
     }
 
-    protected LLVMExpressionNode getLLVMBuiltin(String name, LLVMExpressionNode[] args, int callerArgumentCount, SourceSection sourceSection) {
-        switch (name) {
+    protected LLVMExpressionNode getLLVMBuiltin(LLVMParserRuntime runtime, FunctionDeclaration declaration, LLVMExpressionNode[] args, int callerArgumentCount, SourceSection sourceSection) {
+
+        switch (declaration.getName()) {
             case "@llvm.memset.p0i8.i32":
             case "@llvm.memset.p0i8.i64":
                 return LLVMMemSetNodeGen.create(args[1], args[2], args[3], args[4], args[5], sourceSection);
@@ -601,8 +642,6 @@ public class BasicNodeFactory implements NodeFactory {
                 return LLVMLifetimeStartNodeGen.create(args[1], args[2], sourceSection);
             case "@llvm.lifetime.end":
                 return LLVMLifetimeEndNodeGen.create(args[1], args[2], sourceSection);
-            case "@llvm.uadd.with.overflow.i32":
-                return LLVMUAddWithOverflowI32NodeGen.create(args[2], args[3], args[1], sourceSection);
             case "@llvm.stacksave":
                 return LLVMStackSaveNodeGen.create(sourceSection);
             case "@llvm.stackrestore":
@@ -647,10 +686,119 @@ public class BasicNodeFactory implements NodeFactory {
             case "@llvm.copysign.f64":
                 return LLVMCopySignDoubleFactory.create(args[1], args[2], sourceSection);
 
+            case "@llvm.uadd.with.overflow.i8":
+                return LLVMUAddWithOverflowI8NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.uadd.with.overflow.i16":
+                return LLVMUAddWithOverflowI16NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.uadd.with.overflow.i32":
+                return LLVMUAddWithOverflowI32NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.uadd.with.overflow.i64":
+                return LLVMUAddWithOverflowI64NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.usub.with.overflow.i8":
+                return LLVMUSubWithOverflowI8NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.usub.with.overflow.i16":
+                return LLVMUSubWithOverflowI16NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.usub.with.overflow.i32":
+                return LLVMUSubWithOverflowI32NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.usub.with.overflow.i64":
+                return LLVMUSubWithOverflowI64NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.umul.with.overflow.i8":
+                return LLVMUMulWithOverflowI8NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.umul.with.overflow.i16":
+                return LLVMUMulWithOverflowI16NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.umul.with.overflow.i32":
+                return LLVMUMulWithOverflowI32NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.umul.with.overflow.i64":
+                return LLVMUMulWithOverflowI64NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.sadd.with.overflow.i8":
+                return LLVMSAddWithOverflowI8NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.sadd.with.overflow.i16":
+                return LLVMSAddWithOverflowI16NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.sadd.with.overflow.i32":
+                return LLVMSAddWithOverflowI32NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.sadd.with.overflow.i64":
+                return LLVMSAddWithOverflowI64NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.ssub.with.overflow.i8":
+                return LLVMSSubWithOverflowI8NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.ssub.with.overflow.i16":
+                return LLVMSSubWithOverflowI16NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.ssub.with.overflow.i32":
+                return LLVMSSubWithOverflowI32NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.ssub.with.overflow.i64":
+                return LLVMSSubWithOverflowI64NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.smul.with.overflow.i8":
+                return LLVMSMulWithOverflowI8NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.smul.with.overflow.i16":
+                return LLVMSMulWithOverflowI16NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.smul.with.overflow.i32":
+                return LLVMSMulWithOverflowI32NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+            case "@llvm.smul.with.overflow.i64":
+                return LLVMSMulWithOverflowI64NodeGen.create(getOverflowFieldOffset(runtime, declaration), args[2], args[3], args[1], sourceSection);
+
             default:
-                throw new IllegalStateException("Missing LLVM builtin: " + name);
+                throw new IllegalStateException("Missing LLVM builtin: " + declaration.getName());
         }
 
+    }
+
+    private static int getOverflowFieldOffset(LLVMParserRuntime runtime, FunctionDeclaration declaration) {
+        return runtime.getIndexOffset(1, (AggregateType) declaration.getType().getReturnType());
+    }
+
+    protected LLVMExpressionNode getGccBuiltin(FunctionDeclaration declaration, LLVMExpressionNode[] args, SourceSection sourceSection) {
+        switch (declaration.getName()) {
+            case "@__builtin_addcb":
+                return LLVMUAddWithOverflowAndCarryI8NodeGen.create(args[1], args[2], args[3], args[4], sourceSection);
+            case "@__builtin_addcs":
+                return LLVMUAddWithOverflowAndCarryI16NodeGen.create(args[1], args[2], args[3], args[4], sourceSection);
+            case "@__builtin_addc":
+                return LLVMUAddWithOverflowAndCarryI32NodeGen.create(args[1], args[2], args[3], args[4], sourceSection);
+            case "@__builtin_addcl":
+                return LLVMUAddWithOverflowAndCarryI64NodeGen.create(args[1], args[2], args[3], args[4], sourceSection);
+            case "@__builtin_subcb":
+                return LLVMUSubWithOverflowAndCarryI8NodeGen.create(args[1], args[2], args[3], args[4], sourceSection);
+            case "@__builtin_subcs":
+                return LLVMUSubWithOverflowAndCarryI16NodeGen.create(args[1], args[2], args[3], args[4], sourceSection);
+            case "@__builtin_subc":
+                return LLVMUSubWithOverflowAndCarryI32NodeGen.create(args[1], args[2], args[3], args[4], sourceSection);
+            case "@__builtin_subcl":
+                return LLVMUSubWithOverflowAndCarryI64NodeGen.create(args[1], args[2], args[3], args[4], sourceSection);
+
+            case "@__builtin_add_overflow":
+                if (isZeroExtendArithmeticBuiltin(declaration)) {
+                    throw new IllegalStateException("Missing GCC builtin: " + declaration.getName());
+                } else {
+                    return GCCAddWithOverflowNodeGen.create(args[1], args[2], args[3], sourceSection);
+                }
+            case "@__builtin_sub_overflow":
+                if (isZeroExtendArithmeticBuiltin(declaration)) {
+                    throw new IllegalStateException("Missing GCC builtin: " + declaration.getName());
+                } else {
+                    return GCCSubWithOverflowNodeGen.create(args[1], args[2], args[3], sourceSection);
+                }
+            case "@__builtin_mul_overflow":
+                if (isZeroExtendArithmeticBuiltin(declaration)) {
+                    return GCCUMulWithOverflowNodeGen.create(args[1], args[2], args[3], sourceSection);
+                } else {
+                    return GCCSMulWithOverflowNodeGen.create(args[1], args[2], args[3], sourceSection);
+                }
+
+            default:
+                throw new IllegalStateException("Missing GCC builtin: " + declaration.getName());
+        }
+    }
+
+    private static boolean isZeroExtendArithmeticBuiltin(FunctionDeclaration declaration) {
+        final AttributesGroup group = declaration.getParameterAttributesGroup(0);
+        if (group == null) {
+            return false;
+        }
+        for (Attribute a : group.getAttributes()) {
+            if (a instanceof KnownAttribute && ((KnownAttribute) a).getAttr() == Attribute.Kind.ZEROEXT) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
@@ -124,12 +124,16 @@ import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUAddWithOverflowF
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUAddWithOverflowFactory.LLVMUAddWithOverflowAndCarryI16NodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUAddWithOverflowFactory.LLVMUAddWithOverflowAndCarryI32NodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.arith.LLVMUAddWithOverflowFactory.LLVMUAddWithOverflowAndCarryI64NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.bit.CountLeadingZeroesNodeFactory.CountLeadingZeroesI16NodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.bit.CountLeadingZeroesNodeFactory.CountLeadingZeroesI32NodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.bit.CountLeadingZeroesNodeFactory.CountLeadingZeroesI64NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.bit.CountLeadingZeroesNodeFactory.CountLeadingZeroesI8NodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.bit.CountSetBitsNodeFactory.CountSetBitsI32NodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.bit.CountSetBitsNodeFactory.CountSetBitsI64NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.bit.CountTrailingZeroesNodeFactory.CountTrailingZeroesI16NodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.bit.CountTrailingZeroesNodeFactory.CountTrailingZeroesI32NodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.bit.CountTrailingZeroesNodeFactory.CountTrailingZeroesI64NodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.bit.CountTrailingZeroesNodeFactory.CountTrailingZeroesI8NodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.x86.LLVMX86_64BitVACopyNodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.x86.LLVMX86_64BitVAEnd;
 import com.oracle.truffle.llvm.nodes.intrinsics.llvm.x86.LLVMX86_64BitVAStart;
@@ -596,6 +600,10 @@ public class BasicNodeFactory implements NodeFactory {
                 return LLVMNoOpNodeGen.create(sourceSection);
             case "@llvm.prefetch":
                 return LLVMPrefetchNodeGen.create(args[1], args[2], args[3], args[4], sourceSection);
+            case "@llvm.ctlz.i8":
+                return CountLeadingZeroesI8NodeGen.create(args[1], args[2], sourceSection);
+            case "@llvm.ctlz.i16":
+                return CountLeadingZeroesI16NodeGen.create(args[1], args[2], sourceSection);
             case "@llvm.ctlz.i32":
                 return CountLeadingZeroesI32NodeGen.create(args[1], args[2], sourceSection);
             case "@llvm.ctlz.i64":
@@ -608,6 +616,10 @@ public class BasicNodeFactory implements NodeFactory {
                 return CountSetBitsI32NodeGen.create(args[1], sourceSection);
             case "@llvm.ctpop.i64":
                 return CountSetBitsI64NodeGen.create(args[1], sourceSection);
+            case "@llvm.cttz.i8":
+                return CountTrailingZeroesI8NodeGen.create(args[1], args[2], sourceSection);
+            case "@llvm.cttz.i16":
+                return CountTrailingZeroesI16NodeGen.create(args[1], args[2], sourceSection);
             case "@llvm.cttz.i32":
                 return CountTrailingZeroesI32NodeGen.create(args[1], args[2], sourceSection);
             case "@llvm.cttz.i64":

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMBitcodeInstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMBitcodeInstructionVisitor.java
@@ -234,7 +234,7 @@ final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
 
         final SourceSection sourceSection = runtime.getSourceSection(call);
         final Symbol target = call.getCallTarget();
-        LLVMExpressionNode result = nodeFactory.createLLVMBuiltin(target, argNodes, argCount, sourceSection);
+        LLVMExpressionNode result = nodeFactory.createLLVMBuiltin(runtime, target, argNodes, argCount, sourceSection);
         if (result == null) {
             if (target instanceof InlineAsmConstant) {
                 final InlineAsmConstant inlineAsmConstant = (InlineAsmConstant) target;
@@ -315,7 +315,7 @@ final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
         }
 
         final SourceSection sourceSection = runtime.getSourceSection(call);
-        LLVMExpressionNode node = nodeFactory.createLLVMBuiltin(target, args, argCount, sourceSection);
+        LLVMExpressionNode node = nodeFactory.createLLVMBuiltin(runtime, target, args, argCount, sourceSection);
         if (node == null) {
             if (target instanceof InlineAsmConstant) {
                 final InlineAsmConstant inlineAsmConstant = (InlineAsmConstant) target;
@@ -387,7 +387,7 @@ final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
                         unwindType.toArray(new Type[unwindType.size()]));
 
         final SourceSection sourceSection = runtime.getSourceSection(call);
-        LLVMExpressionNode function = nodeFactory.createLLVMBuiltin(target, argNodes, argCount, null);
+        LLVMExpressionNode function = nodeFactory.createLLVMBuiltin(runtime, target, argNodes, argCount, null);
         if (function == null) {
             function = symbols.resolve(target);
         }
@@ -452,7 +452,7 @@ final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
                         unwindType.toArray(new Type[unwindType.size()]));
 
         final SourceSection sourceSection = runtime.getSourceSection(call);
-        LLVMExpressionNode function = nodeFactory.createLLVMBuiltin(target, args, argCount, null);
+        LLVMExpressionNode function = nodeFactory.createLLVMBuiltin(runtime, target, args, argCount, null);
         if (function == null) {
             function = symbols.resolve(target);
         }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactory.java
@@ -173,7 +173,7 @@ public interface NodeFactory {
     LLVMExpressionNode createCompareExchangeInstruction(LLVMParserRuntime runtime, Type returnType, Type elementType, LLVMExpressionNode ptrNode, LLVMExpressionNode cmpNode,
                     LLVMExpressionNode newNode);
 
-    LLVMExpressionNode createLLVMBuiltin(Symbol target, LLVMExpressionNode[] args, int callerArgumentCount, SourceSection sourceSection);
+    LLVMExpressionNode createLLVMBuiltin(LLVMParserRuntime runtime, Symbol target, LLVMExpressionNode[] args, int callerArgumentCount, SourceSection sourceSection);
 
     NativeIntrinsicProvider getNativeIntrinsicsFactory(LLVMLanguage language, LLVMContext context);
 

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_sadd_i16.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_sadd_i16.c
@@ -1,0 +1,46 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_add_overflow(signed short, signed short, signed short*);
+#endif
+
+int main(int argc, const char **argv) {
+  signed short res;
+
+  if (__builtin_add_overflow((signed short)0x0, (signed short)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed short)0x7FFF, (signed short)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed short)0x0, (signed short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed short)0x8000, (signed short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed short)0x7FFF, (signed short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed short)0x7FFF, (signed short)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed short)0x1, (signed short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed short)0x7FFF, (signed short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed short)0x8000, (signed short)0x8000, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_sadd_i32.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_sadd_i32.c
@@ -1,0 +1,46 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_add_overflow(signed int, signed int, signed int*);
+#endif
+
+int main(int argc, const char **argv) {
+  signed int res;
+
+  if (__builtin_add_overflow((signed int)0x0, (signed int)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed int)0x7FFFFFFF, (signed int)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed int)0x0, (signed int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed int)0x80000000, (signed int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed int)0x7FFFFFFF, (signed int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed int)0x7FFFFFFF, (signed int)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed int)0x1, (signed int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed int)0x7FFFFFFF, (signed int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed int)0x80000000, (signed int)0x80000000, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_sadd_i64.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_sadd_i64.c
@@ -1,0 +1,46 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_add_overflow(signed long, signed long, signed long*);
+#endif
+
+int main(int argc, const char **argv) {
+  signed long res;
+
+  if (__builtin_add_overflow((signed long)0x0, (signed long)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed long)0x0, (signed long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed long)0x8000000000000000, (signed long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed long)0x1, (signed long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed long)0x8000000000000000, (signed long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_sadd_i8.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_sadd_i8.c
@@ -1,0 +1,46 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_add_overflow(signed char, signed char, signed char*);
+#endif
+
+int main(int argc, const char **argv) {
+  signed char res;
+
+  if (__builtin_add_overflow((signed char)0x0, (signed char)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed char)0x7F, (signed char)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed char)0x0, (signed char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed char)0x80, (signed char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (__builtin_add_overflow((signed char)0x7F, (signed char)0x80, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed char)0x7F, (signed char)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed char)0x1, (signed char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed char)0x7F, (signed char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_add_overflow((signed char)0x80, (signed char)0x80, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_smul_i16.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_smul_i16.c
@@ -1,0 +1,106 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_mul_overflow(signed short, signed short, signed short*);
+#endif
+
+int main(int argc, const char **argv) {
+  signed short res;
+
+  if (__builtin_mul_overflow((signed short)0x0, (signed short)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0x0, (signed short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0x0, (signed short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0x1, (signed short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0x1, (signed short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0x2, (signed short)0x3FFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0x2, (signed short)0xC000, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed short)0x2, (signed short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed short)0x2, (signed short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0x0FFF, (signed short)0x8, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed short)0x1000, (signed short)0x8, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0x7FFF, (signed short)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0x7FFF, (signed short)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed short)0x7FFF, (signed short)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed short)0x7FFF, (signed short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed short)0x7FFF, (signed short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0x8000, (signed short)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0x8000, (signed short)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed short)0x8000, (signed short)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed short)0x8000, (signed short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed short)0x8000, (signed short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0xFFFF, (signed short)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0xFFFF, (signed short)0x1, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed short)0xFFFF, (signed short)0xFFFF, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_smul_i32.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_smul_i32.c
@@ -1,0 +1,106 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_mul_overflow(signed int, signed int, signed int*);
+#endif
+
+int main(int argc, const char **argv) {
+  signed int res;
+
+  if (__builtin_mul_overflow((signed int)0x0, (signed int)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0x0, (signed int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0x0, (signed int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0x1, (signed int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0x1, (signed int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0x2, (signed int)0x3FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0x2, (signed int)0xC0000000, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed int)0x2, (signed int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed int)0x2, (signed int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0x0FFFFFFF, (signed int)0x8, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed int)0x10000000, (signed int)0x8, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0x7FFFFFFF, (signed int)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0x7FFFFFFF, (signed int)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed int)0x7FFFFFFF, (signed int)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed int)0x7FFFFFFF, (signed int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed int)0x7FFFFFFF, (signed int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0x80000000, (signed int)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0x80000000, (signed int)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed int)0x80000000, (signed int)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed int)0x80000000, (signed int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed int)0x80000000, (signed int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0xFFFFFFFF, (signed int)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0xFFFFFFFF, (signed int)0x1, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed int)0xFFFFFFFF, (signed int)0xFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_smul_i64.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_smul_i64.c
@@ -1,0 +1,106 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_mul_overflow(signed long, signed long, signed long*);
+#endif
+
+int main(int argc, const char **argv) {
+  signed long res;
+
+  if (__builtin_mul_overflow((signed long)0x0, (signed long)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0x0, (signed long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0x0, (signed long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0x1, (signed long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0x1, (signed long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0x2, (signed long)0x3FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0x2, (signed long)0xC000000000000000, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed long)0x2, (signed long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed long)0x2, (signed long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0x0FFFFFFFFFFFFFFF, (signed long)0x8, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed long)0x1000000000000000, (signed long)0x8, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0x8000000000000000, (signed long)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0x8000000000000000, (signed long)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed long)0x8000000000000000, (signed long)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed long)0x8000000000000000, (signed long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed long)0x8000000000000000, (signed long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0xFFFFFFFFFFFFFFFF, (signed long)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0xFFFFFFFFFFFFFFFF, (signed long)0x1, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed long)0xFFFFFFFFFFFFFFFF, (signed long)0xFFFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_smul_i8.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_smul_i8.c
@@ -1,0 +1,106 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_mul_overflow(signed char, signed char, signed char*);
+#endif
+
+int main(int argc, const char **argv) {
+  signed char res;
+
+  if (__builtin_mul_overflow((signed char)0x0, (signed char)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0x0, (signed char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0x0, (signed char)0x80, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0x1, (signed char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0x1, (signed char)0x80, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0x2, (signed char)0x3F, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0x2, (signed char)0xC0, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed char)0x2, (signed char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed char)0x2, (signed char)0x80, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0x0F, (signed char)0x8, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed char)0x10, (signed char)0x8, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0x7F, (signed char)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0x7F, (signed char)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed char)0x7F, (signed char)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed char)0x7F, (signed char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed char)0x7F, (signed char)0x80, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0x80, (signed char)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0x80, (signed char)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed char)0x80, (signed char)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed char)0x80, (signed char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((signed char)0x80, (signed char)0x80, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0xFF, (signed char)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0xFF, (signed char)0x1, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((signed char)0xFF, (signed char)0xFF, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_ssub_i16.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_ssub_i16.c
@@ -1,0 +1,66 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_sub_overflow(signed short, signed short, signed short*);
+#endif
+
+int main(int argc, const char **argv) {
+  signed short res;
+
+  if (__builtin_sub_overflow((signed short)0x0, (signed short)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed short)0x0, (signed short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed short)0x0, (signed short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed short)0x0, (signed short)0x8001, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed short)0x1, (signed short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed short)0x7FFF, (signed short)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed short)0x7FFF, (signed short)0x1, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed short)0x7FFF, (signed short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed short)0x7FFF, (signed short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed short)0x7FFF, (signed short)0xFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed short)0x8000, (signed short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed short)0x8000, (signed short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed short)0x8001, (signed short)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed short)0x8001, (signed short)0x2, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_ssub_i32.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_ssub_i32.c
@@ -1,0 +1,66 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_sub_overflow(signed int, signed int, signed int*);
+#endif
+
+int main(int argc, const char **argv) {
+  signed int res;
+
+  if (__builtin_sub_overflow((signed int)0x0, (signed int)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed int)0x0, (signed int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed int)0x0, (signed int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed int)0x0, (signed int)0x80000001, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed int)0x1, (signed int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed int)0x7FFFFFFF, (signed int)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed int)0x7FFFFFFF, (signed int)0x1, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed int)0x7FFFFFFF, (signed int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed int)0x7FFFFFFF, (signed int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed int)0x7FFFFFFF, (signed int)0xFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed int)0x80000000, (signed int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed int)0x80000000, (signed int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed int)0x80000001, (signed int)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed int)0x80000001, (signed int)0x2, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_ssub_i64.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_ssub_i64.c
@@ -1,0 +1,66 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_sub_overflow(signed long, signed long, signed long*);
+#endif
+
+int main(int argc, const char **argv) {
+  signed long res;
+
+  if (__builtin_sub_overflow((signed long)0x0, (signed long)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed long)0x0, (signed long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed long)0x0, (signed long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed long)0x0, (signed long)0x8000000000000001, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed long)0x1, (signed long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0x1, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed long)0x7FFFFFFFFFFFFFFF, (signed long)0xFFFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed long)0x8000000000000000, (signed long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed long)0x8000000000000000, (signed long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed long)0x8000000000000001, (signed long)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed long)0x8000000000000001, (signed long)0x2, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_ssub_i8.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_ssub_i8.c
@@ -1,0 +1,66 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_sub_overflow(signed char, signed char, signed char*);
+#endif
+
+int main(int argc, const char **argv) {
+  signed char res;
+
+  if (__builtin_sub_overflow((signed char)0x0, (signed char)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed char)0x0, (signed char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed char)0x0, (signed char)0x80, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed char)0x0, (signed char)0x81, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed char)0x1, (signed char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed char)0x7F, (signed char)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed char)0x7F, (signed char)0x1, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed char)0x7F, (signed char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed char)0x7F, (signed char)0x80, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed char)0x7F, (signed char)0xFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed char)0x80, (signed char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed char)0x80, (signed char)0x80, &res)) {
+    return -1;
+  }
+
+  if (__builtin_sub_overflow((signed char)0x81, (signed char)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_sub_overflow((signed char)0x81, (signed char)0x2, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_uadd_i16.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_uadd_i16.c
@@ -1,0 +1,74 @@
+#ifndef __clang__
+unsigned short __builtin_addcs(unsigned short, unsigned short, unsigned short, unsigned short*);
+#endif
+
+int main(int argc, const char **argv) {
+  unsigned short carryout;
+
+  __builtin_addcs((unsigned short)0x0, (unsigned short)0x0, 0, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcs((unsigned short)0xFFFF, (unsigned short)0x0, 0, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcs((unsigned short)0x0, (unsigned short)0xFFFF, 0, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcs((unsigned short)0xFFFF, (unsigned short)0x1, 0, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcs((unsigned short)0x1, (unsigned short)0xFFFF, 0, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcs((unsigned short)0xFFFF, (unsigned short)0xFFFF, 0, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcs((unsigned short)0x0, (unsigned short)0xFFFE, 1, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcs((unsigned short)0x0, (unsigned short)0xFFFF, 1, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcs((unsigned short)0xFFFE, (unsigned short)0x0, 1, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcs((unsigned short)0xFFFF, (unsigned short)0x0, 1, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcs((unsigned short)0xFFFF, (unsigned short)0xFFFF, 1, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  unsigned short res1 = __builtin_addcs((unsigned short)0x0FFF, (unsigned short)0x1, 0, &carryout);
+  if (res1 != 0x1000 || carryout != 0) {
+    return -1;
+  }
+
+  unsigned short res2 = __builtin_addcs((unsigned short)0x0FFF, (unsigned short)0x1, 1, &carryout);
+  if (res2 != 0x1001 || carryout != 0) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_uadd_i32.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_uadd_i32.c
@@ -1,0 +1,74 @@
+#ifndef __clang__
+unsigned int __builtin_addc(unsigned int, unsigned int, unsigned int, unsigned int*);
+#endif
+
+int main(int argc, const char **argv) {
+  unsigned int carryout;
+
+  __builtin_addc((unsigned int)0x0, (unsigned int)0x0, 0, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addc((unsigned int)0xFFFFFFFF, (unsigned int)0x0, 0, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addc((unsigned int)0x0, (unsigned int)0xFFFFFFFF, 0, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addc((unsigned int)0xFFFFFFFF, (unsigned int)0x1, 0, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addc((unsigned int)0x1, (unsigned int)0xFFFFFFFF, 0, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addc((unsigned int)0xFFFFFFFF, (unsigned int)0xFFFFFFFF, 0, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addc((unsigned int)0x0, (unsigned int)0xFFFFFFFE, 1, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addc((unsigned int)0x0, (unsigned int)0xFFFFFFFF, 1, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addc((unsigned int)0xFFFFFFFE, (unsigned int)0x0, 1, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addc((unsigned int)0xFFFFFFFF, (unsigned int)0x0, 1, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addc((unsigned int)0xFFFFFFFF, (unsigned int)0xFFFFFFFF, 1, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  unsigned int res1 = __builtin_addc((unsigned int)0x0FFFFFFF, (unsigned int)0x1, 0, &carryout);
+  if (res1 != 0x10000000 || carryout != 0) {
+    return -1;
+  }
+
+  unsigned int res2 = __builtin_addc((unsigned int)0x0FFFFFFF, (unsigned int)0x1, 1, &carryout);
+  if (res2 != 0x10000001 || carryout != 0) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_uadd_i64.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_uadd_i64.c
@@ -1,0 +1,74 @@
+#ifndef __clang__
+unsigned long __builtin_addcl(unsigned long, unsigned long, unsigned long, unsigned long*);
+#endif
+
+int main(int argc, const char **argv) {
+  unsigned long carryout;
+
+  __builtin_addcl((unsigned long)0x0, (unsigned long)0x0, 0, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcl((unsigned long)0xFFFFFFFFFFFFFFFF, (unsigned long)0x0, 0, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcl((unsigned long)0x0, (unsigned long)0xFFFFFFFFFFFFFFFF, 0, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcl((unsigned long)0xFFFFFFFFFFFFFFFF, (unsigned long)0x1, 0, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcl((unsigned long)0x1, (unsigned long)0xFFFFFFFFFFFFFFFF, 0, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcl((unsigned long)0xFFFFFFFFFFFFFFFF, (unsigned long)0xFFFFFFFFFFFFFFF, 0, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcl((unsigned long)0x0, (unsigned long)0xFFFFFFFFFFFFFFFE, 1, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcl((unsigned long)0x0, (unsigned long)0xFFFFFFFFFFFFFFFF, 1, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcl((unsigned long)0xFFFFFFFFFFFFFFFE, (unsigned long)0x0, 1, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcl((unsigned long)0xFFFFFFFFFFFFFFFF, (unsigned long)0x0, 1, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcl((unsigned long)0xFFFFFFFFFFFFFFFF, (unsigned long)0xFFFFFFFFFFFFFFFF, 1, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  long res1 = __builtin_addcl((unsigned long)0x0FFFFFFFFFFFFFFF, (unsigned long)0x1, 0, &carryout);
+  if (res1 != 0x1000000000000000 || carryout != 0) {
+    return -1;
+  }
+
+  long res2 = __builtin_addcl((unsigned long)0x0FFFFFFFFFFFFFFF, (unsigned long)0x1, 1, &carryout);
+  if (res2 != 0x1000000000000001 || carryout != 0) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_uadd_i8.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_uadd_i8.c
@@ -1,0 +1,74 @@
+#ifndef __clang__
+unsigned char __builtin_addcb(unsigned char, unsigned char, unsigned char, unsigned char*);
+#endif
+
+int main(int argc, const char **argv) {
+  unsigned char carryout;
+
+  __builtin_addcb((unsigned char)0x0, (unsigned char)0x0, 0, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcb((unsigned char)0xFF, (unsigned char)0x0, 0, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcb((unsigned char)0x0, (unsigned char)0xFF, 0, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcb((unsigned char)0xFF, (unsigned char)0x1, 0, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcb((unsigned char)0x1, (unsigned char)0xFF, 0, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcb((unsigned char)0xFF, (unsigned char)0xFF, 0, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcb((unsigned char)0x0, (unsigned char)0xFE, 1, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcb((unsigned char)0x0, (unsigned char)0xFF, 1, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcb((unsigned char)0xFE, (unsigned char)0x0, 1, &carryout);
+  if (carryout != 0) {
+    return -1;
+  }
+
+  __builtin_addcb((unsigned char)0xFF, (unsigned char)0x0, 1, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  __builtin_addcb((unsigned char)0xFF, (unsigned char)0xFF, 1, &carryout);
+  if (carryout != 1) {
+    return -1;
+  }
+
+  unsigned char res1 = __builtin_addcb((unsigned char)0x0F, (unsigned char)0x1, 0, &carryout);
+  if (res1 != 0x10 || carryout != 0) {
+    return -1;
+  }
+
+  unsigned char res2 = __builtin_addcb((unsigned char)0x0F, (unsigned char)0x1, 1, &carryout);
+  if (res2 != 0x11 || carryout != 0) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_umul_i16.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_umul_i16.c
@@ -1,0 +1,130 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_mul_overflow(unsigned short, unsigned short, unsigned short*);
+#endif
+
+int main(int argc, const char **argv) {
+  unsigned short res;
+
+  if (__builtin_mul_overflow((unsigned short)0x0, (unsigned short)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0x0, (unsigned short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0x0, (unsigned short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0x1, (unsigned short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0x1, (unsigned short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0x2, (unsigned short)0x3FFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned short)0x2, (unsigned short)0xC000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0x2, (unsigned short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned short)0x2, (unsigned short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned short)0x4, (unsigned short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned short)0x4, (unsigned short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0x0F, (unsigned short)0x8, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0x1000, (unsigned short)0x8, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned short)0x1000, (unsigned short)0x1000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0x7FFF, (unsigned short)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0x7FFF, (unsigned short)0x1, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0x7FFF, (unsigned short)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned short)0x7FFF, (unsigned short)0x4, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned short)0x7FFF, (unsigned short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned short)0x7FFF, (unsigned short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0x8000, (unsigned short)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0x8000, (unsigned short)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned short)0x8000, (unsigned short)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned short)0x8000, (unsigned short)0x7FFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned short)0x8000, (unsigned short)0x8000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0xFFFF, (unsigned short)0x0, &res)) {
+    return -1;
+  }
+
+  if (res != 0x0) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned short)0xFFFF, (unsigned short)0x1, &res)) {
+    return -1;
+  }
+
+  if (res != 0xFFFF) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned short)0xFFFF, (unsigned short)0xFFFF, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_umul_i32.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_umul_i32.c
@@ -1,0 +1,135 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_mul_overflow(unsigned int, unsigned int, unsigned int*);
+#endif
+
+int main(int argc, const char **argv) {
+  unsigned int res;
+
+#ifndef __clang__
+  #warning "Disable testcase for non clang compiler!"
+  return 0;
+#endif
+
+  if (__builtin_mul_overflow((unsigned int)0x0, (unsigned int)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0x0, (unsigned int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0x0, (unsigned int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0x1, (unsigned int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0x1, (unsigned int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0x2, (unsigned int)0x3FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned int)0x2, (unsigned int)0xC0000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0x2, (unsigned int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned int)0x2, (unsigned int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned int)0x4, (unsigned int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned int)0x4, (unsigned int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0x0F, (unsigned int)0x8, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0x10000000, (unsigned int)0x8, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned int)0x10000000, (unsigned int)0x10000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0x7FFFFFFF, (unsigned int)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0x7FFFFFFF, (unsigned int)0x1, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0x7FFFFFFF, (unsigned int)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned int)0x7FFFFFFF, (unsigned int)0x4, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned int)0x7FFFFFFF, (unsigned int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned int)0x7FFFFFFF, (unsigned int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0x80000000, (unsigned int)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0x80000000, (unsigned int)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned int)0x80000000, (unsigned int)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned int)0x80000000, (unsigned int)0x7FFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned int)0x80000000, (unsigned int)0x80000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0xFFFFFFFF, (unsigned int)0x0, &res)) {
+    return -1;
+  }
+
+  if (res != 0x0) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned int)0xFFFFFFFF, (unsigned int)0x1, &res)) {
+    return -1;
+  }
+
+  if (res != 0xFFFFFFFF) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned int)0xFFFFFFFF, (unsigned int)0xFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_umul_i64.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_umul_i64.c
@@ -1,0 +1,135 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_mul_overflow(unsigned long, unsigned long, unsigned long*);
+#endif
+
+int main(int argc, const char **argv) {
+  unsigned long res;
+
+#ifndef __clang__
+  #warning "Disable testcase for non clang compiler!"
+  return 0;
+#endif
+
+  if (__builtin_mul_overflow((unsigned long)0x0, (unsigned long)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0x0, (unsigned long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0x0, (unsigned long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0x1, (unsigned long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0x1, (unsigned long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0x2, (unsigned long)0x3FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned long)0x2, (unsigned long)0xC000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0x2, (unsigned long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned long)0x2, (unsigned long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned long)0x4, (unsigned long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned long)0x4, (unsigned long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0x0F, (unsigned long)0x8, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0x1000000000000000, (unsigned long)0x8, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned long)0x1000000000000000, (unsigned long)0x1000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0x7FFFFFFFFFFFFFFF, (unsigned long)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0x7FFFFFFFFFFFFFFF, (unsigned long)0x1, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0x7FFFFFFFFFFFFFFF, (unsigned long)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned long)0x7FFFFFFFFFFFFFFF, (unsigned long)0x4, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned long)0x7FFFFFFFFFFFFFFF, (unsigned long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned long)0x7FFFFFFFFFFFFFFF, (unsigned long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0x8000000000000000, (unsigned long)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0x8000000000000000, (unsigned long)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned long)0x8000000000000000, (unsigned long)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned long)0x8000000000000000, (unsigned long)0x7FFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned long)0x8000000000000000, (unsigned long)0x8000000000000000, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0xFFFFFFFFFFFFFFFF, (unsigned long)0x0, &res)) {
+    return -1;
+  }
+
+  if (res != 0x0) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned long)0xFFFFFFFFFFFFFFFF, (unsigned long)0x1, &res)) {
+    return -1;
+  }
+
+  if (res != 0xFFFFFFFFFFFFFFFF) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned long)0xFFFFFFFFFFFFFFFF, (unsigned long)0xFFFFFFFFFFFFFFFF, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_umul_i8.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_umul_i8.c
@@ -1,0 +1,130 @@
+#ifndef __clang__
+#include <stdbool.h>
+bool __builtin_mul_overflow(unsigned char, unsigned char, unsigned char*);
+#endif
+
+int main(int argc, const char **argv) {
+  unsigned char res;
+
+  if (__builtin_mul_overflow((unsigned char)0x0, (unsigned char)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0x0, (unsigned char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0x0, (unsigned char)0x80, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0x1, (unsigned char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0x1, (unsigned char)0x80, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0x2, (unsigned char)0x3F, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned char)0x2, (unsigned char)0xC0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0x2, (unsigned char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned char)0x2, (unsigned char)0x80, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned char)0x4, (unsigned char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned char)0x4, (unsigned char)0x80, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0x0F, (unsigned char)0x8, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0x10, (unsigned char)0x8, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned char)0x10, (unsigned char)0x10, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0x7F, (unsigned char)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0x7F, (unsigned char)0x1, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0x7F, (unsigned char)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned char)0x7F, (unsigned char)0x4, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned char)0x7F, (unsigned char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned char)0x7F, (unsigned char)0x80, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0x80, (unsigned char)0x0, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0x80, (unsigned char)0x1, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned char)0x80, (unsigned char)0x2, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned char)0x80, (unsigned char)0x7F, &res)) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned char)0x80, (unsigned char)0x80, &res)) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0xFF, (unsigned char)0x0, &res)) {
+    return -1;
+  }
+
+  if (res != 0x0) {
+    return -1;
+  }
+
+  if (__builtin_mul_overflow((unsigned char)0xFF, (unsigned char)0x1, &res)) {
+    return -1;
+  }
+
+  if (res != 0xFF) {
+    return -1;
+  }
+
+  if (!__builtin_mul_overflow((unsigned char)0xFF, (unsigned char)0xFF, &res)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_usub_i16.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_usub_i16.c
@@ -1,0 +1,94 @@
+#ifndef __clang__
+unsigned short __builtin_subcs(unsigned short, unsigned short, unsigned short, unsigned short*);
+#endif
+
+int main(int argc, const char **argv) {
+  unsigned short carryout, res;
+
+  res = __builtin_subcs((unsigned short)0x0, (unsigned short)0x0, 0, &carryout);
+  if (res != 0x0 || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcs((unsigned short)0xFFFF, (unsigned short)0x0, 0, &carryout);
+  if (res != 0xFFFF || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcs((unsigned short)0x0, (unsigned short)0xFFFF, 0, &carryout);
+  if (res != 0x01 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcs((unsigned short)0xFFFF, (unsigned short)0x1, 0, &carryout);
+  if (res != 0xFFFE || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcs((unsigned short)0x1, (unsigned short)0xFFFF, 0, &carryout);
+  if (res != 0x2 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcs((unsigned short)0xFFFF, (unsigned short)0xFFFF, 0, &carryout);
+  if (res != 0x0 || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcs((unsigned short)0x8FFF, (unsigned short)0x0FFF, 0, &carryout);
+  if (res != 0x8000 || carryout != 0) {
+    return res;
+  }
+
+  res = __builtin_subcs((unsigned short)0x0, (unsigned short)0xFFFE, 1, &carryout);
+  if (res != 0x1 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcs((unsigned short)0x0, (unsigned short)0xFFFF, 1, &carryout);
+  if (res != 0x0 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcs((unsigned short)0xFFFE, (unsigned short)0x0, 1, &carryout);
+  if (res != 0xFFFD || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcs((unsigned short)0xFFFE, (unsigned short)0xFFFE, 1, &carryout);
+  if (res != 0xFFFF || carryout != 1) {
+    return res;
+  }
+
+  res = __builtin_subcs((unsigned short)0xFFFE, (unsigned short)0xFFFF, 0, &carryout);
+  if (res != 0xFFFF || carryout != 1) {
+    return res;
+  }
+
+  res = __builtin_subcs((unsigned short)0xFFFE, (unsigned short)0xFFFF, 1, &carryout);
+  if (res != 0xFFFE || carryout != 1) {
+    return res;
+  }
+
+  res = __builtin_subcs((unsigned short)0xFFFF, (unsigned short)0x0, 1, &carryout);
+  if (res != 0xFFFE || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcs((unsigned short)0xFFFF, (unsigned short)0xFFFF, 1, &carryout);
+  if (res != 0xFFFF || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcs((unsigned short)0x0F, (unsigned short)0x1, 0, &carryout);
+  if (res != 0x0E || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcs((unsigned short)0x0F, (unsigned short)0x1, 1, &carryout);
+  if (res != 0x0D || carryout != 0) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_usub_i32.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_usub_i32.c
@@ -1,0 +1,94 @@
+#ifndef __clang__
+unsigned int __builtin_subc(unsigned int, unsigned int, unsigned int, unsigned int*);
+#endif
+
+int main(int argc, const char **argv) {
+  unsigned int carryout, res;
+
+  res = __builtin_subc((unsigned int)0x0, (unsigned int)0x0, 0, &carryout);
+  if (res != 0x0 || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subc((unsigned int)0xFFFFFFFF, (unsigned int)0x0, 0, &carryout);
+  if (res != 0xFFFFFFFF || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subc((unsigned int)0x0, (unsigned int)0xFFFFFFFF, 0, &carryout);
+  if (res != 0x01 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subc((unsigned int)0xFFFFFFFF, (unsigned int)0x1, 0, &carryout);
+  if (res != 0xFFFFFFFE || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subc((unsigned int)0x1, (unsigned int)0xFFFFFFFF, 0, &carryout);
+  if (res != 0x2 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subc((unsigned int)0xFFFFFFFF, (unsigned int)0xFFFFFFFF, 0, &carryout);
+  if (res != 0x0 || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subc((unsigned int)0x8FFFFFFF, (unsigned int)0x0FFFFFFF, 0, &carryout);
+  if (res != 0x80000000 || carryout != 0) {
+    return res;
+  }
+
+  res = __builtin_subc((unsigned int)0x0, (unsigned int)0xFFFFFFFE, 1, &carryout);
+  if (res != 0x1 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subc((unsigned int)0x0, (unsigned int)0xFFFFFFFF, 1, &carryout);
+  if (res != 0x0 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subc((unsigned int)0xFFFFFFFE, (unsigned int)0x0, 1, &carryout);
+  if (res != 0xFFFFFFFD || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subc((unsigned int)0xFFFFFFFE, (unsigned int)0xFFFFFFFE, 1, &carryout);
+  if (res != 0xFFFFFFFF || carryout != 1) {
+    return res;
+  }
+
+  res = __builtin_subc((unsigned int)0xFFFFFFFE, (unsigned int)0xFFFFFFFF, 0, &carryout);
+  if (res != 0xFFFFFFFF || carryout != 1) {
+    return res;
+  }
+
+  res = __builtin_subc((unsigned int)0xFFFFFFFE, (unsigned int)0xFFFFFFFF, 1, &carryout);
+  if (res != 0xFFFFFFFE || carryout != 1) {
+    return res;
+  }
+
+  res = __builtin_subc((unsigned int)0xFFFFFFFF, (unsigned int)0x0, 1, &carryout);
+  if (res != 0xFFFFFFFE || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subc((unsigned int)0xFFFFFFFF, (unsigned int)0xFFFFFFFF, 1, &carryout);
+  if (res != 0xFFFFFFFF || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subc((unsigned int)0x0F, (unsigned int)0x1, 0, &carryout);
+  if (res != 0x0E || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subc((unsigned int)0x0F, (unsigned int)0x1, 1, &carryout);
+  if (res != 0x0D || carryout != 0) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_usub_i64.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_usub_i64.c
@@ -1,0 +1,94 @@
+#ifndef __clang__
+unsigned long __builtin_subcl(unsigned long, unsigned long, unsigned long, unsigned long*);
+#endif
+
+int main(int argc, const char **argv) {
+  unsigned long carryout, res;
+
+  res = __builtin_subcl((unsigned long)0x0, (unsigned long)0x0, 0, &carryout);
+  if (res != 0x0 || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcl((unsigned long)0xFFFFFFFFFFFFFFFF, (unsigned long)0x0, 0, &carryout);
+  if (res != 0xFFFFFFFFFFFFFFFF || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcl((unsigned long)0x0, (unsigned long)0xFFFFFFFFFFFFFFFF, 0, &carryout);
+  if (res != 0x01 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcl((unsigned long)0xFFFFFFFFFFFFFFFF, (unsigned long)0x1, 0, &carryout);
+  if (res != 0xFFFFFFFFFFFFFFFE || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcl((unsigned long)0x1, (unsigned long)0xFFFFFFFFFFFFFFFF, 0, &carryout);
+  if (res != 0x2 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcl((unsigned long)0xFFFFFFFFFFFFFFFF, (unsigned long)0xFFFFFFFFFFFFFFFF, 0, &carryout);
+  if (res != 0x0 || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcl((unsigned long)0x8FFFFFFFFFFFFFFF, (unsigned long)0x0FFFFFFFFFFFFFFF, 0, &carryout);
+  if (res != 0x8000000000000000 || carryout != 0) {
+    return res;
+  }
+
+  res = __builtin_subcl((unsigned long)0x0, (unsigned long)0xFFFFFFFFFFFFFFFE, 1, &carryout);
+  if (res != 0x1 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcl((unsigned long)0x0, (unsigned long)0xFFFFFFFFFFFFFFFF, 1, &carryout);
+  if (res != 0x0 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcl((unsigned long)0xFFFFFFFFFFFFFFFE, (unsigned long)0x0, 1, &carryout);
+  if (res != 0xFFFFFFFFFFFFFFFD || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcl((unsigned long)0xFFFFFFFFFFFFFFFE, (unsigned long)0xFFFFFFFFFFFFFFFE, 1, &carryout);
+  if (res != 0xFFFFFFFFFFFFFFFF || carryout != 1) {
+    return res;
+  }
+
+  res = __builtin_subcl((unsigned long)0xFFFFFFFFFFFFFFFE, (unsigned long)0xFFFFFFFFFFFFFFFF, 0, &carryout);
+  if (res != 0xFFFFFFFFFFFFFFFF || carryout != 1) {
+    return res;
+  }
+
+  res = __builtin_subcl((unsigned long)0xFFFFFFFFFFFFFFFE, (unsigned long)0xFFFFFFFFFFFFFFFF, 1, &carryout);
+  if (res != 0xFFFFFFFFFFFFFFFE || carryout != 1) {
+    return res;
+  }
+
+  res = __builtin_subcl((unsigned long)0xFFFFFFFFFFFFFFFF, (unsigned long)0x0, 1, &carryout);
+  if (res != 0xFFFFFFFFFFFFFFFE || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcl((unsigned long)0xFFFFFFFFFFFFFFFF, (unsigned long)0xFFFFFFFFFFFFFFFF, 1, &carryout);
+  if (res != 0xFFFFFFFFFFFFFFFF || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcl((unsigned long)0x0F, (unsigned long)0x1, 0, &carryout);
+  if (res != 0x0E || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcl((unsigned long)0x0F, (unsigned long)0x1, 1, &carryout);
+  if (res != 0x0D || carryout != 0) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_usub_i8.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin/arithmetic/arithmetic_usub_i8.c
@@ -1,0 +1,94 @@
+#ifndef __clang__
+unsigned char __builtin_subcb(unsigned char, unsigned char, unsigned char, unsigned char*);
+#endif
+
+int main(int argc, const char **argv) {
+  unsigned char carryout, res;
+
+  res = __builtin_subcb((unsigned char)0x0, (unsigned char)0x0, 0, &carryout);
+  if (res != 0x0 || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcb((unsigned char)0xFF, (unsigned char)0x0, 0, &carryout);
+  if (res != 0xFF || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcb((unsigned char)0x0, (unsigned char)0xFF, 0, &carryout);
+  if (res != 0x01 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcb((unsigned char)0xFF, (unsigned char)0x1, 0, &carryout);
+  if (res != 0xFE || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcb((unsigned char)0x1, (unsigned char)0xFF, 0, &carryout);
+  if (res != 0x2 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcb((unsigned char)0xFF, (unsigned char)0xFF, 0, &carryout);
+  if (res != 0x0 || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcb((unsigned char)0x8F, (unsigned char)0x0F, 0, &carryout);
+  if (res != 0x80 || carryout != 0) {
+    return res;
+  }
+
+  res = __builtin_subcb((unsigned char)0x0, (unsigned char)0xFE, 1, &carryout);
+  if (res != 0x1 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcb((unsigned char)0x0, (unsigned char)0xFF, 1, &carryout);
+  if (res != 0x0 || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcb((unsigned char)0xFE, (unsigned char)0x0, 1, &carryout);
+  if (res != 0xFD || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcb((unsigned char)0xFE, (unsigned char)0xFE, 1, &carryout);
+  if (res != 0xFF || carryout != 1) {
+    return res;
+  }
+
+  res = __builtin_subcb((unsigned char)0xFE, (unsigned char)0xFF, 0, &carryout);
+  if (res != 0xFF || carryout != 1) {
+    return res;
+  }
+
+  res = __builtin_subcb((unsigned char)0xFE, (unsigned char)0xFF, 1, &carryout);
+  if (res != 0xFE || carryout != 1) {
+    return res;
+  }
+
+  res = __builtin_subcb((unsigned char)0xFF, (unsigned char)0x0, 1, &carryout);
+  if (res != 0xFE || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcb((unsigned char)0xFF, (unsigned char)0xFF, 1, &carryout);
+  if (res != 0xFF || carryout != 1) {
+    return -1;
+  }
+
+  res = __builtin_subcb((unsigned char)0x0F, (unsigned char)0x1, 0, &carryout);
+  if (res != 0x0E || carryout != 0) {
+    return -1;
+  }
+
+  res = __builtin_subcb((unsigned char)0x0F, (unsigned char)0x1, 1, &carryout);
+  if (res != 0x0D || carryout != 0) {
+    return -1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Implement some builtin which are used for arithmetic calculation including overflow checks.

There was also a implementation error with the ```"@llvm.uadd.with.overflow.i32``` builtin, which should be fixed now.

Documentation:
* https://clang.llvm.org/docs/LanguageExtensions.html#multiprecision-arithmetic-builtins
* https://llvm.org/docs/LangRef.html#llvm-sadd-with-overflow-intrinsics
* https://github.com/llvm-mirror/clang/blob/release_40/include/clang/Basic/Builtins.def#L1303