### PR TITLE
Clarify Supported LLVM Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Build Dependencies
 Sulong is mostly implemented in Java. However, parts of Sulong are
 implemented in C/C++ and will be compiled to a shared library or a bitcode
 file. For a successful build you need to have LLVM (incl. `CLANG` and `OPT`
-tool) v3.2 - v4.0 installed. Sulong also depends on `libc++` and `libc++abi`
+tool) 3.8 - v4.0 installed. Sulong also depends on `libc++` and `libc++abi`
 (on Ubuntu, install `libc++1`, `libc++abi1`, `libc++-dev`, `libc++abi-dev`).
 For a full list of external dependencies on Ubuntu you can look at our
 Travis configuration.

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Metadata.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Metadata.java
@@ -187,7 +187,7 @@ public final class Metadata implements ParserListener {
                 break;
 
             case SUBPROGRAM:
-                metadata.add(MDSubprogram.create38(args, metadata, this::getSymbolReference));
+                metadata.add(MDSubprogram.create38(args, metadata));
                 break;
 
             case SUBROUTINE_TYPE:
@@ -317,15 +317,6 @@ public final class Metadata implements ParserListener {
             } else {
                 container.attachMetadata(attachment);
             }
-        }
-    }
-
-    private MDSymbolReference getSymbolReference(long index) {
-        if (index > 0) {
-            return new MDSymbolReference(types.get(index), () -> container.getSymbols().getOrNull((int) index));
-
-        } else {
-            return MDSymbolReference.VOID;
         }
     }
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/metadata/MDSubprogram.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/metadata/MDSubprogram.java
@@ -31,8 +31,6 @@ package com.oracle.truffle.llvm.parser.metadata;
 
 import com.oracle.truffle.llvm.parser.metadata.subtypes.MDName;
 
