### PR TITLE
Add support for "atomicrmw" instruction

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/rmw/LLVMI16RMWNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/rmw/LLVMI16RMWNode.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.memory.rmw;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+import com.oracle.truffle.llvm.runtime.global.LLVMGlobalVariable;
+import com.oracle.truffle.llvm.runtime.global.LLVMGlobalVariableAccess;
+import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+@NodeChildren(value = {@NodeChild(type = LLVMExpressionNode.class, value = "pointerNode"), @NodeChild(type = LLVMExpressionNode.class, value = "valueNode")})
+public abstract class LLVMI16RMWNode extends LLVMExpressionNode {
+
+    public abstract static class LLVMI16RMWXchgNode extends LLVMI16RMWNode {
+        @Specialization
+        public short execute(LLVMGlobalVariable address, short value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            short old = globalAccess.getI16(address);
+            globalAccess.putI16(address, value);
+            return old;
+        }
+
+        @Specialization
+        public short execute(LLVMAddress address, short value) {
+            short old = LLVMMemory.getI16(address);
+            LLVMMemory.putI16(address, value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI16RMWAddNode extends LLVMI16RMWNode {
+        @Specialization
+        public short execute(LLVMGlobalVariable address, short value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            short old = globalAccess.getI16(address);
+            globalAccess.putI16(address, (short) (old + value));
+            return old;
+        }
+
+        @Specialization
+        public short execute(LLVMAddress address, short value) {
+            short old = LLVMMemory.getI16(address);
+            LLVMMemory.putI16(address, (short) (old + value));
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI16RMWSubNode extends LLVMI16RMWNode {
+        @Specialization
+        public short execute(LLVMGlobalVariable address, short value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            short old = globalAccess.getI16(address);
+            globalAccess.putI16(address, (short) (old - value));
+            return old;
+        }
+
+        @Specialization
+        public short execute(LLVMAddress address, short value) {
+            short old = LLVMMemory.getI16(address);
+            LLVMMemory.putI16(address, (short) (old - value));
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI16RMWAndNode extends LLVMI16RMWNode {
+        @Specialization
+        public short execute(LLVMGlobalVariable address, short value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            short old = globalAccess.getI16(address);
+            globalAccess.putI16(address, (short) (old & value));
+            return old;
+        }
+
+        @Specialization
+        public short execute(LLVMAddress address, short value) {
+            short old = LLVMMemory.getI16(address);
+            LLVMMemory.putI16(address, (short) (old & value));
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI16RMWNandNode extends LLVMI16RMWNode {
+        @Specialization
+        public short execute(LLVMGlobalVariable address, short value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            short old = globalAccess.getI16(address);
+            globalAccess.putI16(address, (short) ~(old & value));
+            return old;
+        }
+
+        @Specialization
+        public short execute(LLVMAddress address, short value) {
+            short old = LLVMMemory.getI16(address);
+            LLVMMemory.putI16(address, (short) ~(old & value));
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI16RMWOrNode extends LLVMI16RMWNode {
+        @Specialization
+        public short execute(LLVMGlobalVariable address, short value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            short old = globalAccess.getI16(address);
+            globalAccess.putI16(address, (short) (old | value));
+            return old;
+        }
+
+        @Specialization
+        public short execute(LLVMAddress address, short value) {
+            short old = LLVMMemory.getI16(address);
+            LLVMMemory.putI16(address, (short) (old | value));
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI16RMWXorNode extends LLVMI16RMWNode {
+        @Specialization
+        public short execute(LLVMGlobalVariable address, short value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            short old = globalAccess.getI16(address);
+            globalAccess.putI16(address, (short) (old ^ value));
+            return old;
+        }
+
+        @Specialization
+        public short execute(LLVMAddress address, short value) {
+            short old = LLVMMemory.getI16(address);
+            LLVMMemory.putI16(address, (short) (old ^ value));
+            return old;
+        }
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/rmw/LLVMI1RMWNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/rmw/LLVMI1RMWNode.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.memory.rmw;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+import com.oracle.truffle.llvm.runtime.global.LLVMGlobalVariable;
+import com.oracle.truffle.llvm.runtime.global.LLVMGlobalVariableAccess;
+import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+@NodeChildren(value = {@NodeChild(type = LLVMExpressionNode.class, value = "pointerNode"), @NodeChild(type = LLVMExpressionNode.class, value = "valueNode")})
+public abstract class LLVMI1RMWNode extends LLVMExpressionNode {
+
+    public abstract static class LLVMI1RMWXchgNode extends LLVMI1RMWNode {
+        @Specialization
+        public boolean execute(LLVMGlobalVariable address, boolean value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            boolean old = globalAccess.getI1(address);
+            globalAccess.putI1(address, value);
+            return old;
+        }
+
+        @Specialization
+        public boolean execute(LLVMAddress address, boolean value) {
+            boolean old = LLVMMemory.getI1(address);
+            LLVMMemory.putI1(address, value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI1RMWAddNode extends LLVMI1RMWNode {
+        @Specialization
+        public boolean execute(LLVMGlobalVariable address, boolean value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            boolean old = globalAccess.getI1(address);
+            globalAccess.putI1(address, old ^ value);
+            return old;
+        }
+
+        @Specialization
+        public boolean execute(LLVMAddress address, boolean value) {
+            boolean old = LLVMMemory.getI1(address);
+            LLVMMemory.putI1(address, old ^ value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI1RMWSubNode extends LLVMI1RMWNode {
+        @Specialization
+        public boolean execute(LLVMGlobalVariable address, boolean value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            boolean old = globalAccess.getI1(address);
+            globalAccess.putI1(address, old ^ value);
+            return old;
+        }
+
+        @Specialization
+        public boolean execute(LLVMAddress address, boolean value) {
+            boolean old = LLVMMemory.getI1(address);
+            LLVMMemory.putI1(address, old ^ value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI1RMWAndNode extends LLVMI1RMWNode {
+        @Specialization
+        public boolean execute(LLVMGlobalVariable address, boolean value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            boolean old = globalAccess.getI1(address);
+            globalAccess.putI1(address, old & value);
+            return old;
+        }
+
+        @Specialization
+        public boolean execute(LLVMAddress address, boolean value) {
+            boolean old = LLVMMemory.getI1(address);
+            LLVMMemory.putI1(address, old & value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI1RMWNandNode extends LLVMI1RMWNode {
+        @Specialization
+        public boolean execute(LLVMGlobalVariable address, boolean value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            boolean old = globalAccess.getI1(address);
+            globalAccess.putI1(address, !(old & value));
+            return old;
+        }
+
+        @Specialization
+        public boolean execute(LLVMAddress address, boolean value) {
+            boolean old = LLVMMemory.getI1(address);
+            LLVMMemory.putI1(address, !(old & value));
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI1RMWOrNode extends LLVMI1RMWNode {
+        @Specialization
+        public boolean execute(LLVMGlobalVariable address, boolean value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            boolean old = globalAccess.getI1(address);
+            globalAccess.putI1(address, old | value);
+            return old;
+        }
+
+        @Specialization
+        public boolean execute(LLVMAddress address, boolean value) {
+            boolean old = LLVMMemory.getI1(address);
+            LLVMMemory.putI1(address, old | value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI1RMWXorNode extends LLVMI1RMWNode {
+        @Specialization
+        public boolean execute(LLVMGlobalVariable address, boolean value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            boolean old = globalAccess.getI1(address);
+            globalAccess.putI1(address, old ^ value);
+            return old;
+        }
+
+        @Specialization
+        public boolean execute(LLVMAddress address, boolean value) {
+            boolean old = LLVMMemory.getI1(address);
+            LLVMMemory.putI1(address, old ^ value);
+            return old;
+        }
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/rmw/LLVMI32RMWNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/rmw/LLVMI32RMWNode.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.memory.rmw;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+import com.oracle.truffle.llvm.runtime.global.LLVMGlobalVariable;
+import com.oracle.truffle.llvm.runtime.global.LLVMGlobalVariableAccess;
+import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+@NodeChildren(value = {@NodeChild(type = LLVMExpressionNode.class, value = "pointerNode"), @NodeChild(type = LLVMExpressionNode.class, value = "valueNode")})
+public abstract class LLVMI32RMWNode extends LLVMExpressionNode {
+
+    public abstract static class LLVMI32RMWXchgNode extends LLVMI32RMWNode {
+        @Specialization
+        public int execute(LLVMGlobalVariable address, int value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            int old = globalAccess.getI32(address);
+            globalAccess.putI32(address, value);
+            return old;
+        }
+
+        @Specialization
+        public int execute(LLVMAddress address, int value) {
+            int old = LLVMMemory.getI32(address);
+            LLVMMemory.putI32(address, value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI32RMWAddNode extends LLVMI32RMWNode {
+        @Specialization
+        public int execute(LLVMGlobalVariable address, int value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            int old = globalAccess.getI32(address);
+            globalAccess.putI32(address, old + value);
+            return old;
+        }
+
+        @Specialization
+        public int execute(LLVMAddress address, int value) {
+            int old = LLVMMemory.getI32(address);
+            LLVMMemory.putI32(address, old + value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI32RMWSubNode extends LLVMI32RMWNode {
+        @Specialization
+        public int execute(LLVMGlobalVariable address, int value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            int old = globalAccess.getI32(address);
+            globalAccess.putI32(address, old - value);
+            return old;
+        }
+
+        @Specialization
+        public int execute(LLVMAddress address, int value) {
+            int old = LLVMMemory.getI32(address);
+            LLVMMemory.putI32(address, old - value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI32RMWAndNode extends LLVMI32RMWNode {
+        @Specialization
+        public int execute(LLVMGlobalVariable address, int value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            int old = globalAccess.getI32(address);
+            globalAccess.putI32(address, old & value);
+            return old;
+        }
+
+        @Specialization
+        public int execute(LLVMAddress address, int value) {
+            int old = LLVMMemory.getI32(address);
+            LLVMMemory.putI32(address, old & value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI32RMWNandNode extends LLVMI32RMWNode {
+        @Specialization
+        public int execute(LLVMGlobalVariable address, int value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            int old = globalAccess.getI32(address);
+            globalAccess.putI32(address, ~(old & value));
+            return old;
+        }
+
+        @Specialization
+        public int execute(LLVMAddress address, int value) {
+            int old = LLVMMemory.getI32(address);
+            LLVMMemory.putI32(address, ~(old & value));
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI32RMWOrNode extends LLVMI32RMWNode {
+        @Specialization
+        public int execute(LLVMGlobalVariable address, int value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            int old = globalAccess.getI32(address);
+            globalAccess.putI32(address, old | value);
+            return old;
+        }
+
+        @Specialization
+        public int execute(LLVMAddress address, int value) {
+            int old = LLVMMemory.getI32(address);
+            LLVMMemory.putI32(address, old | value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI32RMWXorNode extends LLVMI32RMWNode {
+        @Specialization
+        public int execute(LLVMGlobalVariable address, int value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            int old = globalAccess.getI32(address);
+            globalAccess.putI32(address, old ^ value);
+            return old;
+        }
+
+        @Specialization
+        public int execute(LLVMAddress address, int value) {
+            int old = LLVMMemory.getI32(address);
+            LLVMMemory.putI32(address, old ^ value);
+            return old;
+        }
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/rmw/LLVMI64RMWNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/rmw/LLVMI64RMWNode.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.memory.rmw;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+import com.oracle.truffle.llvm.runtime.global.LLVMGlobalVariable;
+import com.oracle.truffle.llvm.runtime.global.LLVMGlobalVariableAccess;
+import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+@NodeChildren(value = {@NodeChild(type = LLVMExpressionNode.class, value = "pointerNode"), @NodeChild(type = LLVMExpressionNode.class, value = "valueNode")})
+public abstract class LLVMI64RMWNode extends LLVMExpressionNode {
+
+    public abstract static class LLVMI64RMWXchgNode extends LLVMI64RMWNode {
+        @Specialization
+        public long execute(LLVMGlobalVariable address, long value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            long old = globalAccess.getI64(address);
+            globalAccess.putI64(address, value);
+            return old;
+        }
+
+        @Specialization
+        public long execute(LLVMAddress address, long value) {
+            long old = LLVMMemory.getI64(address);
+            LLVMMemory.putI64(address, value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI64RMWAddNode extends LLVMI64RMWNode {
+        @Specialization
+        public long execute(LLVMGlobalVariable address, long value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            long old = globalAccess.getI64(address);
+            globalAccess.putI64(address, old + value);
+            return old;
+        }
+
+        @Specialization
+        public long execute(LLVMAddress address, long value) {
+            long old = LLVMMemory.getI64(address);
+            LLVMMemory.putI64(address, old + value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI64RMWSubNode extends LLVMI64RMWNode {
+        @Specialization
+        public long execute(LLVMGlobalVariable address, long value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            long old = globalAccess.getI64(address);
+            globalAccess.putI64(address, old - value);
+            return old;
+        }
+
+        @Specialization
+        public long execute(LLVMAddress address, long value) {
+            long old = LLVMMemory.getI64(address);
+            LLVMMemory.putI64(address, old - value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI64RMWAndNode extends LLVMI64RMWNode {
+        @Specialization
+        public long execute(LLVMGlobalVariable address, long value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            long old = globalAccess.getI64(address);
+            globalAccess.putI64(address, old & value);
+            return old;
+        }
+
+        @Specialization
+        public long execute(LLVMAddress address, long value) {
+            long old = LLVMMemory.getI64(address);
+            LLVMMemory.putI64(address, old & value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI64RMWNandNode extends LLVMI64RMWNode {
+        @Specialization
+        public long execute(LLVMGlobalVariable address, long value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            long old = globalAccess.getI64(address);
+            globalAccess.putI64(address, ~(old & value));
+            return old;
+        }
+
+        @Specialization
+        public long execute(LLVMAddress address, long value) {
+            long old = LLVMMemory.getI64(address);
+            LLVMMemory.putI64(address, ~(old & value));
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI64RMWOrNode extends LLVMI64RMWNode {
+        @Specialization
+        public long execute(LLVMGlobalVariable address, long value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            long old = globalAccess.getI64(address);
+            globalAccess.putI64(address, old | value);
+            return old;
+        }
+
+        @Specialization
+        public long execute(LLVMAddress address, long value) {
+            long old = LLVMMemory.getI64(address);
+            LLVMMemory.putI64(address, old | value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI64RMWXorNode extends LLVMI64RMWNode {
+        @Specialization
+        public long execute(LLVMGlobalVariable address, long value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            long old = globalAccess.getI64(address);
+            globalAccess.putI64(address, old ^ value);
+            return old;
+        }
+
+        @Specialization
+        public long execute(LLVMAddress address, long value) {
+            long old = LLVMMemory.getI64(address);
+            LLVMMemory.putI64(address, old ^ value);
+            return old;
+        }
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/rmw/LLVMI8RMWNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/rmw/LLVMI8RMWNode.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.memory.rmw;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+import com.oracle.truffle.llvm.runtime.global.LLVMGlobalVariable;
+import com.oracle.truffle.llvm.runtime.global.LLVMGlobalVariableAccess;
+import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+@NodeChildren(value = {@NodeChild(type = LLVMExpressionNode.class, value = "pointerNode"), @NodeChild(type = LLVMExpressionNode.class, value = "valueNode")})
+public abstract class LLVMI8RMWNode extends LLVMExpressionNode {
+
+    public abstract static class LLVMI8RMWXchgNode extends LLVMI8RMWNode {
+        @Specialization
+        public byte execute(LLVMGlobalVariable address, byte value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            byte old = globalAccess.getI8(address);
+            globalAccess.putI8(address, value);
+            return old;
+        }
+
+        @Specialization
+        public byte execute(LLVMAddress address, byte value) {
+            byte old = LLVMMemory.getI8(address);
+            LLVMMemory.putI8(address, value);
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI8RMWAddNode extends LLVMI8RMWNode {
+        @Specialization
+        public byte execute(LLVMGlobalVariable address, byte value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            byte old = globalAccess.getI8(address);
+            globalAccess.putI8(address, (byte) (old + value));
+            return old;
+        }
+
+        @Specialization
+        public byte execute(LLVMAddress address, byte value) {
+            byte old = LLVMMemory.getI8(address);
+            LLVMMemory.putI8(address, (byte) (old + value));
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI8RMWSubNode extends LLVMI8RMWNode {
+        @Specialization
+        public byte execute(LLVMGlobalVariable address, byte value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            byte old = globalAccess.getI8(address);
+            globalAccess.putI8(address, (byte) (old - value));
+            return old;
+        }
+
+        @Specialization
+        public byte execute(LLVMAddress address, byte value) {
+            byte old = LLVMMemory.getI8(address);
+            LLVMMemory.putI8(address, (byte) (old - value));
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI8RMWAndNode extends LLVMI8RMWNode {
+        @Specialization
+        public byte execute(LLVMGlobalVariable address, byte value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            byte old = globalAccess.getI8(address);
+            globalAccess.putI8(address, (byte) (old & value));
+            return old;
+        }
+
+        @Specialization
+        public byte execute(LLVMAddress address, byte value) {
+            byte old = LLVMMemory.getI8(address);
+            LLVMMemory.putI8(address, (byte) (old & value));
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI8RMWNandNode extends LLVMI8RMWNode {
+        @Specialization
+        public byte execute(LLVMGlobalVariable address, byte value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            byte old = globalAccess.getI8(address);
+            globalAccess.putI8(address, (byte) ~(old & value));
+            return old;
+        }
+
+        @Specialization
+        public byte execute(LLVMAddress address, byte value) {
+            byte old = LLVMMemory.getI8(address);
+            LLVMMemory.putI8(address, (byte) ~(old & value));
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI8RMWOrNode extends LLVMI8RMWNode {
+        @Specialization
+        public byte execute(LLVMGlobalVariable address, byte value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            byte old = globalAccess.getI8(address);
+            globalAccess.putI8(address, (byte) (old | value));
+            return old;
+        }
+
+        @Specialization
+        public byte execute(LLVMAddress address, byte value) {
+            byte old = LLVMMemory.getI8(address);
+            LLVMMemory.putI8(address, (byte) (old | value));
+            return old;
+        }
+    }
+
+    public abstract static class LLVMI8RMWXorNode extends LLVMI8RMWNode {
+        @Specialization
+        public byte execute(LLVMGlobalVariable address, byte value, @Cached("createGlobalAccess()") LLVMGlobalVariableAccess globalAccess) {
+            byte old = globalAccess.getI8(address);
+            globalAccess.putI8(address, (byte) (old ^ value));
+            return old;
+        }
+
+        @Specialization
+        public byte execute(LLVMAddress address, byte value) {
+            byte old = LLVMMemory.getI8(address);
+            LLVMMemory.putI8(address, (byte) (old ^ value));
+            return old;
+        }
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
@@ -119,6 +119,7 @@ import com.oracle.truffle.llvm.parser.metadata.DebugInfoGenerator;
 import com.oracle.truffle.llvm.parser.model.enums.CompareOperator;
 import com.oracle.truffle.llvm.parser.model.enums.Flag;
 import com.oracle.truffle.llvm.parser.model.enums.Linkage;
+import com.oracle.truffle.llvm.parser.model.enums.ReadModifyWriteOperator;
 import com.oracle.truffle.llvm.parser.model.functions.FunctionDeclaration;
 import com.oracle.truffle.llvm.parser.model.functions.FunctionDefinition;
 import com.oracle.truffle.llvm.parser.model.globals.GlobalConstant;
@@ -178,6 +179,11 @@ public class BasicNodeFactory implements NodeFactory {
     @Override
     public LLVMExpressionNode createStore(LLVMParserRuntime runtime, LLVMExpressionNode pointerNode, LLVMExpressionNode valueNode, Type type, SourceSection source) {
         return LLVMMemoryReadWriteFactory.createStore(runtime, pointerNode, valueNode, type, source);
+    }
+
+    @Override
+    public LLVMExpressionNode createReadModifyWrite(LLVMParserRuntime runtime, ReadModifyWriteOperator operator, LLVMExpressionNode pointerNode, LLVMExpressionNode valueNode, Type type) {
+        return LLVMMemoryReadWriteFactory.createReadModifyWrite(operator, pointerNode, valueNode, type);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMMemoryReadWriteFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMMemoryReadWriteFactory.java
@@ -64,8 +64,14 @@ import com.oracle.truffle.llvm.nodes.memory.load.LLVMI1LoadNodeGen;
 import com.oracle.truffle.llvm.nodes.memory.load.LLVMI32LoadNodeGen;
 import com.oracle.truffle.llvm.nodes.memory.load.LLVMI64LoadNodeGen;
 import com.oracle.truffle.llvm.nodes.memory.load.LLVMI8LoadNodeGen;
+import com.oracle.truffle.llvm.nodes.memory.rmw.LLVMI16RMWNodeFactory;
+import com.oracle.truffle.llvm.nodes.memory.rmw.LLVMI1RMWNodeFactory;
+import com.oracle.truffle.llvm.nodes.memory.rmw.LLVMI32RMWNodeFactory;
+import com.oracle.truffle.llvm.nodes.memory.rmw.LLVMI64RMWNodeFactory;
+import com.oracle.truffle.llvm.nodes.memory.rmw.LLVMI8RMWNodeFactory;
 import com.oracle.truffle.llvm.nodes.others.LLVMAccessGlobalVariableStorageNode;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
+import com.oracle.truffle.llvm.parser.model.enums.ReadModifyWriteOperator;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 import com.oracle.truffle.llvm.runtime.types.ArrayType;
 import com.oracle.truffle.llvm.runtime.types.PointerType;
@@ -191,6 +197,126 @@ final class LLVMMemoryReadWriteFactory {
             }
         } else if (type instanceof VectorType) {
             return LLVMStoreVectorNodeGen.create(type, source, pointerNode, valueNode);
+        } else {
+            throw new AssertionError(type);
+        }
+    }
+
+    static LLVMExpressionNode createReadModifyWrite(ReadModifyWriteOperator operator, LLVMExpressionNode pointerNode, LLVMExpressionNode valueNode, Type type) {
+        if (type instanceof PrimitiveType) {
+            switch (operator) {
+                case XCHG:
+                    switch (((PrimitiveType) type).getPrimitiveKind()) {
+                        case I1:
+                            return LLVMI1RMWNodeFactory.LLVMI1RMWXchgNodeGen.create(pointerNode, valueNode);
+                        case I8:
+                            return LLVMI8RMWNodeFactory.LLVMI8RMWXchgNodeGen.create(pointerNode, valueNode);
+                        case I16:
+                            return LLVMI16RMWNodeFactory.LLVMI16RMWXchgNodeGen.create(pointerNode, valueNode);
+                        case I32:
+                            return LLVMI32RMWNodeFactory.LLVMI32RMWXchgNodeGen.create(pointerNode, valueNode);
+                        case I64:
+                            return LLVMI64RMWNodeFactory.LLVMI64RMWXchgNodeGen.create(pointerNode, valueNode);
+                        default:
+                            throw new AssertionError(type);
+                    }
+                case ADD:
+                    switch (((PrimitiveType) type).getPrimitiveKind()) {
+                        case I1:
+                            return LLVMI1RMWNodeFactory.LLVMI1RMWAddNodeGen.create(pointerNode, valueNode);
+                        case I8:
+                            return LLVMI8RMWNodeFactory.LLVMI8RMWAddNodeGen.create(pointerNode, valueNode);
+                        case I16:
+                            return LLVMI16RMWNodeFactory.LLVMI16RMWAddNodeGen.create(pointerNode, valueNode);
+                        case I32:
+                            return LLVMI32RMWNodeFactory.LLVMI32RMWAddNodeGen.create(pointerNode, valueNode);
+                        case I64:
+                            return LLVMI64RMWNodeFactory.LLVMI64RMWAddNodeGen.create(pointerNode, valueNode);
+                        default:
+                            throw new AssertionError(type);
+                    }
+                case SUB:
+                    switch (((PrimitiveType) type).getPrimitiveKind()) {
+                        case I1:
+                            return LLVMI1RMWNodeFactory.LLVMI1RMWSubNodeGen.create(pointerNode, valueNode);
+                        case I8:
+                            return LLVMI8RMWNodeFactory.LLVMI8RMWSubNodeGen.create(pointerNode, valueNode);
+                        case I16:
+                            return LLVMI16RMWNodeFactory.LLVMI16RMWSubNodeGen.create(pointerNode, valueNode);
+                        case I32:
+                            return LLVMI32RMWNodeFactory.LLVMI32RMWSubNodeGen.create(pointerNode, valueNode);
+                        case I64:
+                            return LLVMI64RMWNodeFactory.LLVMI64RMWSubNodeGen.create(pointerNode, valueNode);
+                        default:
+                            throw new AssertionError(type);
+                    }
+                case AND:
+                    switch (((PrimitiveType) type).getPrimitiveKind()) {
+                        case I1:
+                            return LLVMI1RMWNodeFactory.LLVMI1RMWAndNodeGen.create(pointerNode, valueNode);
+                        case I8:
+                            return LLVMI8RMWNodeFactory.LLVMI8RMWAndNodeGen.create(pointerNode, valueNode);
+                        case I16:
+                            return LLVMI16RMWNodeFactory.LLVMI16RMWAndNodeGen.create(pointerNode, valueNode);
+                        case I32:
+                            return LLVMI32RMWNodeFactory.LLVMI32RMWAndNodeGen.create(pointerNode, valueNode);
+                        case I64:
+                            return LLVMI64RMWNodeFactory.LLVMI64RMWAndNodeGen.create(pointerNode, valueNode);
+                        default:
+                            throw new AssertionError(type);
+                    }
+                case NAND:
+                    switch (((PrimitiveType) type).getPrimitiveKind()) {
+                        case I1:
+                            return LLVMI1RMWNodeFactory.LLVMI1RMWNandNodeGen.create(pointerNode, valueNode);
+                        case I8:
+                            return LLVMI8RMWNodeFactory.LLVMI8RMWNandNodeGen.create(pointerNode, valueNode);
+                        case I16:
+                            return LLVMI16RMWNodeFactory.LLVMI16RMWNandNodeGen.create(pointerNode, valueNode);
+                        case I32:
+                            return LLVMI32RMWNodeFactory.LLVMI32RMWNandNodeGen.create(pointerNode, valueNode);
+                        case I64:
+                            return LLVMI64RMWNodeFactory.LLVMI64RMWNandNodeGen.create(pointerNode, valueNode);
+                        default:
+                            throw new AssertionError(type);
+                    }
+                case OR:
+                    switch (((PrimitiveType) type).getPrimitiveKind()) {
+                        case I1:
+                            return LLVMI1RMWNodeFactory.LLVMI1RMWOrNodeGen.create(pointerNode, valueNode);
+                        case I8:
+                            return LLVMI8RMWNodeFactory.LLVMI8RMWOrNodeGen.create(pointerNode, valueNode);
+                        case I16:
+                            return LLVMI16RMWNodeFactory.LLVMI16RMWOrNodeGen.create(pointerNode, valueNode);
+                        case I32:
+                            return LLVMI32RMWNodeFactory.LLVMI32RMWOrNodeGen.create(pointerNode, valueNode);
+                        case I64:
+                            return LLVMI64RMWNodeFactory.LLVMI64RMWOrNodeGen.create(pointerNode, valueNode);
+                        default:
+                            throw new AssertionError(type);
+                    }
+                case XOR:
+                    switch (((PrimitiveType) type).getPrimitiveKind()) {
+                        case I1:
+                            return LLVMI1RMWNodeFactory.LLVMI1RMWXorNodeGen.create(pointerNode, valueNode);
+                        case I8:
+                            return LLVMI8RMWNodeFactory.LLVMI8RMWXorNodeGen.create(pointerNode, valueNode);
+                        case I16:
+                            return LLVMI16RMWNodeFactory.LLVMI16RMWXorNodeGen.create(pointerNode, valueNode);
+                        case I32:
+                            return LLVMI32RMWNodeFactory.LLVMI32RMWXorNodeGen.create(pointerNode, valueNode);
+                        case I64:
+                            return LLVMI64RMWNodeFactory.LLVMI64RMWXorNodeGen.create(pointerNode, valueNode);
+                        default:
+                            throw new AssertionError(type);
+                    }
+                case MAX:
+                case MIN:
+                case UMAX:
+                case UMIN:
+                default:
+                    throw new AssertionError(operator);
+            }
         } else {
             throw new AssertionError(type);
         }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMBitcodeInstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMBitcodeInstructionVisitor.java
@@ -63,6 +63,7 @@ import com.oracle.truffle.llvm.parser.model.symbols.instructions.InvokeInstructi
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.LandingpadInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.LoadInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.PhiInstruction;
+import com.oracle.truffle.llvm.parser.model.symbols.instructions.ReadModifyWriteInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ResumeInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ReturnInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.SelectInstruction;
@@ -652,6 +653,18 @@ final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
         final LLVMExpressionNode node = nodeFactory.createStore(runtime, pointerNode, valueNode, type, sourceSection);
 
         addInstruction(node);
+    }
+
+    @Override
+    public void visit(ReadModifyWriteInstruction rmw) {
+        final LLVMExpressionNode pointerNode = symbols.resolve(rmw.getPtr());
+        final LLVMExpressionNode valueNode = symbols.resolve(rmw.getValue());
+
+        final Type type = rmw.getValue().getType();
+
+        final LLVMExpressionNode result = nodeFactory.createReadModifyWrite(runtime, rmw.getOperator(), pointerNode, valueNode, type);
+
+        createFrameWrite(result, rmw);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMLivenessAnalysis.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMLivenessAnalysis.java
@@ -63,6 +63,7 @@ import com.oracle.truffle.llvm.parser.model.symbols.instructions.InvokeInstructi
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.LandingpadInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.LoadInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.PhiInstruction;
+import com.oracle.truffle.llvm.parser.model.symbols.instructions.ReadModifyWriteInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ResumeInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ReturnInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.SelectInstruction;
@@ -692,6 +693,12 @@ public final class LLVMLivenessAnalysis {
                 visitLocalRead(call.getArgument(i));
             }
             visitLocalRead(call.getCallTarget());
+        }
+
+        @Override
+        public void visit(ReadModifyWriteInstruction rmw) {
+            visitLocalRead(rmw.getPtr());
+            visitLocalRead(rmw.getValue());
         }
 
         protected abstract void visitLocalRead(Symbol symbol);

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactory.java
@@ -43,6 +43,7 @@ import com.oracle.truffle.llvm.parser.instructions.LLVMConversionType;
 import com.oracle.truffle.llvm.parser.instructions.LLVMLogicalInstructionKind;
 import com.oracle.truffle.llvm.parser.model.enums.CompareOperator;
 import com.oracle.truffle.llvm.parser.model.enums.Flag;
+import com.oracle.truffle.llvm.parser.model.enums.ReadModifyWriteOperator;
 import com.oracle.truffle.llvm.parser.model.functions.FunctionDefinition;
 import com.oracle.truffle.llvm.parser.model.globals.GlobalConstant;
 import com.oracle.truffle.llvm.parser.model.globals.GlobalVariable;
@@ -74,6 +75,8 @@ public interface NodeFactory {
     LLVMExpressionNode createLoad(LLVMParserRuntime runtime, Type resolvedResultType, LLVMExpressionNode loadTarget);
 
     LLVMExpressionNode createStore(LLVMParserRuntime runtime, LLVMExpressionNode pointerNode, LLVMExpressionNode valueNode, Type type, SourceSection source);
+
+    LLVMExpressionNode createReadModifyWrite(LLVMParserRuntime runtime, ReadModifyWriteOperator operator, LLVMExpressionNode pointerNode, LLVMExpressionNode valueNode, Type type);
 
     LLVMExpressionNode createLogicalOperation(LLVMParserRuntime runtime, LLVMExpressionNode left, LLVMExpressionNode right, LLVMLogicalInstructionKind opCode, Type llvmType, Flag[] flags);
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Function.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Function.java
@@ -251,6 +251,10 @@ public final class Function implements ParserListener {
                 createCompareExchange(args, record);
                 break;
 
+            case ATOMICRMW:
+                createAtomicReadModifyWrite(args);
+                break;
+
             default:
                 throw new UnsupportedOperationException("Unsupported Record: " + record);
         }
@@ -629,6 +633,23 @@ public final class Function implements ParserListener {
         final long synchronizationScope = args[i];
 
         instructionBlock.createAtomicStore(destination, source, align, isVolatile, atomicOrdering, synchronizationScope);
+    }
+
+    private void createAtomicReadModifyWrite(long[] args) {
+        int i = 0;
+
+        final int ptr = getIndex(args[i++]);
+        final Type ptrType = symbols.get(ptr);
+        final int value = getIndex(args[i++]);
+        final int opcode = (int) args[i++];
+        final boolean isVolatile = args[i++] != 0;
+        final long atomicOrdering = args[i++];
+        final long synchronizationScope = args[i];
+
+        final Type type = ((PointerType) ptrType).getPointeeType();
+
+        instructionBlock.createAtomicReadModifyWrite(type, ptr, value, opcode, isVolatile, atomicOrdering, synchronizationScope);
+        symbols.add(type);
     }
 
     private void createBinaryOperation(long[] args) {

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/blocks/InstructionBlock.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/blocks/InstructionBlock.java
@@ -53,6 +53,7 @@ import com.oracle.truffle.llvm.parser.model.symbols.instructions.InvokeInstructi
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.LandingpadInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.LoadInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.PhiInstruction;
+import com.oracle.truffle.llvm.parser.model.symbols.instructions.ReadModifyWriteInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ResumeInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ReturnInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.SelectInstruction;
@@ -109,6 +110,10 @@ public final class InstructionBlock implements ValueSymbol {
 
     public void createAtomicStore(int destination, int source, int align, boolean isVolatile, long atomicOrdering, long synchronizationScope) {
         addInstruction(StoreInstruction.fromSymbols(function.getSymbols(), destination, source, align, isVolatile, atomicOrdering, synchronizationScope));
+    }
+
+    public void createAtomicReadModifyWrite(Type type, int ptr, int value, int opcode, boolean isVolatile, long atomicOrdering, long synchronizationScope) {
+        addInstruction(ReadModifyWriteInstruction.fromSymbols(function.getSymbols(), type, ptr, value, opcode, isVolatile, atomicOrdering, synchronizationScope));
     }
 
     public void createBinaryOperation(Type type, int opcode, int flags, int lhs, int rhs) {

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/enums/ReadModifyWriteOperator.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/enums/ReadModifyWriteOperator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.parser.model.enums;
+
+public enum ReadModifyWriteOperator {
+
+    XCHG,
+    ADD,
+    SUB,
+    AND,
+    NAND,
+    OR,
+    XOR,
+    MAX,
+    MIN,
+    UMAX,
+    UMIN;
+
+    public static ReadModifyWriteOperator decode(int opcode) {
+        ReadModifyWriteOperator[] ops = values();
+        if (opcode >= 0 && opcode < ops.length) {
+            return ops[opcode];
+        }
+        return null;
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/symbols/instructions/ReadModifyWriteInstruction.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/symbols/instructions/ReadModifyWriteInstruction.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.parser.model.symbols.instructions;
+
+import com.oracle.truffle.llvm.parser.model.enums.AtomicOrdering;
+import com.oracle.truffle.llvm.parser.model.enums.ReadModifyWriteOperator;
+import com.oracle.truffle.llvm.parser.model.enums.SynchronizationScope;
+import com.oracle.truffle.llvm.parser.model.symbols.Symbols;
+import com.oracle.truffle.llvm.parser.model.visitors.InstructionVisitor;
+import com.oracle.truffle.llvm.runtime.types.Type;
+import com.oracle.truffle.llvm.runtime.types.symbols.Symbol;
+
+public final class ReadModifyWriteInstruction extends ValueInstruction {
+
+    private final ReadModifyWriteOperator operator;
+
+    private final AtomicOrdering atomicOrdering;
+    private final boolean isVolatile;
+    private final SynchronizationScope synchronizationScope;
+
+    private Symbol ptr;
+    private Symbol value;
+
+    private ReadModifyWriteInstruction(Type type, ReadModifyWriteOperator operator, boolean isVolatile, AtomicOrdering atomicOrdering, SynchronizationScope synchronizationScope) {
+        super(type);
+        this.operator = operator;
+        this.atomicOrdering = atomicOrdering;
+        this.isVolatile = isVolatile;
+        this.synchronizationScope = synchronizationScope;
+    }
+
+    @Override
+    public void accept(InstructionVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    public Symbol getPtr() {
+        return ptr;
+    }
+
+    public Symbol getValue() {
+        return value;
+    }
+
+    public ReadModifyWriteOperator getOperator() {
+        return operator;
+    }
+
+    public static Instruction fromSymbols(Symbols symbols, Type type, int ptr, int value, int opcode, boolean isVolatile, long atomicOrdering, long synchronizationScope) {
+        final ReadModifyWriteOperator operator = ReadModifyWriteOperator.decode(opcode);
+        final ReadModifyWriteInstruction inst = new ReadModifyWriteInstruction(type, operator, isVolatile, AtomicOrdering.decode(atomicOrdering), SynchronizationScope.decode(synchronizationScope));
+        inst.ptr = symbols.getSymbol(ptr, inst);
+        inst.value = symbols.getSymbol(value, inst);
+        return inst;
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/visitors/InstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/visitors/InstructionVisitor.java
@@ -47,6 +47,7 @@ import com.oracle.truffle.llvm.parser.model.symbols.instructions.InvokeInstructi
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.LandingpadInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.LoadInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.PhiInstruction;
+import com.oracle.truffle.llvm.parser.model.symbols.instructions.ReadModifyWriteInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ResumeInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ReturnInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.SelectInstruction;
@@ -115,4 +116,7 @@ public interface InstructionVisitor {
     void visit(ResumeInstruction resume);
 
     void visit(CompareExchangeInstruction cmpxchg);
+
+    void visit(ReadModifyWriteInstruction rmw);
+
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/visitors/InstructionVisitorAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/visitors/InstructionVisitorAdapter.java
@@ -48,6 +48,7 @@ import com.oracle.truffle.llvm.parser.model.symbols.instructions.InvokeInstructi
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.LandingpadInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.LoadInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.PhiInstruction;
+import com.oracle.truffle.llvm.parser.model.symbols.instructions.ReadModifyWriteInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ResumeInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ReturnInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.SelectInstruction;
@@ -203,4 +204,10 @@ public interface InstructionVisitorAdapter extends InstructionVisitor {
     default void visit(CompareExchangeInstruction cmpxchg) {
         defaultAction(cmpxchg);
     }
+
+    @Override
+    default void visit(ReadModifyWriteInstruction rmw) {
+        defaultAction(rmw);
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/visitors/ValueInstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/visitors/ValueInstructionVisitor.java
@@ -44,6 +44,7 @@ import com.oracle.truffle.llvm.parser.model.symbols.instructions.InvokeInstructi
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.LandingpadInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.LoadInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.PhiInstruction;
+import com.oracle.truffle.llvm.parser.model.symbols.instructions.ReadModifyWriteInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.SelectInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ShuffleVectorInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ValueInstruction;
@@ -135,5 +136,10 @@ public abstract class ValueInstructionVisitor implements InstructionVisitorAdapt
     @Override
     public void visit(CompareExchangeInstruction cmpxchg) {
         visitValueInstruction(cmpxchg);
+    }
+
+    @Override
+    public void visit(ReadModifyWriteInstruction rmw) {
+        visitValueInstruction(rmw);
     }
 }

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/readModifyWrite.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/readModifyWrite.c
@@ -1,0 +1,31 @@
+#include <stdlib.h>
+
+int main() {
+  int val = 1;
+  int old;
+
+  old = __sync_lock_test_and_set(&val, 2); // atomicrmw xchg
+  if (old != 1 || val != 2) {
+    abort();
+  }
+
+  old = __sync_fetch_and_add(&val, 2); // atomicrmw add
+  if (old != 2 || val != 4) {
+    abort();
+  }
+
+  old = __sync_fetch_and_sub(&val, 1); // atomicrmw sub
+  if (old != 3 || val != 3) {
+    abort();
+  }
+
+  old = __sync_fetch_and_and(&val, 2); // atomicrmw and
+  if (old != 3 || val != 2) {
+    abort();
+  }
+
+  old = __sync_fetch_and_or(&val, 1); // atomicrmw or
+  if (old != 2 || val != 3) {
+    abort();
+  }
+}


### PR DESCRIPTION
During experiments with Sulong at [JCrete](http://www.jcrete.org/) with @jtulach and @alexsnaps we found that [`atomicrmw` instruction](https://llvm.org/docs/LangRef.html#atomicrmw-instruction) was not implemented.

---

Despite the fact that @graalvmbot complains about OCA, at http://www.oracle.com/technetwork/community/oca-486395.html#m you can find that it was signed.