### PR TITLE
Implement __builtin_cpu_supports stub

### DIFF
--- a/projects/com.oracle.truffle.llvm.libraries.bitcode/src/builtin.c
+++ b/projects/com.oracle.truffle.llvm.libraries.bitcode/src/builtin.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+struct __llvm_builtin_cpu_model {
+  unsigned int __cpu_vendor;
+  unsigned int __cpu_type;
+  unsigned int __cpu_subtype;
+  unsigned int __cpu_features[1];
+};
+
+struct __llvm_builtin_cpu_model __cpu_model = { 0x00, 0x0, 0x0, 0x0 };

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/Runner.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/Runner.java
@@ -58,6 +58,12 @@ public final class Runner {
 
     public CallTarget parse(LLVMLanguage language, LLVMContext context, Source code) throws IOException {
         try {
+            /*
+             * TODO: currently, we need to load the bitcode libraries first. Otherwise, sulong is
+             * not able to link external variables which were defined in those libraries.
+             */
+            parseDynamicBitcodeLibraries(language, context);
+
             CallTarget mainFunction = null;
             if (code.getMimeType().equals(Sulong.LLVM_BITCODE_MIME_TYPE) || code.getMimeType().equals(Sulong.LLVM_BITCODE_BASE64_MIME_TYPE) || code.getMimeType().equals("x-unknown")) {
                 LLVMParserResult parserResult = parseBitcodeFile(code, language, context);
@@ -94,7 +100,6 @@ public final class Runner {
             } else {
                 throw new IllegalArgumentException("undeclared mime type: " + code.getMimeType());
             }
-            parseDynamicBitcodeLibraries(language, context);
             if (context.getEnv().getOptions().get(SulongEngineOption.PARSE_ONLY)) {
                 return Truffle.getRuntime().createCallTarget(RootNode.createConstantNode(0));
             } else {


### PR DESCRIPTION
Add a stub, which allows applications to check for CPU features. (I'm returning false for all features)

Internally, ```__builtin_cpu_supports``` is not a builtin function we can overwrite with our factory. Instead it's a global variable, which is evaluated inside the instruction block.

I was required to prepend loading of the bitcode files, to allow us to declare global variables, which are then linked correctly into the executed bitcode file. Doing it in the opposite way doesn't work yet in sulong.
(Ask @mrigger for details of that issue)

### Example Program
```c
#include<stdio.h>

#define CHECK_CPU_SUPPORT(f) _check_cpu_support(__builtin_cpu_supports (f), f)

void _check_cpu_support(int isSupported, char *cpu_function) {
    if (isSupported) {
        printf(" * %-7s [Yes]\n", cpu_function);
    } else {
        printf(" * %-7s [No]\n", cpu_function);
    }
}

int main() {

    CHECK_CPU_SUPPORT("cmov");
    CHECK_CPU_SUPPORT("mmx");
    CHECK_CPU_SUPPORT("popcnt");
    CHECK_CPU_SUPPORT("sse");
    CHECK_CPU_SUPPORT("sse2");
    CHECK_CPU_SUPPORT("sse3");
    CHECK_CPU_SUPPORT("ssse3");
    CHECK_CPU_SUPPORT("sse4.1");
    CHECK_CPU_SUPPORT("sse4.2");
    CHECK_CPU_SUPPORT("avx");
    CHECK_CPU_SUPPORT("avx2");
    CHECK_CPU_SUPPORT("popcnt");

    return 0;
}
```