### PR TITLE
Add support for "fence" instruction

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/LLVMFence.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/LLVMFence.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.memory;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+public abstract class LLVMFence extends LLVMExpressionNode {
+
+    @Specialization
+    public Object execute() {
+        LLVMMemory.fullFence();
+        return null;
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
@@ -108,6 +108,7 @@ import com.oracle.truffle.llvm.nodes.memory.LLVMAllocInstruction.LLVMAllocaConst
 import com.oracle.truffle.llvm.nodes.memory.LLVMAllocInstructionFactory.LLVMAllocaConstInstructionNodeGen;
 import com.oracle.truffle.llvm.nodes.memory.LLVMAllocInstructionFactory.LLVMAllocaInstructionNodeGen;
 import com.oracle.truffle.llvm.nodes.memory.LLVMCompareExchangeNodeGen;
+import com.oracle.truffle.llvm.nodes.memory.LLVMFenceNodeGen;
 import com.oracle.truffle.llvm.nodes.memory.LLVMStoreNode.LLVMAddressArrayLiteralNode;
 import com.oracle.truffle.llvm.nodes.others.LLVMStaticInitsBlockNode;
 import com.oracle.truffle.llvm.nodes.others.LLVMUnreachableNode;
@@ -185,6 +186,11 @@ public class BasicNodeFactory implements NodeFactory {
     @Override
     public LLVMExpressionNode createReadModifyWrite(LLVMParserRuntime runtime, ReadModifyWriteOperator operator, LLVMExpressionNode pointerNode, LLVMExpressionNode valueNode, Type type) {
         return LLVMMemoryReadWriteFactory.createReadModifyWrite(operator, pointerNode, valueNode, type);
+    }
+
+    @Override
+    public LLVMExpressionNode createFence(LLVMParserRuntime runtime) {
+        return LLVMFenceNodeGen.create();
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMBitcodeInstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMBitcodeInstructionVisitor.java
@@ -55,6 +55,7 @@ import com.oracle.truffle.llvm.parser.model.symbols.instructions.CompareInstruct
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ConditionalBranchInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ExtractElementInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ExtractValueInstruction;
+import com.oracle.truffle.llvm.parser.model.symbols.instructions.FenceInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.GetElementPointerInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.IndirectBranchInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.InsertElementInstruction;
@@ -665,6 +666,13 @@ final class LLVMBitcodeInstructionVisitor implements InstructionVisitor {
         final LLVMExpressionNode result = nodeFactory.createReadModifyWrite(runtime, rmw.getOperator(), pointerNode, valueNode, type);
 
         createFrameWrite(result, rmw);
+    }
+
+    @Override
+    public void visit(FenceInstruction fence) {
+        final LLVMExpressionNode node = nodeFactory.createFence(runtime);
+
+        addInstruction(node);
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMLivenessAnalysis.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMLivenessAnalysis.java
@@ -54,6 +54,7 @@ import com.oracle.truffle.llvm.parser.model.symbols.instructions.CompareInstruct
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ConditionalBranchInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ExtractElementInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ExtractValueInstruction;
+import com.oracle.truffle.llvm.parser.model.symbols.instructions.FenceInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.GetElementPointerInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.IndirectBranchInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.InsertElementInstruction;
@@ -699,6 +700,10 @@ public final class LLVMLivenessAnalysis {
         public void visit(ReadModifyWriteInstruction rmw) {
             visitLocalRead(rmw.getPtr());
             visitLocalRead(rmw.getValue());
+        }
+
+        @Override
+        public void visit(FenceInstruction fence) {
         }
 
         protected abstract void visitLocalRead(Symbol symbol);

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactory.java
@@ -78,6 +78,8 @@ public interface NodeFactory {
 
     LLVMExpressionNode createReadModifyWrite(LLVMParserRuntime runtime, ReadModifyWriteOperator operator, LLVMExpressionNode pointerNode, LLVMExpressionNode valueNode, Type type);
 
+    LLVMExpressionNode createFence(LLVMParserRuntime runtime);
+
     LLVMExpressionNode createLogicalOperation(LLVMParserRuntime runtime, LLVMExpressionNode left, LLVMExpressionNode right, LLVMLogicalInstructionKind opCode, Type llvmType, Flag[] flags);
 
     LLVMExpressionNode createLiteral(LLVMParserRuntime runtime, Object value, Type type);

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Function.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Function.java
@@ -255,6 +255,10 @@ public final class Function implements ParserListener {
                 createAtomicReadModifyWrite(args);
                 break;
 
+            case FENCE:
+                createFence(args);
+                break;
+
             default:
                 throw new UnsupportedOperationException("Unsupported Record: " + record);
         }
@@ -650,6 +654,15 @@ public final class Function implements ParserListener {
 
         instructionBlock.createAtomicReadModifyWrite(type, ptr, value, opcode, isVolatile, atomicOrdering, synchronizationScope);
         symbols.add(type);
+    }
+
+    private void createFence(long[] args) {
+        int i = 0;
+
+        final long atomicOrdering = args[i++];
+        final long synchronizationScope = args[i];
+
+        instructionBlock.createFence(atomicOrdering, synchronizationScope);
     }
 
     private void createBinaryOperation(long[] args) {

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/blocks/InstructionBlock.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/blocks/InstructionBlock.java
@@ -44,6 +44,7 @@ import com.oracle.truffle.llvm.parser.model.symbols.instructions.CompareInstruct
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ConditionalBranchInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ExtractElementInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ExtractValueInstruction;
+import com.oracle.truffle.llvm.parser.model.symbols.instructions.FenceInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.GetElementPointerInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.IndirectBranchInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.InsertElementInstruction;
@@ -114,6 +115,10 @@ public final class InstructionBlock implements ValueSymbol {
 
     public void createAtomicReadModifyWrite(Type type, int ptr, int value, int opcode, boolean isVolatile, long atomicOrdering, long synchronizationScope) {
         addInstruction(ReadModifyWriteInstruction.fromSymbols(function.getSymbols(), type, ptr, value, opcode, isVolatile, atomicOrdering, synchronizationScope));
+    }
+
+    public void createFence(long atomicOrdering, long synchronizationScope) {
+        addInstruction(FenceInstruction.generate(atomicOrdering, synchronizationScope));
     }
 
     public void createBinaryOperation(Type type, int opcode, int flags, int lhs, int rhs) {

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/symbols/instructions/FenceInstruction.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/symbols/instructions/FenceInstruction.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.parser.model.symbols.instructions;
+
+import com.oracle.truffle.llvm.parser.model.enums.AtomicOrdering;
+import com.oracle.truffle.llvm.parser.model.enums.SynchronizationScope;
+import com.oracle.truffle.llvm.parser.model.visitors.InstructionVisitor;
+
+public final class FenceInstruction extends VoidInstruction {
+
+    private final AtomicOrdering atomicOrdering;
+    private final SynchronizationScope synchronizationScope;
+
+    private FenceInstruction(AtomicOrdering atomicOrdering, SynchronizationScope synchronizationScope) {
+        this.atomicOrdering = atomicOrdering;
+        this.synchronizationScope = synchronizationScope;
+    }
+
+    @Override
+    public void accept(InstructionVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    public AtomicOrdering getAtomicOrdering() {
+        return atomicOrdering;
+    }
+
+    public SynchronizationScope getSynchronizationScope() {
+        return synchronizationScope;
+    }
+
+    public static Instruction generate(long atomicOrdering, long synchronizationScope) {
+        return new FenceInstruction(AtomicOrdering.decode(atomicOrdering), SynchronizationScope.decode(synchronizationScope));
+    }
+
+}

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/visitors/InstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/visitors/InstructionVisitor.java
@@ -39,6 +39,7 @@ import com.oracle.truffle.llvm.parser.model.symbols.instructions.CompareInstruct
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ConditionalBranchInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ExtractElementInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ExtractValueInstruction;
+import com.oracle.truffle.llvm.parser.model.symbols.instructions.FenceInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.GetElementPointerInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.IndirectBranchInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.InsertElementInstruction;
@@ -118,5 +119,7 @@ public interface InstructionVisitor {
     void visit(CompareExchangeInstruction cmpxchg);
 
     void visit(ReadModifyWriteInstruction rmw);
+
+    void visit(FenceInstruction fence);
 
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/visitors/InstructionVisitorAdapter.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/visitors/InstructionVisitorAdapter.java
@@ -39,6 +39,7 @@ import com.oracle.truffle.llvm.parser.model.symbols.instructions.CompareInstruct
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ConditionalBranchInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ExtractElementInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.ExtractValueInstruction;
+import com.oracle.truffle.llvm.parser.model.symbols.instructions.FenceInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.GetElementPointerInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.IndirectBranchInstruction;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.InsertElementInstruction;
@@ -208,6 +209,11 @@ public interface InstructionVisitorAdapter extends InstructionVisitor {
     @Override
     default void visit(ReadModifyWriteInstruction rmw) {
         defaultAction(rmw);
+    }
+
+    @Override
+    default void visit(FenceInstruction fence) {
+        defaultAction(fence);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/memory/LLVMMemory.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/memory/LLVMMemory.java
@@ -654,4 +654,9 @@ public abstract class LLVMMemory {
         } while (compareAndSwapI8(address, old, (byte) (nevv ? 1 : 0)).swap);
         return nevv;
     }
+
+    public static void fullFence() {
+        UNSAFE.fullFence();
+    }
+
 }

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/fence.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/fence.c
@@ -1,0 +1,3 @@
+int main() {
+  __sync_synchronize(); // fence
+}


### PR DESCRIPTION
During experiments with Sulong at [JCrete](http://www.jcrete.org/) with @jtulach and @alexsnaps we found that [`fence` instruction](https://llvm.org/docs/LangRef.html#fence-instruction) was not implemented.

---

Despite the fact that @graalvmbot complains about OCA, at http://www.oracle.com/technetwork/community/oca-486395.html#m you can find that it was signed.
