### PR TITLE
Link shootout benchmarks with libgmp

### DIFF
--- a/mx.sulong/mx_testsuites.py
+++ b/mx.sulong/mx_testsuites.py
@@ -176,9 +176,9 @@ def compileShootoutSuite():
     ensureShootoutsExist()
     excludes = mx_tools.collectExcludePattern(os.path.join(_benchmarksgameSuiteDir, "configs/"))
     print("Compiling Shootout Suite reference executables ", end='')
-    mx_tools.printProgress(mx_tools.multicompileRefFolder(_benchmarksgameSuiteDir, _cacheDir, [mx_tools.Tool.CLANG], ['-Iinclude', '-lm'], excludes=excludes))
+    mx_tools.printProgress(mx_tools.multicompileRefFolder(_benchmarksgameSuiteDir, _cacheDir, [mx_tools.Tool.CLANG], ['-Iinclude', '-lm', '-lgmp'], excludes=excludes))
     print("Compiling Shootout Suite with -O1 ", end='')
-    mx_tools.printProgress(mx_tools.multicompileFolder(_benchmarksgameSuiteDir, _cacheDir, [mx_tools.Tool.CLANG], ['-Iinclude', '-lm'], [mx_tools.Optimization.O1], mx_tools.ProgrammingLanguage.LLVMBC, excludes=excludes))
+    mx_tools.printProgress(mx_tools.multicompileFolder(_benchmarksgameSuiteDir, _cacheDir, [mx_tools.Tool.CLANG], ['-Iinclude', '-lm', '-lgmp'], [mx_tools.Optimization.O1], mx_tools.ProgrammingLanguage.LLVMBC, excludes=excludes))
 
 def compileNWCCSuite():
     ensureNWCCSuiteExists()


### PR DESCRIPTION
Two pidigits test cases fail to compile, because they are not linked against libgmp:
```
Error: Cannot compile /home/travis/build/graalvm/sulong/tests/benchmarksgame/pidigits/pidigits.cint-4.cint.c with clang

/home/travis/build/graalvm/sulong/llvmDir/clang -o /home/travis/build/graalvm/sulong/cache/tests/benchmarksgame/pidigits/pidigits.cint-4.cint/pidigits.cint-4.cint.out -Iinclude -lm /home/travis/build/graalvm/sulong/tests/benchmarksgame/pidigits/pidigits.cint-4.cint.c

Error: Cannot compile /home/travis/build/graalvm/sulong/tests/benchmarksgame/pidigits/pidigits.gcc.c with clang

/home/travis/build/graalvm/sulong/llvmDir/clang -o /home/travis/build/graalvm/sulong/cache/tests/benchmarksgame/pidigits/pidigits.gcc/pidigits.gcc.out -Iinclude -lm /home/travis/build/graalvm/sulong/tests/benchmarksgame/pidigits/pidigits.gcc.c
```

This PR fixes the problem by adding libgmp to the linker options.