-import java.util.function.Function;
-
 public final class MDSubprogram extends MDName implements MDBaseNode {
 
     private final MDReference scope;
@@ -69,11 +67,11 @@ public final class MDSubprogram extends MDName implements MDBaseNode {
 
     private final MDReference variables;
 
-    private final MDSymbolReference function;
+    private final MDReference function;
 
     private MDSubprogram(MDReference scope, MDReference name, MDReference displayName, MDReference linkageName, MDReference file, long line, MDReference type, boolean isLocalToUnit,
                     boolean isDefinedInCompileUnit, long scopeLine, MDReference containingType, long virtuality, long virtualIndex, long flags, boolean isOptimized,
-                    MDReference templateParams, MDReference declaration, MDReference variables, MDSymbolReference function) {
+                    MDReference templateParams, MDReference declaration, MDReference variables, MDReference function) {
         super(name);
         this.scope = scope;
         this.displayName = displayName;
@@ -168,7 +166,7 @@ public final class MDSubprogram extends MDName implements MDBaseNode {
         return scope;
     }
 
-    public MDSymbolReference getFunction() {
+    public MDReference getFunction() {
         return function;
     }
 
@@ -201,7 +199,7 @@ public final class MDSubprogram extends MDName implements MDBaseNode {
     private static final int ARGINDEX_38_VARIABLES = 17;
     private static final int OFFSET_INDICATOR = 19;
 
-    public static MDSubprogram create38(long[] args, MetadataList md, Function<Long, MDSymbolReference> symbolMapper) {
+    public static MDSubprogram create38(long[] args, MetadataList md) {
         final int fnOffset = args.length == OFFSET_INDICATOR ? 1 : 0;
 
         final MDReference scope = md.getMDRefOrNullRef(args[ARGINDEX_38_SCOPE]);
@@ -222,11 +220,11 @@ public final class MDSubprogram extends MDName implements MDBaseNode {
         final MDReference declaration = md.getMDRefOrNullRef(args[ARGINDEX_38_DECLARATION + fnOffset]);
         final MDReference variables = md.getMDRefOrNullRef(args[ARGINDEX_38_VARIABLES + fnOffset]);
 
-        final MDSymbolReference function;
+        final MDReference function;
         if (fnOffset != 0 && args[ARGINDEX_38_FN] != 0) {
-            function = symbolMapper.apply(args[ARGINDEX_38_FN]);
+            function = md.getMDRefOrNullRef(args[ARGINDEX_38_FN]);
         } else {
-            function = MDSymbolReference.VOID;
+            function = MDReference.VOID;
         }
 
         return new MDSubprogram(scope, name, MDReference.VOID, linkageName, file, line, type, localToCompileUnit, definedInCompileUnit, scopeLine, containingType, virtuality, virtualIndex, flags,
@@ -268,7 +266,7 @@ public final class MDSubprogram extends MDName implements MDBaseNode {
         final MDReference containingType = ParseUtil.getReference(args[ARGINDEX_32_CONTAININGTYPE]);
         final long flags = ParseUtil.asInt32(args[ARGINDEX_32_FLAGS]);
         final boolean optimized = ParseUtil.asInt1(args[ARGINDEX_3_OPTIMIZED]);
-        final MDSymbolReference function = ParseUtil.getSymbolReference(args[ARGINDEX_32_FN]);
+        final MDReference function = MDReference.fromSymbolRef(ParseUtil.getSymbolReference(args[ARGINDEX_32_FN]));
 
         final MDReference templateParams = ParseUtil.getReferenceIfPresent(args, ARGINDEX_32_TEMPLATEPARAMS);
         final MDReference declaration = ParseUtil.getReferenceIfPresent(args, ARGINDEX_32_DECLARATION);

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/metadata/MetadataList.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/metadata/MetadataList.java
@@ -83,6 +83,9 @@ public final class MetadataList {
     }
 
     MDBaseNode getFromRef(int index) {
+        if (index >= metadata.size()) {
+            return MDReference.VOID;
+        }
         return metadata.get(index);
     }
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/metadata/debuginfo/SourceSectionGenerator.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/metadata/debuginfo/SourceSectionGenerator.java
@@ -47,7 +47,9 @@ import com.oracle.truffle.llvm.parser.metadata.MDNamedNode;
 import com.oracle.truffle.llvm.parser.metadata.MDOldNode;
 import com.oracle.truffle.llvm.parser.metadata.MDReference;
 import com.oracle.truffle.llvm.parser.metadata.MDSubprogram;
+import com.oracle.truffle.llvm.parser.metadata.MDSymbolReference;
 import com.oracle.truffle.llvm.parser.metadata.MDTypedValue;
+import com.oracle.truffle.llvm.parser.metadata.MDValue;
 import com.oracle.truffle.llvm.parser.model.functions.FunctionDefinition;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.Call;
 import com.oracle.truffle.llvm.parser.model.symbols.instructions.Instruction;
@@ -266,8 +268,17 @@ final class SourceSectionGenerator {
 
         @Override
         public void visit(MDSubprogram md) {
-            if (search.equals(md.getFunction().get())) {
-                found = md;
+            final MDReference valueRef = md.getFunction();
+            if (valueRef == MDReference.VOID) {
+                return;
+            }
+
+            final MDBaseNode valueNode = valueRef.get();
+            if (valueNode instanceof MDValue) {
+                final MDSymbolReference value = ((MDValue) valueNode).getValue();
+                if (value.isPresent() && search.equals(value.get())) {
+                    found = md;
+                }
             }
         }
     }


### PR DESCRIPTION
The metadata encoding in LLVM bitcode has been subject to frequent and significant changes between LLVM versions. This changed from LLVM 3.8 onwards as new-format metadata was introduced. For versions prior to this, however, we cannot reliably detect the correct version to parse. This PR clarifies in the README that only versions 3.2 (because of dragonegg) and 3.8 to 4.0 (which we use most actively) are supported.