### PR TITLE
Add support for Rust version 1.19.0

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMVectorFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/LLVMVectorFactory.java
@@ -43,7 +43,10 @@ import com.oracle.truffle.llvm.nodes.vector.LLVMInsertElementNodeFactory.LLVMI1I
 import com.oracle.truffle.llvm.nodes.vector.LLVMInsertElementNodeFactory.LLVMI32InsertElementNodeGen;
 import com.oracle.truffle.llvm.nodes.vector.LLVMInsertElementNodeFactory.LLVMI64InsertElementNodeGen;
 import com.oracle.truffle.llvm.nodes.vector.LLVMInsertElementNodeFactory.LLVMI8InsertElementNodeGen;
+import com.oracle.truffle.llvm.nodes.vector.LLVMShuffleVectorNodeFactory.LLVMShuffleDoubleVectorNodeGen;
+import com.oracle.truffle.llvm.nodes.vector.LLVMShuffleVectorNodeFactory.LLVMShuffleFloatVectorNodeGen;
 import com.oracle.truffle.llvm.nodes.vector.LLVMShuffleVectorNodeFactory.LLVMShuffleI32VectorNodeGen;
+import com.oracle.truffle.llvm.nodes.vector.LLVMShuffleVectorNodeFactory.LLVMShuffleI64VectorNodeGen;
 import com.oracle.truffle.llvm.nodes.vector.LLVMShuffleVectorNodeFactory.LLVMShuffleI8VectorNodeGen;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 import com.oracle.truffle.llvm.runtime.types.PrimitiveType;
@@ -103,6 +106,12 @@ final class LLVMVectorFactory {
                 return LLVMShuffleI8VectorNodeGen.create(vector1, vector2, mask);
             case I32:
                 return LLVMShuffleI32VectorNodeGen.create(vector1, vector2, mask);
+            case I64:
+                return LLVMShuffleI64VectorNodeGen.create(vector1, vector2, mask);
+            case FLOAT:
+                return LLVMShuffleFloatVectorNodeGen.create(vector1, vector2, mask);
+            case DOUBLE:
+                return LLVMShuffleDoubleVectorNodeGen.create(vector1, vector2, mask);
             default:
                 throw new AssertionError(resultType);
         }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Function.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Function.java
@@ -763,13 +763,13 @@ public final class Function implements ParserListener {
         int i = 0;
         int vector = getIndex(args[i++]);
 
-        Type type;
+        Type vectorType;
         if (function.isValueForwardRef(vector)) {
-            type = types.get(i++);
+            vectorType = types.get(args[i++]);
         } else {
-            type = ((VectorType) function.getValueType(vector)).getElementType();
+            vectorType = function.getValueType(vector);
         }
-
+        Type type = ((VectorType) vectorType).getElementType();
         int index = getIndex(args[i]);
 
         emit(ExtractElementInstruction.fromSymbols(function.getSymbols(), type, vector, index));


### PR DESCRIPTION
The signature for the std::rt::lang_start function has changed with version 1.19.0. This pull request includes support for the new signature and fixes some other minor issues that were revealed when running bitcode produced by the latest version of the Rust compiler.