### PR TITLE
Refactor Type Parsing to handle Forward-Referenced Types

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Types.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Types.java
@@ -32,10 +32,13 @@ package com.oracle.truffle.llvm.parser.listeners;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.function.Consumer;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.llvm.parser.model.ModelModule;
 import com.oracle.truffle.llvm.parser.records.Records;
 import com.oracle.truffle.llvm.parser.records.TypesRecord;
+import com.oracle.truffle.llvm.runtime.debug.LLVMSourceType;
 import com.oracle.truffle.llvm.runtime.types.ArrayType;
 import com.oracle.truffle.llvm.runtime.types.DataSpecConverter;
 import com.oracle.truffle.llvm.runtime.types.FunctionType;
@@ -47,23 +50,16 @@ import com.oracle.truffle.llvm.runtime.types.StructureType;
 import com.oracle.truffle.llvm.runtime.types.Type;
 import com.oracle.truffle.llvm.runtime.types.VectorType;
 import com.oracle.truffle.llvm.runtime.types.VoidType;
+import com.oracle.truffle.llvm.runtime.types.symbols.LLVMIdentifier;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
 public final class Types implements ParserListener, Iterable<Type> {
 
-    private static Type[] toTypes(Types types, long[] args, long from, long to) {
-        Type[] t = new Type[(int) (to - from)];
-
-        for (int i = 0; i < t.length; i++) {
-            t[i] = types.get(args[(int) from + i]);
-        }
-
-        return t;
-    }
-
     private final ModelModule module;
 
     private Type[] table = new Type[0];
+
+    private String structName = null;
 
     private int size = 0;
 
@@ -103,15 +99,13 @@ public final class Types implements ParserListener, Iterable<Type> {
                 break;
 
             case OPAQUE:
-                OpaqueType opaque = new OpaqueType();
-                if (table[size] != null) {
-                    if (table[size] instanceof UnresolvedNamedPointeeType) {
-                        opaque.setName(((UnresolvedNamedPointeeType) table[size]).getName());
-                    } else {
-                        opaque.setName(((UnresolvedNamedType) table[size]).getName());
-                    }
+                if (structName != null) {
+                    type = new OpaqueType(LLVMIdentifier.toLocalIdentifier(structName));
+                    structName = null;
+                    module.addGlobalType(type);
+                } else {
+                    type = new OpaqueType();
                 }
-                type = opaque;
                 break;
 
             case INTEGER:
@@ -119,35 +113,32 @@ public final class Types implements ParserListener, Iterable<Type> {
                 break;
 
             case POINTER: {
-                int idx = (int) args[0];
-
-                if (idx > size) {
-                    table[size] = new PointerType(null);
-                    table[idx] = new UnresolvedPointeeType(size);
-                    size++;
-                    return;
-                } else {
-                    type = new PointerType(get(idx));
-                }
+                final PointerType pointerType = new PointerType(null);
+                setType((int) args[0], pointerType::setPointeeType);
+                type = pointerType;
                 break;
             }
             case FUNCTION_OLD: {
-                int i = 2;
-                Type returnType = get(args[i++]);
-                type = new FunctionType(returnType, toTypes(this, args, i, args.length), args[0] != 0);
+                final FunctionType functionType = new FunctionType(null, toTypes(args, 3, args.length), args[0] != 0);
+                setType((int) args[2], functionType::setReturnType);
+                type = functionType;
                 break;
             }
             case HALF:
                 type = PrimitiveType.HALF;
                 break;
 
-            case ARRAY:
-                type = new ArrayType(get(args[1]), (int) args[0]);
+            case ARRAY: {
+                final ArrayType arrayType = new ArrayType(null, (int) args[0]);
+                setType((int) args[1], arrayType::setElementType);
+                type = arrayType;
                 break;
+            }
 
             case VECTOR: {
-                final Type baseType = get(args[1]);
-                type = new VectorType(baseType, (int) args[0]);
+                final VectorType vectorType = new VectorType(null, (int) args[0]);
+                setType((int) args[1], vectorType::setElementType);
+                type = vectorType;
                 break;
             }
 
@@ -171,34 +162,30 @@ public final class Types implements ParserListener, Iterable<Type> {
                 type = MetaType.X86MMX;
                 break;
 
-            case STRUCT_ANON:
-                type = new StructureType(args[0] != 0, toTypes(this, args, 1, args.length));
-                break;
-
             case STRUCT_NAME: {
-                String name = Records.toString(args);
-                if (table[size] instanceof UnresolvedPointeeType) {
-                    table[size] = new UnresolvedNamedPointeeType(name, ((UnresolvedPointeeType) table[size]).getIndex());
-                } else {
-                    table[size] = new UnresolvedNamedType(name);
-                }
+                structName = Records.toString(args);
                 return;
             }
+
+            case STRUCT_ANON:
             case STRUCT_NAMED: {
-                StructureType structure = new StructureType(args[0] != 0, toTypes(this, args, 1, args.length));
-                if (table[size] != null) {
-                    if (table[size] instanceof UnresolvedNamedPointeeType) {
-                        structure.setName(((UnresolvedNamedPointeeType) table[size]).getName());
-                    } else {
-                        structure.setName(((UnresolvedNamedType) table[size]).getName());
-                    }
+                final boolean isPacked = args[0] != 0;
+                final Type[] members = toTypes(args, 1, args.length);
+                if (structName != null) {
+                    type = new StructureType(LLVMIdentifier.toLocalIdentifier(structName), isPacked, members);
+                    structName = null;
+                    module.addGlobalType(type);
+                } else {
+                    type = new StructureType(isPacked, members);
                 }
-                type = structure;
                 break;
             }
-            case FUNCTION:
-                type = new FunctionType(get(args[1]), toTypes(this, args, 2, args.length), args[0] != 0);
+            case FUNCTION: {
+                final FunctionType functionType = new FunctionType(null, toTypes(args, 2, args.length), args[0] != 0);
+                setType((int) args[1], functionType::setReturnType);
+                type = functionType;
                 break;
+            }
 
             case TOKEN:
                 type = MetaType.TOKEN;
@@ -209,53 +196,101 @@ public final class Types implements ParserListener, Iterable<Type> {
                 break;
         }
 
-        if (table[size] instanceof UnresolvedPointeeType) {
-            PointerType pointer = (PointerType) table[((UnresolvedPointeeType) table[size]).getIndex()];
-            pointer.setPointeeType(type);
-            module.addGlobalType(pointer);
+        if (table[size] != null) {
+            ((UnresolvedType) table[size]).dependent.accept(type);
         }
         table[size++] = type;
-        module.addGlobalType(type);
+
+    }
+
+    private void setType(int typeIndex, Consumer<Type> typeFieldSetter) {
+        if (typeIndex < size) {
+            typeFieldSetter.accept(table[typeIndex]);
+
+        } else if (table[typeIndex] == null) {
+            table[typeIndex] = new UnresolvedType(typeFieldSetter);
+
+        } else {
+            ((UnresolvedType) table[typeIndex]).addDependent(typeFieldSetter);
+        }
+    }
+
+    private Type[] toTypes(long[] args, int from, int to) {
+        final Type[] types = new Type[to - from];
+
+        for (int i = 0; i < types.length; i++) {
+            final int typeIndex = (int) args[from + i];
+            if (typeIndex < size) {
+                types[i] = table[typeIndex];
+
+            } else {
+                final Consumer<Type> setter = new MemberDependent(i, types);
+                if (table[typeIndex] == null) {
+                    table[typeIndex] = new UnresolvedType(setter);
+
+                } else {
+                    ((UnresolvedType) table[typeIndex]).addDependent(setter);
+                }
+            }
+        }
+
+        return types;
+    }
+
+    private static final class MemberDependent implements Consumer<Type> {
+
+        private final int index;
+        private final Type[] target;
+
+        private MemberDependent(int index, Type[] target) {
+            this.index = index;
+            this.target = target;
+        }
+
+        @Override
+        public void accept(Type type) {
+            target[index] = type;
+        }
     }
 
     public Type get(long index) {
         return table[(int) index];
     }
 
-    private static class UnresolvedPointeeType extends Type {
+    private static final class UnresolvedType extends Type {
 
-        private final int idx;
+        private Consumer<Type> dependent;
 
-        UnresolvedPointeeType(int idx) {
-            this.idx = idx;
+        UnresolvedType(Consumer<Type> dependent) {
+            this.dependent = dependent;
+        }
+
+        private void addDependent(Consumer<Type> newDependent) {
+            dependent = dependent.andThen(newDependent);
         }
 
         @Override
         public void accept(TypeVisitor visitor) {
-            // This is a private type only required for resolving
-            throw new IllegalStateException();
-        }
-
-        public int getIndex() {
-            return idx;
+            CompilerDirectives.transferToInterpreter();
+            throw new IllegalStateException("Unresolved Forward-Referenced Type!");
         }
 
         @Override
         public int getBitSize() {
-            // This is a private type only required for resolving
-            throw new IllegalStateException();
+            CompilerDirectives.transferToInterpreter();
+            throw new IllegalStateException("Unresolved Forward-Referenced Type!");
         }
 
         @Override
         public int getAlignment(DataSpecConverter targetDataLayout) {
-            // This is a private type only required for resolving
-            throw new IllegalStateException();
+            CompilerDirectives.transferToInterpreter();
+            throw new IllegalStateException("Unresolved Forward-Referenced Type!");
         }
 
         @Override
         public int getSize(DataSpecConverter targetDataLayout) {
-            // This is a private type only required for resolving
-            throw new IllegalStateException();
+            CompilerDirectives.transferToInterpreter();
+            throw new IllegalStateException("Unresolved Forward-Referenced Type!");
         }
 
         @Override
@@ -264,121 +299,31 @@ public final class Types implements ParserListener, Iterable<Type> {
         }
 
         @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + idx;
-            return result;
-        }
-
-        @Override
         public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null) {
-                return false;
-            }
-            if (getClass() != obj.getClass()) {
-                return false;
-            }
-            UnresolvedPointeeType other = (UnresolvedPointeeType) obj;
-            if (idx != other.idx) {
-                return false;
-            }
-            return true;
-        }
-
-    }
-
-    private static final class UnresolvedNamedPointeeType extends UnresolvedPointeeType {
-
-        private final String name;
-
-        UnresolvedNamedPointeeType(String name, int idx) {
-            super(idx);
-            this.name = name;
-        }
-
-        public String getName() {
-            return name;
-        }
-    }
-
-    private static final class UnresolvedNamedType extends Type {
-
-        private final String name;
-
-        UnresolvedNamedType(String name) {
-            this.name = name;
-        }
-
-        @Override
-        public void accept(TypeVisitor visitor) {
-            // This is a private type only required for resolving
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        @Override
-        public int getBitSize() {
-            // This is a private type only required for resolving
-            throw new IllegalStateException();
-        }
-
-        @Override
-        public int getAlignment(DataSpecConverter targetDataLayout) {
-            // This is a private type only required for resolving
-            throw new IllegalStateException();
-        }
-
-        @Override
-        public int getSize(DataSpecConverter targetDataLayout) {
-            // This is a private type only required for resolving
-            throw new IllegalStateException();
-        }
-
-        @Override
-        public Type shallowCopy() {
-            return this;
+            return obj == this;
         }
 
         @Override
         public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + ((name == null) ? 0 : name.hashCode());
-            return result;
+            return 0;
         }
 
         @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null) {
-                return false;
-            }
-            if (!(obj instanceof UnresolvedNamedType)) {
-                return false;
-            }
-            UnresolvedNamedType other = (UnresolvedNamedType) obj;
-            if (name == null) {
-                if (other.name != null) {
-                    return false;
-                }
-            } else if (!name.equals(other.name)) {
-                return false;
-            }
-            return true;
+        public LLVMSourceType getSourceType() {
+            CompilerDirectives.transferToInterpreter();
+            throw new IllegalStateException("Unresolved Forward-Referenced Type!");
         }
 
+        @Override
+        public void setSourceType(LLVMSourceType sourceType) {
+            CompilerDirectives.transferToInterpreter();
+            throw new IllegalStateException("Unresolved Forward-Referenced Type!");
+        }
     }
 
     @Override
     public String toString() {
-        return "Types " + Arrays.toString(table);
+        CompilerDirectives.transferToInterpreter();
+        return "Typetable (size: " + table.length + ", currentIndex: " + size + ")";
     }
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/nodes/LLVMSymbolReadResolver.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/nodes/LLVMSymbolReadResolver.java
@@ -88,7 +88,6 @@ import com.oracle.truffle.llvm.runtime.types.VariableBitWidthType;
 import com.oracle.truffle.llvm.runtime.types.VectorType;
 import com.oracle.truffle.llvm.runtime.types.VoidType;
 import com.oracle.truffle.llvm.runtime.types.symbols.Symbol;
-import com.oracle.truffle.llvm.runtime.types.symbols.ValueSymbol;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
 import java.math.BigInteger;
@@ -524,7 +523,7 @@ public final class LLVMSymbolReadResolver {
             ((GlobalValueSymbol) symbol).accept(visitor);
 
         } else if (symbol instanceof FunctionParameter) {
-            final FrameSlot slot = frame.findFrameSlot(((ValueSymbol) symbol).getName());
+            final FrameSlot slot = frame.findFrameSlot(((FunctionParameter) symbol).getName());
             resolvedNode = runtime.getNodeFactory().createFrameRead(runtime, symbol.getType(), slot);
 
         } else {

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/ArrayType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/ArrayType.java
@@ -29,16 +29,23 @@
  */
 package com.oracle.truffle.llvm.runtime.types;
 
+import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
 public final class ArrayType extends AggregateType {
 
-    private final Type elementType;
+    @CompilationFinal private Type elementType;
     private final int length;
 
     public ArrayType(Type type, int length) {
         this.elementType = type;
         this.length = length;
+    }
+
+    public void setElementType(Type elementType) {
+        CompilerAsserts.neverPartOfCompilation();
+        this.elementType = elementType;
     }
 
     @Override
@@ -125,5 +132,4 @@ public final class ArrayType extends AggregateType {
         }
         return true;
     }
-
 }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/ArrayType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/ArrayType.java
@@ -29,22 +29,30 @@
  */
 package com.oracle.truffle.llvm.runtime.types;
 
+import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
 public final class ArrayType extends AggregateType {
 
+    @CompilationFinal private Assumption assumption;
     @CompilationFinal private Type elementType;
     private final int length;
 
     public ArrayType(Type type, int length) {
+        this.assumption = Truffle.getRuntime().createAssumption();
         this.elementType = type;
         this.length = length;
     }
 
     public void setElementType(Type elementType) {
         CompilerAsserts.neverPartOfCompilation();
+        this.assumption.invalidate();
+        this.assumption = Truffle.getRuntime().createAssumption();
         this.elementType = elementType;
     }
 
@@ -59,6 +67,9 @@ public final class ArrayType extends AggregateType {
     }
 
     public Type getElementType() {
+        if (!assumption.isValid()) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+        }
         return elementType;
     }
 
@@ -69,7 +80,7 @@ public final class ArrayType extends AggregateType {
 
     @Override
     public Type getElementType(int index) {
-        return elementType;
+        return getElementType();
     }
 
     @Override
@@ -84,7 +95,7 @@ public final class ArrayType extends AggregateType {
 
     @Override
     public Type shallowCopy() {
-        final ArrayType copy = new ArrayType(elementType, length);
+        final ArrayType copy = new ArrayType(getElementType(), length);
         copy.setSourceType(getSourceType());
         return copy;
     }
@@ -95,6 +106,7 @@ public final class ArrayType extends AggregateType {
     }
 
     @Override
+    @TruffleBoundary
     public String toString() {
         return String.format("[%d x %s]", getNumberOfElements(), getElementType());
     }
@@ -103,7 +115,7 @@ public final class ArrayType extends AggregateType {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((elementType == null) ? 0 : elementType.hashCode());
+        result = prime * result + ((getElementType() == null) ? 0 : getElementType().hashCode());
         result = prime * result + length;
         return result;
     }
@@ -120,11 +132,11 @@ public final class ArrayType extends AggregateType {
             return false;
         }
         ArrayType other = (ArrayType) obj;
-        if (elementType == null) {
-            if (other.elementType != null) {
+        if (getElementType() == null) {
+            if (other.getElementType() != null) {
                 return false;
             }
-        } else if (!elementType.equals(other.elementType)) {
+        } else if (!getElementType().equals(other.getElementType())) {
             return false;
         }
         if (length != other.length) {

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/FunctionType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/FunctionType.java
@@ -31,19 +31,25 @@ package com.oracle.truffle.llvm.runtime.types;
 
 import java.util.Arrays;
 
+import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.llvm.runtime.memory.LLVMHeap;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
 public final class FunctionType extends Type {
 
+    @CompilationFinal private Assumption assumption;
     @CompilationFinal private Type returnType;
 
     private final Type[] argumentTypes;
     private final boolean isVarargs;
 
     public FunctionType(Type returnType, Type[] argumentTypes, boolean isVarargs) {
+        this.assumption = Truffle.getRuntime().createAssumption();
         this.returnType = returnType;
         this.argumentTypes = argumentTypes;
         this.isVarargs = isVarargs;
@@ -54,11 +60,16 @@ public final class FunctionType extends Type {
     }
 
     public Type getReturnType() {
+        if (!assumption.isValid()) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+        }
         return returnType;
     }
 
     public void setReturnType(Type returnType) {
         CompilerAsserts.neverPartOfCompilation();
+        this.assumption.invalidate();
+        this.assumption = Truffle.getRuntime().createAssumption();
         this.returnType = returnType;
     }
 
@@ -92,12 +103,13 @@ public final class FunctionType extends Type {
 
     @Override
     public Type shallowCopy() {
-        final FunctionType copy = new FunctionType(returnType, argumentTypes, isVarargs);
+        final FunctionType copy = new FunctionType(getReturnType(), argumentTypes, isVarargs);
         copy.setSourceType(getSourceType());
         return copy;
     }
 
     @Override
+    @TruffleBoundary
     public String toString() {
         StringBuilder sb = new StringBuilder();
 
@@ -127,7 +139,7 @@ public final class FunctionType extends Type {
         int result = 1;
         result = prime * result + Arrays.hashCode(argumentTypes);
         result = prime * result + (isVarargs ? 1231 : 1237);
-        result = prime * result + ((returnType == null) ? 0 : returnType.hashCode());
+        result = prime * result + ((getReturnType() == null) ? 0 : getReturnType().hashCode());
         return result;
     }
 
@@ -149,11 +161,11 @@ public final class FunctionType extends Type {
         if (isVarargs != other.isVarargs) {
             return false;
         }
-        if (returnType == null) {
-            if (other.returnType != null) {
+        if (getReturnType() == null) {
+            if (other.getReturnType() != null) {
                 return false;
             }
-        } else if (!returnType.equals(other.returnType)) {
+        } else if (!getReturnType().equals(other.getReturnType())) {
             return false;
         }
         return true;

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/FunctionType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/FunctionType.java
@@ -31,12 +31,14 @@ package com.oracle.truffle.llvm.runtime.types;
 
 import java.util.Arrays;
 
+import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.llvm.runtime.memory.LLVMHeap;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
 public final class FunctionType extends Type {
 
-    private final Type returnType;
+    @CompilationFinal private Type returnType;
 
     private final Type[] argumentTypes;
     private final boolean isVarargs;
@@ -53,6 +55,11 @@ public final class FunctionType extends Type {
 
     public Type getReturnType() {
         return returnType;
+    }
+
+    public void setReturnType(Type returnType) {
+        CompilerAsserts.neverPartOfCompilation();
+        this.returnType = returnType;
     }
 
     public boolean isVarargs() {

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/OpaqueType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/OpaqueType.java
@@ -36,17 +36,18 @@ import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
 public class OpaqueType extends Type {
 
-    private String name = LLVMIdentifier.UNKNOWN;
+    private final String name;
 
     public OpaqueType() {
+        this(LLVMIdentifier.UNKNOWN);
+    }
+
+    public OpaqueType(String name) {
+        this.name = name;
     }
 
     public String getName() {
         return name;
-    }
-
-    public void setName(String name) {
-        this.name = LLVMIdentifier.toLocalIdentifier(name);
     }
 
     @Override
@@ -71,8 +72,7 @@ public class OpaqueType extends Type {
 
     @Override
     public Type shallowCopy() {
-        final OpaqueType shallowCopy = new OpaqueType();
-        shallowCopy.name = this.name;
+        final OpaqueType shallowCopy = new OpaqueType(name);
         shallowCopy.setSourceType(getSourceType());
         return shallowCopy;
     }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/OpaqueType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/OpaqueType.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 import com.oracle.truffle.llvm.runtime.types.symbols.LLVMIdentifier;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
-public class OpaqueType extends Type {
+public final class OpaqueType extends Type {
 
     private final String name;
 

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/PointerType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/PointerType.java
@@ -31,6 +31,7 @@ package com.oracle.truffle.llvm.runtime.types;
 
 import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.llvm.runtime.LLVMAddress;
@@ -72,7 +73,7 @@ public final class PointerType extends AggregateType {
 
     @Override
     public int getSize(DataSpecConverter targetDataLayout) {
-        if (pointeeType instanceof FunctionType) {
+        if (getPointeeType() instanceof FunctionType) {
             return LLVMHeap.FUNCTION_PTR_SIZE_BYTE;
         } else {
             return LLVMAddress.WORD_LENGTH_BIT / Byte.SIZE;
@@ -81,23 +82,24 @@ public final class PointerType extends AggregateType {
 
     @Override
     public Type shallowCopy() {
-        final PointerType copy = new PointerType(pointeeType);
+        final PointerType copy = new PointerType(getPointeeType());
         copy.setSourceType(getSourceType());
         return copy;
     }
 
     @Override
     public int getOffsetOf(int index, DataSpecConverter targetDataLayout) {
-        return pointeeType.getSize(targetDataLayout) * index;
+        return getPointeeType().getSize(targetDataLayout) * index;
     }
 
     @Override
     public Type getElementType(int index) {
-        return pointeeType;
+        return getPointeeType();
     }
 
     @Override
     public int getNumberOfElements() {
+        CompilerDirectives.transferToInterpreter();
         throw new IllegalStateException();
     }
 
@@ -112,8 +114,9 @@ public final class PointerType extends AggregateType {
     }
 
     @Override
+    @TruffleBoundary
     public String toString() {
-        return String.format("%s*", pointeeType);
+        return String.format("%s*", getPointeeType());
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/PrimitiveType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/PrimitiveType.java
@@ -29,6 +29,7 @@
  */
 package com.oracle.truffle.llvm.runtime.types;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
 public final class PrimitiveType extends Type {
@@ -128,6 +129,7 @@ public final class PrimitiveType extends Type {
     }
 
     @Override
+    @TruffleBoundary
     public String toString() {
         if (Type.isIntegerType(this)) {
             return String.format("i%d", getBitSize());

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/StructureType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/StructureType.java
@@ -31,6 +31,7 @@ package com.oracle.truffle.llvm.runtime.types;
 
 import java.util.Arrays;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.llvm.runtime.types.symbols.LLVMIdentifier;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
@@ -68,6 +69,7 @@ public final class StructureType extends AggregateType {
         if (isPacked) {
             return Arrays.stream(types).mapToInt(Type::getBitSize).sum();
         } else {
+            CompilerDirectives.transferToInterpreter();
             throw new UnsupportedOperationException("TargetDataLayout is necessary to compute Padding information!");
         }
     }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/StructureType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/StructureType.java
@@ -37,13 +37,18 @@ import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
 public final class StructureType extends AggregateType {
 
-    private String name = LLVMIdentifier.UNKNOWN;
+    private final String name;
     private final boolean isPacked;
     private final Type[] types;
 
-    public StructureType(boolean isPacked, Type[] types) {
+    public StructureType(String name, boolean isPacked, Type[] types) {
+        this.name = name;
         this.isPacked = isPacked;
         this.types = types;
+    }
+
+    public StructureType(boolean isPacked, Type[] types) {
+        this(LLVMIdentifier.UNKNOWN, isPacked, types);
     }
 
     public Type[] getElementTypes() {
@@ -56,10 +61,6 @@ public final class StructureType extends AggregateType {
 
     public String getName() {
         return name;
-    }
-
-    public void setName(String name) {
-        this.name = LLVMIdentifier.toLocalIdentifier(name);
     }
 
     @Override
@@ -111,8 +112,7 @@ public final class StructureType extends AggregateType {
 
     @Override
     public Type shallowCopy() {
-        final StructureType copy = new StructureType(isPacked, types);
-        copy.name = this.name;
+        final StructureType copy = new StructureType(name, isPacked, types);
         copy.setSourceType(getSourceType());
         return copy;
     }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/VectorType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/VectorType.java
@@ -29,16 +29,17 @@
  */
 package com.oracle.truffle.llvm.runtime.types;
 
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
 public class VectorType extends AggregateType {
 
-    private final Type elementType;
+    @CompilerDirectives.CompilationFinal private Type elementType;
     private final int length;
 
     public VectorType(Type elementType, int length) {
-        if (!(elementType instanceof PrimitiveType || elementType instanceof PointerType)) {
+        if (elementType != null && !(elementType instanceof PrimitiveType || elementType instanceof PointerType)) {
             CompilerDirectives.transferToInterpreter();
             throw new AssertionError("Invalid ElementType of Vector: " + elementType);
         }
@@ -58,6 +59,14 @@ public class VectorType extends AggregateType {
     @Override
     public int getNumberOfElements() {
         return length;
+    }
+
+    public void setElementType(Type elementType) {
+        CompilerAsserts.neverPartOfCompilation();
+        if (elementType == null || !(elementType instanceof PrimitiveType || elementType instanceof PointerType)) {
+            throw new AssertionError("Invalid ElementType of Vector: " + elementType);
+        }
+        this.elementType = elementType;
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/VectorType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/VectorType.java
@@ -29,13 +29,18 @@
  */
 package com.oracle.truffle.llvm.runtime.types;
 
+import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.llvm.runtime.types.visitors.TypeVisitor;
 
-public class VectorType extends AggregateType {
+public final class VectorType extends AggregateType {
 
-    @CompilerDirectives.CompilationFinal private Type elementType;
+    @CompilationFinal private Assumption assumption;
+    @CompilationFinal private Type elementType;
     private final int length;
 
     public VectorType(Type elementType, int length) {
@@ -43,6 +48,7 @@ public class VectorType extends AggregateType {
             CompilerDirectives.transferToInterpreter();
             throw new AssertionError("Invalid ElementType of Vector: " + elementType);
         }
+        this.assumption = Truffle.getRuntime().createAssumption();
         this.elementType = elementType;
         this.length = length;
     }
@@ -66,6 +72,8 @@ public class VectorType extends AggregateType {
         if (elementType == null || !(elementType instanceof PrimitiveType || elementType instanceof PointerType)) {
             throw new AssertionError("Invalid ElementType of Vector: " + elementType);
         }
+        this.assumption.invalidate();
+        this.assumption = Truffle.getRuntime().createAssumption();
         this.elementType = elementType;
     }
 
@@ -75,7 +83,7 @@ public class VectorType extends AggregateType {
             CompilerDirectives.transferToInterpreter();
             throw new ArrayIndexOutOfBoundsException();
         }
-        return elementType;
+        return getElementType();
     }
 
     @Override
@@ -95,7 +103,7 @@ public class VectorType extends AggregateType {
 
     @Override
     public Type shallowCopy() {
-        final VectorType copy = new VectorType(elementType, length);
+        final VectorType copy = new VectorType(getElementType(), length);
         copy.setSourceType(getSourceType());
         return copy;
     }
@@ -106,6 +114,7 @@ public class VectorType extends AggregateType {
     }
 
     @Override
+    @TruffleBoundary
     public String toString() {
         return String.format("<%d x %s>", getNumberOfElements(), getElementType());
     }
@@ -114,7 +123,7 @@ public class VectorType extends AggregateType {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((elementType == null) ? 0 : elementType.hashCode());
+        result = prime * result + ((getElementType() == null) ? 0 : getElementType().hashCode());
         result = prime * result + length;
         return result;
     }
@@ -131,11 +140,11 @@ public class VectorType extends AggregateType {
             return false;
         }
         VectorType other = (VectorType) obj;
-        if (elementType == null) {
-            if (other.elementType != null) {
+        if (getElementType() == null) {
+            if (other.getElementType() != null) {
                 return false;
             }
-        } else if (!elementType.equals(other.elementType)) {
+        } else if (!getElementType().equals(other.getElementType())) {
             return false;
         }
         if (length != other.length) {


### PR DESCRIPTION
Addresses #747 and #748. Forward references in the type table were barely supported until now.