### PR TITLE
More x86_64 assembly instructions

### DIFF
--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
@@ -63,7 +63,7 @@ PRODUCTIONS
 
 InlineAssembly<> =
   "\""
-  [ ( Prefix
+  [ ( Prefix [ ";" ]
     |							(. factory.setPrefix(null); .)
     )
     AssemblyInstruction

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
@@ -63,8 +63,14 @@ PRODUCTIONS
 
 InlineAssembly<> =
   "\""
-  [ AssemblyInstruction
+  [ ( Prefix
+    |							(. factory.setPrefix(null); .)
+    )
+    AssemblyInstruction
     { ( ";" | "\n" )
+      ( Prefix
+      |							(. factory.setPrefix(null); .)
+      )
       [ AssemblyInstruction ]
     }
   ]
@@ -73,6 +79,16 @@ InlineAssembly<> =
   .
 
 ////////////////////////////////////////////////////////////////////////////////
+Prefix =
+  ( "rep"
+  | "repz"
+  | "repe"
+  | "repne"
+  | "repnz"
+  | "lock"
+  )							(. factory.setPrefix(t.val); .)
+  .
+
 AssemblyInstruction<> =
   ( ZeroOp<>
   | UnOp8<>
@@ -87,7 +103,13 @@ AssemblyInstruction<> =
   | BinOp<>
   | IMulDiv<>
   | Jump<>
+  | Int<>
   )
+  .
+
+Int<> =							(. AsmImmediateOperand nr; .)
+  "int"
+  Immediate<out nr>					(. factory.createInt(nr); .)
   .
 
 Jump<> =						(. @SuppressWarnings("unused") String op; @SuppressWarnings("unused") AsmOperand bta; .)
@@ -140,7 +162,9 @@ ZeroOp<> =						(. String op; .)
   | "cli"
   | "cmc"
   | "lahf"
+  | "popf"
   | "popfw"
+  | "pushf"
   | "pushfw"
   | "sahf"
   | "stc"
@@ -149,6 +173,11 @@ ZeroOp<> =						(. String op; .)
   | "nop"
   | "rdtsc"
   | "cpuid"
+  | "xgetbv"
+  | "ud2"
+  | "mfence"
+  | "lfence"
+  | "sfence"
   )							(. op = t.val; .)
   							(. factory.createOperation(op); .)
   .
@@ -224,6 +253,63 @@ UnOp8<> =						(. String op; AsmOperand arg; .)
   | "notb"
   | "divb"
   | "mulb"
+  )							(. op = t.val; .)
+  Operand8<out arg>
+  							(. factory.createUnaryOperation(op, arg); .)
+  .
+
+UnOp16<> =						(. String op; AsmOperand arg; .)
+  ( "incw"
+  | "decw"
+  | "negw"
+  | "notw"
+  | "divw"
+  | "mulw"
+  | "pushw"
+  | "popw"
+  )							(. op = t.val; .)
+  Operand16<out arg>
+  							(. factory.createUnaryOperation(op, arg); .)
+  .
+
+UnOp32<> =						(. String op; AsmOperand arg; .)
+  ( "incl"
+  | "decl"
+  | "negl"
+  | "notl"
+  | "divl"
+  | "mull"
+  | "bswapl"
+  | "pushl"
+  | "popl"
+  )							(. op = t.val; .)
+  Operand32<out arg>
+  							(. factory.createUnaryOperation(op, arg); .)
+  .
+
+UnOp64<> =						(. String op; AsmOperand arg; .)
+  ( "incq"
+  | "decq"
+  | "negq"
+  | "notq"
+  | "divq"
+  | "mulq"
+  | "bswapq"
+  | "pushq"
+  | "popq"
+  )							(. op = t.val; .)
+  Operand64<out arg>
+  							(. factory.createUnaryOperation(op, arg); .)
+  .
+
+UnOp<> =						(. String op; AsmOperand arg; .)
+  ( "inc"
+  | "dec"
+  | "neg"
+  | "not"
+  | "bswap"
+  | "rdrand"
+  | "rdseed"
   | "seta"
   | "setae"
   | "setb"
@@ -254,55 +340,13 @@ UnOp8<> =						(. String op; AsmOperand arg; .)
   | "setpo"
   | "sets"
   | "setz"
-  )							(. op = t.val; .)
-  Operand8<out arg>
-  							(. factory.createUnaryOperation(op, arg); .)
-  .
-
-UnOp16<> =						(. String op; AsmOperand arg; .)
-  ( "incw"
-  | "decw"
-  | "negw"
-  | "notw"
-  | "divw"
-  | "mulw"
-  )							(. op = t.val; .)
-  Operand16<out arg>
-  							(. factory.createUnaryOperation(op, arg); .)
-  .
-
-UnOp32<> =						(. String op; AsmOperand arg; .)
-  ( "incl"
-  | "decl"
-  | "negl"
-  | "notl"
-  | "divl"
-  | "mull"
-  )							(. op = t.val; .)
-  Operand32<out arg>
-  							(. factory.createUnaryOperation(op, arg); .)
-  .
-
-UnOp64<> =						(. String op; AsmOperand arg; .)
-  ( "incq"
-  | "decq"
-  | "negq"
-  | "notq"
-  | "divq"
-  | "mulq"
-  )							(. op = t.val; .)
-  Operand64<out arg>
-  							(. factory.createUnaryOperation(op, arg); .)
-  .
-
-UnOp<> =						(. String op; AsmOperand arg; .)
-  ( "inc"
-  | "dec"
-  | "neg"
-  | "not"
+  | "push"
+  | "pop"
+  | "cmpxchg8b"
+  | "cmpxchg16b"
   )							(. op = t.val; .)
   Operand<out arg>
-  							(. factory.createUnaryOperation(op, arg); .)
+  							(. factory.createUnaryOperationImplicitSize(op, arg); .)
   .
 
 BinOp8<> =						(. String op; AsmOperand a, b; .)
@@ -326,6 +370,7 @@ BinOp8<> =						(. String op; AsmOperand a, b; .)
   | "shlb"
   | "shrb"
   | "testb"
+  | "cmpxchgb"
   )							(. op = t.val; .)
   Operand8<out a> "," Operand8<out b>
   							(. factory.createBinaryOperation(op, a, b); .)
@@ -375,6 +420,12 @@ BinOp16<> =						(. String op; AsmOperand a, b; .)
   | "orw"
   | "xorw"
   | "testw"
+  | "bsfw"
+  | "bsrw"
+  | "btw"
+  | "btcw"
+  | "btrw"
+  | "btsw"
   )							(. op = t.val; .)
   Operand16<out a> "," Operand16<out b>			(. factory.createBinaryOperation(op, a, b); .)
   |							(. String op; AsmOperand a, b; .)
@@ -439,6 +490,12 @@ BinOp32<> =						(. String op; AsmOperand a, b; .)
   | "orl"
   | "xorl"
   | "testl"
+  | "bsfl"
+  | "bsrl"
+  | "btl"
+  | "btcl"
+  | "btrl"
+  | "btsl"
   )							(. op = t.val; .)
   Operand32<out a> "," Operand32<out b>			(. factory.createBinaryOperation(op, a, b); .)
   |							(. String op; AsmOperand a, b; .)
@@ -509,6 +566,12 @@ BinOp64<> =						(. String op; AsmOperand a, b; .)
   | "orq"
   | "xorq"
   | "testq"
+  | "bsfq"
+  | "bsrq"
+  | "btq"
+  | "btcq"
+  | "btrq"
+  | "btsq"
   )							(. op = t.val; .)
   Operand64<out a> "," Operand64<out b>			(. factory.createBinaryOperation(op, a, b); .)
   |							(. String op; AsmOperand a, b; .)
@@ -566,7 +629,6 @@ BinOp<> =						(. String op; AsmOperand a, b; .)
   | "cmovs"
   | "cmovz"
   | "cmpxchg"
-  | "cmpxchg8b"
   | "mov"
   | "xadd"
   | "xchg"
@@ -588,9 +650,10 @@ BinOp<> =						(. String op; AsmOperand a, b; .)
   | "sar"
   | "shl"
   | "shr"
+  | "lea"
   )							(. op = t.val; .)
   Operand<out a> "," Operand<out b>
-  							(. factory.createBinaryOperation(op, a, b); .)
+  							(. factory.createBinaryOperationImplicitSize(op, a, b); .)
   .
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -637,18 +700,31 @@ Operand<out AsmOperand op> =				(. op = null; .)
   )
   .
 
-MemoryReference<out AsmMemoryOperand operand> =		(. String displacement = null; AsmOperand base = null, offset = null; long tmp; int scale = 1; .)
-  ( ident						(. displacement = t.val; .)
-  | Number<out tmp>					(. displacement = String.valueOf(tmp); .)
-  )
-  [ "("
-    Operand<out base>
+MemoryReference<out AsmMemoryOperand operand> =		(. String displacement = null;
+							   AsmOperand base = null;
+							   AsmOperand offset = null;
+							   long tmp;
+							   int scale = 1; .)
+  ( ( ident						(. displacement = t.val; .)
+    | Number<out tmp>					(. displacement = String.valueOf(tmp); .)
+    )
+    [ "("
+      [ Operand<out base> ]
+      [ "," Operand<out offset>
+        [ "," Number<out tmp>				(. scale = (int) tmp; .)
+        ]
+      ]
+      ")"
+    ]
+  | "("
+    [ Operand<out base> ]
     [ "," Operand<out offset>
       [ "," Number<out tmp>				(. scale = (int) tmp; .)
       ]
     ]
     ")"
-  ]							(. operand = new AsmMemoryOperand(displacement, base, offset, scale); .)
+  )
+							(. operand = new AsmMemoryOperand(displacement, base, offset, scale); .)
   .
 
 Register8<out AsmRegisterOperand reg> =
@@ -787,9 +863,19 @@ Immediate<out AsmImmediateOperand imm> =		(. long n; .)
   Number<out n>						(. imm = new AsmImmediateOperand(n); .)
   .
 
-Argument<out AsmArgumentOperand arg> =			(. long n; .)
+Argument<out AsmArgumentOperand arg> =			(. long n; arg = null; .)
   "$"
-  Number<out n>						(. arg = new AsmArgumentOperand((int) n); .)
+  ( Number<out n>					(. arg = new AsmArgumentOperand((int) n); .)
+  | "{" Number<out n>
+    ":"							(. int size = -1; int shift = 0; .)
+    ( "b"						(. size = 8; .)
+    | "h"						(. size = 8; shift = 8; .)
+    | "w"						(. size = 16; .)
+    | "k"						(. size = 32; .)
+    | "q"						(. size = 64; .)
+    )							(. arg = new AsmArgumentOperand((int) n, size, shift); .)
+    "}"
+  )
   .
 
 END InlineAssembly.

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/Parser.frame
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/Parser.frame
@@ -27,6 +27,8 @@ Coco/R itself) does not fall under the GNU General Public License.
 ------------------------------------------------------------------------*/
 -->begin
 
+import com.oracle.truffle.api.source.SourceSection;
+
 // Checkstyle: stop
 // @formatter:off
 public class Parser {
@@ -45,10 +47,10 @@ public class Parser {
 	private LLVMInlineAssemblyRootNode root;
 	-->declarations
 
-	public Parser(String asmSnippet, String asmFlags, Type[] argTypes, Type retType, Type[] retTypes, int[] retOffsets) {
+	public Parser(String asmSnippet, String asmFlags, Type[] argTypes, Type retType, Type[] retTypes, int[] retOffsets, SourceSection sourceSection) {
 		this.scanner = new Scanner(new ByteArrayInputStream(asmSnippet.getBytes()));
 		errors = new Errors();
-		this.factory = new AsmFactory(argTypes, asmFlags, retType, retTypes, retOffsets);
+		this.factory = new AsmFactory(argTypes, asmFlags, retType, retTypes, retOffsets, sourceSection);
 	}
 
 	void SynErr (int n) {

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmArgumentOperand.java
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmArgumentOperand.java
@@ -29,15 +29,50 @@
  */
 package com.oracle.truffle.llvm.asm.amd64;
 
+import com.oracle.truffle.llvm.runtime.types.PrimitiveType;
+import com.oracle.truffle.llvm.runtime.types.Type;
+
 class AsmArgumentOperand implements AsmOperand {
     private final int index;
+    private final int size;
+    private final int shift;
 
     AsmArgumentOperand(int index) {
+        this(index, -1, -1);
+    }
+
+    AsmArgumentOperand(int index, int size, int shift) {
         this.index = index;
+        this.size = size;
+        this.shift = shift;
     }
 
     public int getIndex() {
         return index;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public int getShift() {
+        return shift;
+    }
+
+    @Override
+    public Type getType() {
+        switch (size) {
+            case 8:
+                return PrimitiveType.I8;
+            case 16:
+                return PrimitiveType.I16;
+            case 32:
+                return PrimitiveType.I32;
+            case 64:
+                return PrimitiveType.I64;
+            default:
+                return null;
+        }
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
+import com.oracle.truffle.api.source.SourceSection;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64AdcNodeFactory.LLVMAMD64AdcbNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64AdcNodeFactory.LLVMAMD64AdclNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64AdcNodeFactory.LLVMAMD64AdcqNodeGen;
@@ -49,28 +50,55 @@ import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64AndNodeFactory.LLVMAMD64AndbNo
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64AndNodeFactory.LLVMAMD64AndlNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64AndNodeFactory.LLVMAMD64AndqNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64AndNodeFactory.LLVMAMD64AndwNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64BsrNodeFactory.LLVMAMD64BsrlNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64BsrNodeFactory.LLVMAMD64BsrqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64BsrNodeFactory.LLVMAMD64BsrwNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64BreakpointNode;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64BsfNodeFactory.LLVMAMD64BsflNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64BsfNodeFactory.LLVMAMD64BsfqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64BsfNodeFactory.LLVMAMD64BsfwNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64BswapNodeFactory.LLVMAMD64BswaplNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64BswapNodeFactory.LLVMAMD64BswapqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64CmpNodeFactory.LLVMAMD64CmpbNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64CmpNodeFactory.LLVMAMD64CmplNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64CmpNodeFactory.LLVMAMD64CmpqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64CmpNodeFactory.LLVMAMD64CmpwNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64CmpXchgNodeFactory.LLVMAMD64CmpXchgbNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64CmpXchgNodeFactory.LLVMAMD64CmpXchglNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64CmpXchgNodeFactory.LLVMAMD64CmpXchglrNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64CmpXchgNodeFactory.LLVMAMD64CmpXchgqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64CmpXchgNodeFactory.LLVMAMD64CmpXchgwNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64CpuidNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64DecNodeFactory.LLVMAMD64DecbNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64DecNodeFactory.LLVMAMD64DeclNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64DecNodeFactory.LLVMAMD64DecqNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64DecNodeFactory.LLVMAMD64DecwNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64DivNodeFactory.LLVMAMD64DivbNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64DivNodeFactory.LLVMAMD64DivlNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64DivNodeFactory.LLVMAMD64DivqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64DivNodeFactory.LLVMAMD64DivwNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64IdivNodeFactory.LLVMAMD64IdivbNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64IdivNodeFactory.LLVMAMD64IdivlNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64IdivNodeFactory.LLVMAMD64IdivqNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64IdivNodeFactory.LLVMAMD64IdivwNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ImmNodeFactory.LLVMAMD64I16NodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ImmNodeFactory.LLVMAMD64I1NodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ImmNodeFactory.LLVMAMD64I32NodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ImmNodeFactory.LLVMAMD64I64NodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ImmNodeFactory.LLVMAMD64I8NodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ImulNodeFactory.LLVMAMD64ImulbNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ImulNodeFactory.LLVMAMD64Imull3NodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ImulNodeFactory.LLVMAMD64ImullNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ImulNodeFactory.LLVMAMD64Imulq3NodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ImulNodeFactory.LLVMAMD64ImulqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ImulNodeFactory.LLVMAMD64Imulw3NodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ImulNodeFactory.LLVMAMD64ImulwNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64IncNodeFactory.LLVMAMD64IncbNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64IncNodeFactory.LLVMAMD64InclNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64IncNodeFactory.LLVMAMD64IncqNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64IncNodeFactory.LLVMAMD64IncwNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64LoadFlagsFactory.LLVMAMD64LahfNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64LoadFlagsFactory.LLVMAMD64ReadFlagswNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64MulNodeFactory.LLVMAMD64MulbNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64MulNodeFactory.LLVMAMD64MullNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64MulNodeFactory.LLVMAMD64MulqNodeGen;
@@ -87,6 +115,18 @@ import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64OrNodeFactory.LLVMAMD64OrbNode
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64OrNodeFactory.LLVMAMD64OrlNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64OrNodeFactory.LLVMAMD64OrqNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64OrNodeFactory.LLVMAMD64OrwNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64PopNodeFactory.LLVMAMD64PoplNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64PopNodeFactory.LLVMAMD64PopqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64PopNodeFactory.LLVMAMD64PopwNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64PushNodeFactory.LLVMAMD64PushlNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64PushNodeFactory.LLVMAMD64PushqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64PushNodeFactory.LLVMAMD64PushwNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64RdRandNodeFactory.LLVMAMD64RdRandlNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64RdRandNodeFactory.LLVMAMD64RdRandqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64RdRandNodeFactory.LLVMAMD64RdRandwNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64RdSeedNodeFactory.LLVMAMD64RdSeedlNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64RdSeedNodeFactory.LLVMAMD64RdSeedqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64RdSeedNodeFactory.LLVMAMD64RdSeedwNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64RdtscNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64RolNodeFactory.LLVMAMD64RolbNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64RolNodeFactory.LLVMAMD64RollNodeGen;
@@ -105,9 +145,13 @@ import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SarNodeFactory.LLVMAMD64SarlNo
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SarNodeFactory.LLVMAMD64SarqNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SarNodeFactory.LLVMAMD64SarwNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SetNodeFactory.LLVMAMD64SetaNodeGen;
-import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SetNodeFactory.LLVMAMD64SetaeNodeGen;
-import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SetNodeFactory.LLVMAMD64SetbNodeGen;
-import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SetNodeFactory.LLVMAMD64SetbeNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SetNodeFactory.LLVMAMD64SeteqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SetNodeFactory.LLVMAMD64SetgNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SetNodeFactory.LLVMAMD64SetleNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SetNodeFactory.LLVMAMD64SetneNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SetNodeFactory.LLVMAMD64SetnzNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SetNodeFactory.LLVMAMD64SetorNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SetNodeFactory.LLVMAMD64SetzNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ShlNodeFactory.LLVMAMD64ShlbNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ShlNodeFactory.LLVMAMD64ShllNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ShlNodeFactory.LLVMAMD64ShlqNodeGen;
@@ -116,10 +160,20 @@ import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ShrNodeFactory.LLVMAMD64ShrbNo
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ShrNodeFactory.LLVMAMD64ShrlNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ShrNodeFactory.LLVMAMD64ShrqNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64ShrNodeFactory.LLVMAMD64ShrwNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64StoreFlagsFactory.LLVMAMD64WriteFlagswNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SubNodeFactory.LLVMAMD64SubbNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SubNodeFactory.LLVMAMD64SublNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SubNodeFactory.LLVMAMD64SubqNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64SubNodeFactory.LLVMAMD64SubwNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64Ud2Node;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64XaddNodeFactory.LLVMAMD64XaddbNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64XaddNodeFactory.LLVMAMD64XaddlNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64XaddNodeFactory.LLVMAMD64XaddqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64XaddNodeFactory.LLVMAMD64XaddwNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64XchgNodeFactory.LLVMAMD64XchgbNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64XchgNodeFactory.LLVMAMD64XchglNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64XchgNodeFactory.LLVMAMD64XchgqNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64XchgNodeFactory.LLVMAMD64XchgwNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64XorNodeFactory.LLVMAMD64XorbNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64XorNodeFactory.LLVMAMD64XorlNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.LLVMAMD64XorNodeFactory.LLVMAMD64XorqNodeGen;
@@ -131,12 +185,18 @@ import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI16RegisterNode;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI32RegisterNode;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI64RegisterNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI8RegisterNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMStructWriteNode;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64AddressComputationNodeFactory.LLVMAMD64AddressDisplacementComputationNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64AddressComputationNodeFactory.LLVMAMD64AddressNoBaseOffsetComputationNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64AddressComputationNodeFactory.LLVMAMD64AddressOffsetComputationNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64Flags;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64ReadAddressNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64ReadRegisterNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64ToI8NodeFactory.LLVMAMD64I64ToI8NodeGen;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64UpdateFlagsNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteAddressRegisterNodeGen;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteBooleanNode;
 import com.oracle.truffle.llvm.nodes.base.LLVMStructWriteNodeFactory.LLVMPrimitiveStructWriteNodeGen;
 import com.oracle.truffle.llvm.nodes.cast.LLVMToI16NodeFactory.LLVMToI16NoZeroExtNodeGen;
 import com.oracle.truffle.llvm.nodes.cast.LLVMToI32NodeGen.LLVMToI32NoZeroExtNodeGen;
@@ -155,22 +215,13 @@ import com.oracle.truffle.llvm.nodes.memory.load.LLVMI8LoadNodeGen;
 import com.oracle.truffle.llvm.nodes.others.LLVMUnsupportedInlineAssemblerNode;
 import com.oracle.truffle.llvm.nodes.others.LLVMUnsupportedInlineAssemblerNode.LLVMI32UnsupportedInlineAssemblerNode;
 import com.oracle.truffle.llvm.nodes.vars.LLVMReadNodeFactory.LLVMAddressReadNodeGen;
-import com.oracle.truffle.llvm.nodes.vars.LLVMReadNodeFactory.LLVMDoubleReadNodeGen;
-import com.oracle.truffle.llvm.nodes.vars.LLVMReadNodeFactory.LLVMFloatReadNodeGen;
 import com.oracle.truffle.llvm.nodes.vars.LLVMReadNodeFactory.LLVMI1ReadNodeGen;
-import com.oracle.truffle.llvm.nodes.vars.LLVMReadNodeFactory.LLVMI16ReadNodeGen;
-import com.oracle.truffle.llvm.nodes.vars.LLVMReadNodeFactory.LLVMI32ReadNodeGen;
-import com.oracle.truffle.llvm.nodes.vars.LLVMReadNodeFactory.LLVMI64ReadNodeGen;
-import com.oracle.truffle.llvm.nodes.vars.LLVMReadNodeFactory.LLVMI8ReadNodeGen;
 import com.oracle.truffle.llvm.nodes.vars.LLVMWriteNode.LLVMWriteAddressNode;
 import com.oracle.truffle.llvm.nodes.vars.LLVMWriteNodeFactory.LLVMWriteAddressNodeGen;
-import com.oracle.truffle.llvm.nodes.vars.LLVMWriteNodeFactory.LLVMWriteDoubleNodeGen;
-import com.oracle.truffle.llvm.nodes.vars.LLVMWriteNodeFactory.LLVMWriteFloatNodeGen;
-import com.oracle.truffle.llvm.nodes.vars.LLVMWriteNodeFactory.LLVMWriteI16NodeGen;
-import com.oracle.truffle.llvm.nodes.vars.LLVMWriteNodeFactory.LLVMWriteI32NodeGen;
+import com.oracle.truffle.llvm.nodes.vars.LLVMWriteNodeFactory.LLVMWriteI1NodeGen;
 import com.oracle.truffle.llvm.nodes.vars.LLVMWriteNodeFactory.LLVMWriteI64NodeGen;
-import com.oracle.truffle.llvm.nodes.vars.LLVMWriteNodeFactory.LLVMWriteI8NodeGen;
 import com.oracle.truffle.llvm.nodes.vars.StructLiteralNode;
+import com.oracle.truffle.llvm.runtime.memory.LLVMStack;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 import com.oracle.truffle.llvm.runtime.types.PointerType;
 import com.oracle.truffle.llvm.runtime.types.PrimitiveType;
@@ -184,7 +235,7 @@ class AsmFactory {
     private static final String TEMP_REGISTER_PREFIX = "__$$tmp_r_";
 
     private static final String CONSTRAINT_REG = "r";
-    private static final String CONSTRAINT_ANY = "imr"; // "g" -> "imr"
+    private static final String CONSTRAINT_REG_L = "q";
 
     private final FrameDescriptor frameDescriptor;
     private final List<LLVMExpressionNode> statements;
@@ -198,7 +249,11 @@ class AsmFactory {
     private final Type[] retTypes;
     private final int[] retOffsets;
 
-    AsmFactory(Type[] argTypes, String asmFlags, Type retType, Type[] retTypes, int[] retOffsets) {
+    private String currentPrefix;
+
+    private final SourceSection sourceSection;
+
+    AsmFactory(Type[] argTypes, String asmFlags, Type retType, Type[] retTypes, int[] retOffsets, SourceSection sourceSection) {
         this.argTypes = argTypes;
         this.asmFlags = asmFlags;
         this.frameDescriptor = new FrameDescriptor();
@@ -208,6 +263,7 @@ class AsmFactory {
         this.retType = retType;
         this.retTypes = retTypes;
         this.retOffsets = retOffsets;
+        this.sourceSection = sourceSection;
         parseArguments();
     }
 
@@ -284,13 +340,13 @@ class AsmFactory {
             if (output) {
                 return LLVMArgNodeGen.create(outIndex);
             } else {
-                throw new IllegalStateException();
+                return LLVMArgNodeGen.create(inIndex);
             }
         }
 
         @Override
         public String toString() {
-            return String.format("Argument[IDX=%d,I=%s,O=%s,M=%s,T=%s,R=%s,S=%s]", index, input, output, memory, type, register, source);
+            return String.format("Argument[IDX=%d,I=%s(%s),O=%s(%s),M=%s,T=%s,R=%s,S=%s]", index, input, inIndex, output, outIndex, memory, type, register, source);
         }
     }
 
@@ -327,6 +383,8 @@ class AsmFactory {
                     case '*':
                         isMemory = true;
                         break;
+                    case '&':
+                        break;
                     default:
                         source = token.substring(i);
                         break;
@@ -341,7 +399,7 @@ class AsmFactory {
             int end = source.lastIndexOf('}');
             if (start != -1 && end != -1) {
                 registerName = source.substring(start + 1, end);
-            } else if (source.equals(CONSTRAINT_REG) || source.equals(CONSTRAINT_ANY)) {
+            } else if (source.equals(CONSTRAINT_REG) || source.equals(CONSTRAINT_REG_L)) {
                 registerName = TEMP_REGISTER_PREFIX + argInfo.size();
                 isAnonymous = true;
             } else if (source.length() == 1 && Character.isDigit(source.charAt(0))) {
@@ -365,7 +423,7 @@ class AsmFactory {
                 type = argTypes[index++];
             } else if (retType instanceof StructureType) {
                 if (isMemory) {
-                    type = new PointerType(retType);
+                    type = argTypes[index];
                     idOut = index++;
                 } else {
                     type = retTypes[outIndex++];
@@ -393,6 +451,19 @@ class AsmFactory {
         return new LLVMInlineAssemblyRootNode(null, null, frameDescriptor, statements.toArray(new LLVMExpressionNode[statements.size()]), arguments, result);
     }
 
+    void setPrefix(String prefix) {
+        this.currentPrefix = prefix;
+    }
+
+    void createInt(AsmImmediateOperand nr) {
+        long id = nr.getValue();
+        if (id == 3) {
+            statements.add(new LLVMAMD64BreakpointNode(sourceSection));
+        } else {
+            statements.add(new LLVMI32UnsupportedInlineAssemblerNode(null));
+        }
+    }
+
     void createOperation(String operation) {
         switch (operation) {
             case "clc":
@@ -400,22 +471,46 @@ class AsmFactory {
             case "cli":
             case "cmc":
                 statements.add(new LLVMI32UnsupportedInlineAssemblerNode(null));
-                return;
+                break;
             case "lahf": {
-                LLVMExpressionNode lahf = LLVMAMD64LahfNodeGen.create(getFlag(LLVMAMD64Flags.CF), getFlag(LLVMAMD64Flags.PF), getFlag(LLVMAMD64Flags.ZF), getFlag(LLVMAMD64Flags.SF));
+                LLVMExpressionNode lahf = LLVMAMD64LahfNodeGen.create(getFlag(LLVMAMD64Flags.CF), getFlag(LLVMAMD64Flags.PF), getFlag(LLVMAMD64Flags.AF), getFlag(LLVMAMD64Flags.ZF),
+                                getFlag(LLVMAMD64Flags.SF));
                 LLVMExpressionNode write = getOperandStore(PrimitiveType.I8, new AsmRegisterOperand("ah"), lahf);
                 statements.add(write);
                 break;
             }
-            case "popfw":
-            case "pushfw":
+            case "popf":
+            case "popfw": {
+                LLVMExpressionNode read = LLVMAMD64PopwNodeGen.create();
+                LLVMExpressionNode write = LLVMAMD64WriteFlagswNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF),
+                                getFlagWrite(LLVMAMD64Flags.ZF), getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), read);
+                statements.add(write);
+                break;
+            }
+            case "pushf":
+            case "pushfw": {
+                LLVMExpressionNode flags = LLVMAMD64ReadFlagswNodeGen.create(getFlag(LLVMAMD64Flags.CF), getFlag(LLVMAMD64Flags.PF), getFlag(LLVMAMD64Flags.AF), getFlag(LLVMAMD64Flags.ZF),
+                                getFlag(LLVMAMD64Flags.SF), getFlag(LLVMAMD64Flags.OF));
+                LLVMExpressionNode write = LLVMAMD64PushwNodeGen.create(flags);
+                statements.add(write);
+                break;
+            }
             case "sahf":
             case "stc":
             case "std":
             case "sti":
                 statements.add(new LLVMI32UnsupportedInlineAssemblerNode(null));
-                return;
+                break;
             case "nop":
+                if ("rep".equals(currentPrefix)) {
+                    // TODO: pause
+                }
+                break;
+            case "hlt":
+            case "mfence":
+            case "lfance":
+            case "sfence":
+                // TODO: implement properly
                 break;
             case "rdtsc": {
                 LLVMAMD64WriteI64RegisterNode high = getRegisterStore("rdx");
@@ -432,10 +527,244 @@ class AsmFactory {
                 statements.add(LLVMAMD64CpuidNodeGen.create(eax, ebx, ecx, edx, level));
                 break;
             }
+            case "ud2":
+                statements.add(new LLVMAMD64Ud2Node());
+                break;
             default:
                 statements.add(new LLVMI32UnsupportedInlineAssemblerNode(null));
                 return;
         }
+    }
+
+    void createUnaryOperationImplicitSize(String operation, AsmOperand operand) {
+        LLVMExpressionNode out;
+        AsmOperand dst = operand;
+        assert operand != null;
+        assert operation.length() > 0;
+        Type dstType = getType(operand);
+        PrimitiveType.PrimitiveKind dstPrimitiveType = (dstType instanceof PrimitiveType) ? ((PrimitiveType) dstType).getPrimitiveKind() : null;
+        switch (operation) {
+            case "seta":
+            case "setnbe":
+                out = LLVMAMD64SetaNodeGen.create(getFlag(LLVMAMD64Flags.CF), getFlag(LLVMAMD64Flags.ZF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "setae":
+            case "setnb":
+            case "setnc":
+                out = LLVMAMD64SetzNodeGen.create(getFlag(LLVMAMD64Flags.CF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "setb":
+            case "setc":
+            case "setnae":
+                out = LLVMAMD64SetnzNodeGen.create(getFlag(LLVMAMD64Flags.CF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "setbe":
+                out = LLVMAMD64SetorNodeGen.create(getFlag(LLVMAMD64Flags.CF), getFlag(LLVMAMD64Flags.ZF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "sete":
+            case "setz":
+                out = LLVMAMD64SetzNodeGen.create(getFlag(LLVMAMD64Flags.ZF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "setg":
+            case "setnle":
+                out = LLVMAMD64SetgNodeGen.create(getFlag(LLVMAMD64Flags.ZF), getFlag(LLVMAMD64Flags.SF), getFlag(LLVMAMD64Flags.OF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "setge":
+            case "setnl":
+                out = LLVMAMD64SeteqNodeGen.create(getFlag(LLVMAMD64Flags.SF), getFlag(LLVMAMD64Flags.OF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "setl":
+            case "setnge":
+                out = LLVMAMD64SetneNodeGen.create(getFlag(LLVMAMD64Flags.SF), getFlag(LLVMAMD64Flags.OF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "setle":
+            case "setng":
+                out = LLVMAMD64SetleNodeGen.create(getFlag(LLVMAMD64Flags.ZF), getFlag(LLVMAMD64Flags.SF), getFlag(LLVMAMD64Flags.OF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "setna":
+                out = LLVMAMD64SetorNodeGen.create(getFlag(LLVMAMD64Flags.CF), getFlag(LLVMAMD64Flags.ZF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "setne":
+            case "setnz":
+                out = LLVMAMD64SetzNodeGen.create(getFlag(LLVMAMD64Flags.ZF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "setno":
+                out = LLVMAMD64SetzNodeGen.create(getFlag(LLVMAMD64Flags.OF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "setnp":
+            case "setpo":
+                out = LLVMAMD64SetzNodeGen.create(getFlag(LLVMAMD64Flags.PF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "setns":
+                out = LLVMAMD64SetzNodeGen.create(getFlag(LLVMAMD64Flags.SF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "seto":
+                out = LLVMAMD64SetnzNodeGen.create(getFlag(LLVMAMD64Flags.OF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "setp":
+            case "setpe":
+                out = LLVMAMD64SetnzNodeGen.create(getFlag(LLVMAMD64Flags.PF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "sets":
+                out = LLVMAMD64SetnzNodeGen.create(getFlag(LLVMAMD64Flags.SF));
+                dstType = PrimitiveType.I8;
+                break;
+            case "rdrand":
+                if (dstType instanceof PrimitiveType) {
+                    switch (dstPrimitiveType) {
+                        case I16:
+                            out = LLVMAMD64RdRandwNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF));
+                            break;
+                        case I32:
+                            out = LLVMAMD64RdRandlNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF));
+                            break;
+                        case I64:
+                            out = LLVMAMD64RdRandqNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF));
+                            break;
+                        default:
+                            statements.add(new LLVMI32UnsupportedInlineAssemblerNode(null));
+                            return;
+                    }
+                } else {
+                    statements.add(new LLVMI32UnsupportedInlineAssemblerNode(null));
+                    return;
+                }
+                break;
+            case "rdseed":
+                if (dstType instanceof PrimitiveType) {
+                    switch (dstPrimitiveType) {
+                        case I16:
+                            out = LLVMAMD64RdSeedwNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF));
+                            break;
+                        case I32:
+                            out = LLVMAMD64RdSeedlNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF));
+                            break;
+                        case I64:
+                            out = LLVMAMD64RdSeedqNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF));
+                            break;
+                        default:
+                            statements.add(new LLVMI32UnsupportedInlineAssemblerNode(null));
+                            return;
+                    }
+                } else {
+                    statements.add(new LLVMI32UnsupportedInlineAssemblerNode(null));
+                    return;
+                }
+                break;
+            case "pop":
+                // default size: I64
+                if (dstType == null) {
+                    dstType = PrimitiveType.I64;
+                    dstPrimitiveType = PrimitiveKind.I64;
+                }
+                if (dstType instanceof PrimitiveType) {
+                    switch (dstPrimitiveType) {
+                        case I16:
+                            out = LLVMAMD64PopwNodeGen.create();
+                            break;
+                        case I32:
+                            out = LLVMAMD64PoplNodeGen.create();
+                            break;
+                        case I64:
+                            out = LLVMAMD64PopqNodeGen.create();
+                            break;
+                        default:
+                            throw new AsmParseException("invalid operand size: " + dstPrimitiveType);
+                    }
+                } else if (dstType instanceof PointerType) {
+                    PointerType ptr = (PointerType) dstType;
+                    dstType = ptr.getPointeeType();
+                    if (dstType instanceof PrimitiveType) {
+                        switch (((PrimitiveType) dstType).getPrimitiveKind()) {
+                            case I16:
+                                out = LLVMAMD64PopwNodeGen.create();
+                                break;
+                            case I32:
+                                out = LLVMAMD64PoplNodeGen.create();
+                                break;
+                            case I64:
+                                out = LLVMAMD64PopqNodeGen.create();
+                                break;
+                            default:
+                                throw new AsmParseException("invalid operand size: " + dstPrimitiveType);
+                        }
+                    } else {
+                        throw new AsmParseException("invalid operand type: " + dstType);
+                    }
+                } else {
+                    throw new AsmParseException("invalid operand type: " + dstType);
+                }
+                break;
+            case "push":
+                // default size: I64
+                if (dstType == null) {
+                    dstType = PrimitiveType.I64;
+                    dstPrimitiveType = PrimitiveKind.I64;
+                }
+                if (dstType instanceof PrimitiveType) {
+                    LLVMExpressionNode src = getOperandLoad(dstType, operand);
+                    switch (dstPrimitiveType) {
+                        case I16:
+                            statements.add(LLVMAMD64PushwNodeGen.create(src));
+                            return;
+                        case I32:
+                            statements.add(LLVMAMD64PushlNodeGen.create(src));
+                            return;
+                        case I64:
+                            statements.add(LLVMAMD64PushqNodeGen.create(src));
+                            return;
+                        default:
+                            throw new AsmParseException("invalid operand size: " + dstPrimitiveType);
+                    }
+                } else if (dstType instanceof PointerType) {
+                    PointerType ptr = (PointerType) dstType;
+                    dstType = ptr.getPointeeType();
+                    LLVMExpressionNode src = getOperandLoad(dstType, operand);
+                    if (dstType instanceof PrimitiveType) {
+                        switch (((PrimitiveType) dstType).getPrimitiveKind()) {
+                            case I16:
+                                statements.add(LLVMAMD64PushwNodeGen.create(src));
+                                return;
+                            case I32:
+                                statements.add(LLVMAMD64PushlNodeGen.create(src));
+                                return;
+                            case I64:
+                                statements.add(LLVMAMD64PushqNodeGen.create(src));
+                                return;
+                            default:
+                                throw new AsmParseException("invalid operand size: " + dstPrimitiveType);
+                        }
+                    } else {
+                        throw new AsmParseException("invalid operand type: " + dstType);
+                    }
+                } else {
+                    throw new AsmParseException("invalid operand type: " + dstType);
+                }
+            default:
+                statements.add(new LLVMI32UnsupportedInlineAssemblerNode(null));
+                return;
+        }
+        if (dstType == null) {
+            throw new IllegalArgumentException("unknown operand width");
+        }
+        LLVMExpressionNode write = getOperandStore(dstType, dst, out);
+        statements.add(write);
     }
 
     void createUnaryOperation(String operation, AsmOperand operand) {
@@ -444,27 +773,9 @@ class AsmFactory {
         AsmOperand dst = operand;
         Type dstType;
         assert operation.length() > 0;
-        switch (operation.charAt(operation.length() - 1)) {
-            case 'b':
-                src = getOperandLoad(PrimitiveType.I8, operand);
-                dstType = PrimitiveType.I8;
-                break;
-            case 'w':
-                src = getOperandLoad(PrimitiveType.I16, operand);
-                dstType = PrimitiveType.I16;
-                break;
-            case 'l':
-                src = getOperandLoad(PrimitiveType.I32, operand);
-                dstType = PrimitiveType.I32;
-                break;
-            case 'q':
-                src = getOperandLoad(PrimitiveType.I64, operand);
-                dstType = PrimitiveType.I64;
-                break;
-            default:
-                src = null;
-                dstType = PrimitiveType.I64;
-        }
+        char suffix = operation.charAt(operation.length() - 1);
+        dstType = getPrimitiveTypeFromSuffix(suffix);
+        src = getOperandLoad(dstType, operand);
         switch (operation) {
             case "incb":
                 out = LLVMAMD64IncbNodeGen.create(getUpdateFlagsNode(), src);
@@ -537,48 +848,51 @@ class AsmFactory {
             }
             case "idivq": {
                 LLVMAMD64WriteI64RegisterNode rem = getRegisterStore("rdx");
-                LLVMExpressionNode high = getOperandLoad(PrimitiveType.I32, new AsmRegisterOperand("rdx"));
+                LLVMExpressionNode high = getOperandLoad(PrimitiveType.I64, new AsmRegisterOperand("rdx"));
                 out = LLVMAMD64IdivqNodeGen.create(rem, high, getOperandLoad(PrimitiveType.I64, new AsmRegisterOperand("rax")), src);
                 dst = new AsmRegisterOperand("rax");
                 dstType = PrimitiveType.I64;
                 break;
             }
             case "imulb":
-                out = LLVMAMD64ImulbNodeGen.create(getOperandLoad(PrimitiveType.I16, new AsmRegisterOperand("ax")), src);
+                out = LLVMAMD64ImulbNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), getOperandLoad(PrimitiveType.I8, new AsmRegisterOperand("al")), src);
                 dst = new AsmRegisterOperand("ax");
                 dstType = PrimitiveType.I16;
                 break;
             case "imulw": {
                 LLVMAMD64WriteI16RegisterNode high = getRegisterStore("dx");
-                out = LLVMAMD64ImulwNodeGen.create(high, getOperandLoad(PrimitiveType.I16, new AsmRegisterOperand("ax")), src);
+                out = LLVMAMD64ImulwNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), high, getOperandLoad(PrimitiveType.I16, new AsmRegisterOperand("ax")), src);
                 dst = new AsmRegisterOperand("ax");
                 dstType = PrimitiveType.I16;
                 break;
             }
             case "imull": {
                 LLVMAMD64WriteI32RegisterNode high = getRegisterStore("edx");
-                out = LLVMAMD64ImullNodeGen.create(high, getOperandLoad(PrimitiveType.I32, new AsmRegisterOperand("eax")), src);
+                out = LLVMAMD64ImullNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), high, getOperandLoad(PrimitiveType.I32, new AsmRegisterOperand("eax")), src);
                 dst = new AsmRegisterOperand("eax");
                 dstType = PrimitiveType.I32;
                 break;
             }
             case "imulq": {
                 LLVMAMD64WriteI64RegisterNode high = getRegisterStore("rdx");
-                out = LLVMAMD64ImulqNodeGen.create(high, getOperandLoad(PrimitiveType.I64, new AsmRegisterOperand("rax")), src);
+                out = LLVMAMD64ImulqNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), high, getOperandLoad(PrimitiveType.I64, new AsmRegisterOperand("rax")), src);
                 dst = new AsmRegisterOperand("rax");
                 dstType = PrimitiveType.I64;
                 break;
             }
-            // TODO: implement properly
             case "divb":
-                out = LLVMAMD64IdivbNodeGen.create(getOperandLoad(PrimitiveType.I16, new AsmRegisterOperand("ax")), src);
+                out = LLVMAMD64DivbNodeGen.create(getOperandLoad(PrimitiveType.I16, new AsmRegisterOperand("ax")), src);
                 dst = new AsmRegisterOperand("ax");
                 dstType = PrimitiveType.I16;
                 break;
             case "divw": {
                 LLVMAMD64WriteI16RegisterNode rem = getRegisterStore("dx");
                 LLVMExpressionNode high = getOperandLoad(PrimitiveType.I16, new AsmRegisterOperand("dx"));
-                out = LLVMAMD64IdivwNodeGen.create(rem, high, getOperandLoad(PrimitiveType.I16, new AsmRegisterOperand("ax")), src);
+                out = LLVMAMD64DivwNodeGen.create(rem, high, getOperandLoad(PrimitiveType.I16, new AsmRegisterOperand("ax")), src);
                 dst = new AsmRegisterOperand("ax");
                 dstType = PrimitiveType.I16;
                 break;
@@ -586,66 +900,73 @@ class AsmFactory {
             case "divl": {
                 LLVMAMD64WriteI32RegisterNode rem = getRegisterStore("edx");
                 LLVMExpressionNode high = getOperandLoad(PrimitiveType.I32, new AsmRegisterOperand("edx"));
-                out = LLVMAMD64IdivlNodeGen.create(rem, high, getOperandLoad(PrimitiveType.I32, new AsmRegisterOperand("eax")), src);
+                out = LLVMAMD64DivlNodeGen.create(rem, high, getOperandLoad(PrimitiveType.I32, new AsmRegisterOperand("eax")), src);
                 dst = new AsmRegisterOperand("eax");
                 dstType = PrimitiveType.I32;
                 break;
             }
             case "divq": {
                 LLVMAMD64WriteI64RegisterNode rem = getRegisterStore("rdx");
-                LLVMExpressionNode high = getOperandLoad(PrimitiveType.I32, new AsmRegisterOperand("rdx"));
-                out = LLVMAMD64IdivqNodeGen.create(rem, high, getOperandLoad(PrimitiveType.I64, new AsmRegisterOperand("rax")), src);
+                LLVMExpressionNode high = getOperandLoad(PrimitiveType.I64, new AsmRegisterOperand("rdx"));
+                out = LLVMAMD64DivqNodeGen.create(rem, high, getOperandLoad(PrimitiveType.I64, new AsmRegisterOperand("rax")), src);
                 dst = new AsmRegisterOperand("rax");
                 dstType = PrimitiveType.I64;
                 break;
             }
             case "mulb":
-                src = getOperandLoad(PrimitiveType.I16, operand);
-                out = LLVMAMD64MulbNodeGen.create(getOperandLoad(PrimitiveType.I16, new AsmRegisterOperand("ax")), src);
+                out = LLVMAMD64MulbNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), getOperandLoad(PrimitiveType.I8, new AsmRegisterOperand("al")), src);
                 dst = new AsmRegisterOperand("ax");
                 dstType = PrimitiveType.I16;
                 break;
             case "mulw": {
                 LLVMAMD64WriteI16RegisterNode high = getRegisterStore("dx");
-                out = LLVMAMD64MulwNodeGen.create(high, getOperandLoad(PrimitiveType.I16, new AsmRegisterOperand("ax")), src);
+                out = LLVMAMD64MulwNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), high, getOperandLoad(PrimitiveType.I16, new AsmRegisterOperand("ax")), src);
                 dst = new AsmRegisterOperand("ax");
                 dstType = PrimitiveType.I16;
                 break;
             }
             case "mull": {
                 LLVMAMD64WriteI32RegisterNode high = getRegisterStore("edx");
-                out = LLVMAMD64MullNodeGen.create(high, getOperandLoad(PrimitiveType.I32, new AsmRegisterOperand("eax")), src);
+                out = LLVMAMD64MullNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), high, getOperandLoad(PrimitiveType.I32, new AsmRegisterOperand("eax")), src);
                 dst = new AsmRegisterOperand("eax");
                 dstType = PrimitiveType.I32;
                 break;
             }
             case "mulq": {
                 LLVMAMD64WriteI64RegisterNode high = getRegisterStore("rdx");
-                out = LLVMAMD64MulqNodeGen.create(high, getOperandLoad(PrimitiveType.I64, new AsmRegisterOperand("rax")), src);
+                out = LLVMAMD64MulqNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), high, getOperandLoad(PrimitiveType.I64, new AsmRegisterOperand("rax")), src);
                 dst = new AsmRegisterOperand("rax");
                 dstType = PrimitiveType.I64;
                 break;
             }
-            case "seta":
-                out = LLVMAMD64SetaNodeGen.create(getFlag(LLVMAMD64Flags.CF), getFlag(LLVMAMD64Flags.ZF));
-                dstType = PrimitiveType.I8;
+            case "bswapl":
+                out = LLVMAMD64BswaplNodeGen.create(src);
                 break;
-            case "setae":
-                out = LLVMAMD64SetaeNodeGen.create(getFlag(LLVMAMD64Flags.CF));
-                dstType = PrimitiveType.I8;
+            case "bswapq":
+                out = LLVMAMD64BswapqNodeGen.create(src);
                 break;
-            case "setb":
-                out = LLVMAMD64SetbNodeGen.create(getFlag(LLVMAMD64Flags.CF));
-                dstType = PrimitiveType.I8;
+            case "popw":
+                out = LLVMAMD64PopwNodeGen.create();
                 break;
-            case "setbe":
-                out = LLVMAMD64SetbeNodeGen.create(getFlag(LLVMAMD64Flags.CF), getFlag(LLVMAMD64Flags.ZF));
-                dstType = PrimitiveType.I8;
+            case "popl":
+                out = LLVMAMD64PoplNodeGen.create();
                 break;
-            case "setc":
-                out = LLVMAMD64SetbNodeGen.create(getFlag(LLVMAMD64Flags.CF));
-                dstType = PrimitiveType.I8;
+            case "popq":
+                out = LLVMAMD64PopqNodeGen.create();
                 break;
+            case "pushw":
+                statements.add(LLVMAMD64PushwNodeGen.create(src));
+                return;
+            case "pushl":
+                statements.add(LLVMAMD64PushlNodeGen.create(src));
+                return;
+            case "pushq":
+                statements.add(LLVMAMD64PushqNodeGen.create(src));
+                return;
             default:
                 statements.add(new LLVMI32UnsupportedInlineAssemblerNode(null));
                 return;
@@ -673,10 +994,125 @@ class AsmFactory {
         }
     }
 
+    private class XchgOperands {
+        public final LLVMExpressionNode srcA;
+        public final LLVMExpressionNode srcB;
+        public final AsmOperand dst;
+        public final LLVMAMD64WriteRegisterNode dst2;
+
+        XchgOperands(AsmOperand a, AsmOperand b, Type type) {
+            if (b instanceof AsmRegisterOperand) {
+                AsmRegisterOperand rb = (AsmRegisterOperand) b;
+                srcA = getOperandLoad(type, a);
+                srcB = getOperandLoad(type, b);
+                dst = a;
+                dst2 = getRegisterStore(rb.getRegister());
+            } else if (a instanceof AsmRegisterOperand) {
+                AsmRegisterOperand ra = (AsmRegisterOperand) a;
+                srcA = getOperandLoad(type, b);
+                srcB = getOperandLoad(type, a);
+                dst = b;
+                dst2 = getRegisterStore(ra.getRegister());
+            } else if (a instanceof AsmArgumentOperand) {
+                AsmArgumentOperand arg = (AsmArgumentOperand) a;
+                Argument info = argInfo.get(arg.getIndex());
+                if (info.isRegister()) {
+                    srcA = getOperandLoad(type, b);
+                    srcB = getOperandLoad(type, a);
+                    dst = b;
+                    dst2 = getRegisterStore(type, info.getRegister());
+                } else {
+                    throw new AsmParseException("not implemented");
+                }
+            } else {
+                throw new AsmParseException("not implemented");
+            }
+        }
+    }
+
+    private Type getType(AsmOperand operand) {
+        Type type = operand.getType();
+        if (type != null) {
+            return type;
+        } else if (operand instanceof AsmArgumentOperand) {
+            AsmArgumentOperand op = (AsmArgumentOperand) operand;
+            Argument info = argInfo.get(op.getIndex());
+            return info.getType();
+        } else {
+            return null;
+        }
+    }
+
+    private Type getType(AsmOperand dst, AsmOperand src) {
+        Type type = getType(dst);
+        if (type == null) {
+            type = getType(src);
+        }
+        if (type == null) {
+            throw new AsmParseException("cannot infer type");
+        }
+        return type;
+    }
+
+    void createBinaryOperationImplicitSize(String operation, AsmOperand a, AsmOperand b) {
+        AsmOperand dst = b;
+        AsmOperand src = a;
+        assert a != null && b != null;
+        Type dstType = getType(b, a);
+        PrimitiveType.PrimitiveKind dstPrimitiveType = (dstType instanceof PrimitiveType) ? ((PrimitiveType) dstType).getPrimitiveKind() : null;
+        LLVMExpressionNode out;
+        switch (operation) {
+            case "lea":
+                out = getOperandAddress(dstType, src);
+                if (isLeaPointer(src)) {
+                    dstType = new PointerType(dstType);
+                }
+                break;
+            case "xor":
+                if (dstType instanceof PrimitiveType) {
+                    LLVMExpressionNode srcA = getOperandLoad(dstType, a);
+                    LLVMExpressionNode srcB = getOperandLoad(dstType, b);
+                    switch (dstPrimitiveType) {
+                        case I8:
+                            out = LLVMAMD64XorbNodeGen.create(srcA, srcB);
+                            break;
+                        case I16:
+                            out = LLVMAMD64XorwNodeGen.create(srcA, srcB);
+                            break;
+                        case I32:
+                            out = LLVMAMD64XorlNodeGen.create(srcA, srcB);
+                            break;
+                        case I64:
+                            out = LLVMAMD64XorqNodeGen.create(srcA, srcB);
+                            break;
+                        default:
+                            throw new AsmParseException("invalid operand type: " + dstType);
+                    }
+                } else {
+                    throw new AsmParseException("invalid operand type: " + dstType);
+                }
+                break;
+            case "mov":
+                if (dstType instanceof PrimitiveType) {
+                    LLVMExpressionNode srcA = getOperandLoad(dstType, a);
+                    out = srcA;
+                } else {
+                    throw new AsmParseException("invalid operand type: " + dstType);
+                }
+                break;
+            default:
+                statements.add(new LLVMI32UnsupportedInlineAssemblerNode(null));
+                return;
+        }
+        LLVMExpressionNode write = getOperandStore(dstType, dst, out);
+        statements.add(write);
+    }
+
     void createBinaryOperation(String operation, AsmOperand a, AsmOperand b) {
         LLVMExpressionNode srcA;
         LLVMExpressionNode srcB;
         LLVMExpressionNode out;
+        assert a != null && b != null;
         AsmOperand dst = b;
         Type dstType;
         char suffix = operation.charAt(operation.length() - 1);
@@ -752,25 +1188,22 @@ class AsmFactory {
                 dst = new AsmRegisterOperand("rax");
                 break;
             }
-            case "imulb":
-                srcA = getOperandLoad(PrimitiveType.I16, a);
-                srcB = getOperandLoad(PrimitiveType.I8, b);
-                out = LLVMAMD64ImulbNodeGen.create(srcA, srcB);
-                dstType = PrimitiveType.I16;
-                break;
             case "imulw": {
                 LLVMAMD64WriteI16RegisterNode high = getRegisterStore("dx");
-                out = LLVMAMD64ImulwNodeGen.create(high, srcA, srcB);
+                out = LLVMAMD64ImulwNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), high, srcA, srcB);
                 break;
             }
             case "imull": {
                 LLVMAMD64WriteI32RegisterNode high = getRegisterStore("edx");
-                out = LLVMAMD64ImullNodeGen.create(high, srcA, srcB);
+                out = LLVMAMD64ImullNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), high, srcA, srcB);
                 break;
             }
             case "imulq": {
                 LLVMAMD64WriteI64RegisterNode high = getRegisterStore("rdx");
-                out = LLVMAMD64ImulqNodeGen.create(high, srcA, srcB);
+                out = LLVMAMD64ImulqNodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), high, srcA, srcB);
                 break;
             }
             case "movb":
@@ -875,6 +1308,110 @@ class AsmFactory {
             case "orq":
                 out = LLVMAMD64OrqNodeGen.create(srcA, srcB);
                 break;
+            case "xchgb": {
+                XchgOperands operands = new XchgOperands(a, b, dstType);
+                out = LLVMAMD64XchgbNodeGen.create((LLVMAMD64WriteI8RegisterNode) operands.dst2, operands.srcA, operands.srcB);
+                dst = operands.dst;
+                break;
+            }
+            case "xchgw": {
+                XchgOperands operands = new XchgOperands(a, b, dstType);
+                out = LLVMAMD64XchgwNodeGen.create((LLVMAMD64WriteI16RegisterNode) operands.dst2, operands.srcA, operands.srcB);
+                dst = operands.dst;
+                break;
+            }
+            case "xchgl": {
+                XchgOperands operands = new XchgOperands(a, b, dstType);
+                out = LLVMAMD64XchglNodeGen.create((LLVMAMD64WriteI32RegisterNode) operands.dst2, operands.srcA, operands.srcB);
+                dst = operands.dst;
+                break;
+            }
+            case "xchgq": {
+                XchgOperands operands = new XchgOperands(a, b, dstType);
+                out = LLVMAMD64XchgqNodeGen.create((LLVMAMD64WriteI64RegisterNode) operands.dst2, operands.srcA, operands.srcB);
+                dst = operands.dst;
+                break;
+            }
+            case "cmpb":
+                statements.add(LLVMAMD64CmpbNodeGen.create(getUpdateFlagsNode(), srcB, srcA));
+                return;
+            case "cmpw":
+                statements.add(LLVMAMD64CmpwNodeGen.create(getUpdateFlagsNode(), srcB, srcA));
+                return;
+            case "cmpl":
+                statements.add(LLVMAMD64CmplNodeGen.create(getUpdateFlagsNode(), srcB, srcA));
+                return;
+            case "cmpq":
+                statements.add(LLVMAMD64CmpqNodeGen.create(getUpdateFlagsNode(), srcB, srcA));
+                return;
+            case "cmpxchgb": {
+                LLVMAMD64WriteI8RegisterNode dst2 = getRegisterStore("al");
+                LLVMExpressionNode accumulator = getOperandLoad(PrimitiveType.I8, new AsmRegisterOperand("al"));
+                out = LLVMAMD64CmpXchgbNodeGen.create(getUpdateFlagsNode(), dst2, accumulator, srcA, srcB);
+                dst = b;
+                break;
+            }
+            case "cmpxchgw": {
+                LLVMAMD64WriteI16RegisterNode dst2 = getRegisterStore("ax");
+                LLVMExpressionNode accumulator = getOperandLoad(PrimitiveType.I16, new AsmRegisterOperand("ax"));
+                out = LLVMAMD64CmpXchgwNodeGen.create(getUpdateFlagsNode(), dst2, accumulator, srcA, srcB);
+                dst = b;
+                break;
+            }
+            case "cmpxchgl": {
+                LLVMAMD64WriteI32RegisterNode dst2 = getRegisterStore("eax");
+                LLVMExpressionNode accumulator = getOperandLoad(PrimitiveType.I32, new AsmRegisterOperand("eax"));
+                if (b instanceof AsmRegisterOperand) {
+                    AsmRegisterOperand rd = (AsmRegisterOperand) b;
+                    LLVMAMD64WriteI32RegisterNode dst1 = getRegisterStore(PrimitiveType.I32, rd.getRegister());
+                    out = LLVMAMD64CmpXchglrNodeGen.create(getUpdateFlagsNode(), dst1, dst2, accumulator, srcA, srcB);
+                    statements.add(out);
+                    return;
+                } else if (b instanceof AsmArgumentOperand) {
+                    AsmArgumentOperand arg = (AsmArgumentOperand) b;
+                    Argument info = argInfo.get(arg.getIndex());
+                    if (info.isMemory()) {
+                        out = LLVMAMD64CmpXchglNodeGen.create(getUpdateFlagsNode(), dst2, accumulator, srcA, srcB);
+                        dst = b;
+                    } else {
+                        LLVMAMD64WriteI32RegisterNode dst1 = getRegisterStore(PrimitiveType.I32, info.getRegister());
+                        out = LLVMAMD64CmpXchglrNodeGen.create(getUpdateFlagsNode(), dst1, dst2, accumulator, srcA, srcB);
+                        statements.add(out);
+                        return;
+                    }
+                } else {
+                    out = LLVMAMD64CmpXchglNodeGen.create(getUpdateFlagsNode(), dst2, accumulator, srcA, srcB);
+                    dst = b;
+                }
+                break;
+            }
+            case "cmpxchgq": {
+                LLVMAMD64WriteI64RegisterNode dst2 = getRegisterStore("rax");
+                LLVMExpressionNode accumulator = getOperandLoad(PrimitiveType.I64, new AsmRegisterOperand("rax"));
+                out = LLVMAMD64CmpXchgqNodeGen.create(getUpdateFlagsNode(), dst2, accumulator, srcA, srcB);
+                dst = b;
+                break;
+            }
+            case "xaddb": {
+                LLVMAMD64WriteI8RegisterNode src = getRegisterStore(PrimitiveType.I8, a);
+                out = LLVMAMD64XaddbNodeGen.create(getUpdateFlagsNode(), src, srcA, srcB);
+                break;
+            }
+            case "xaddw": {
+                LLVMAMD64WriteI16RegisterNode src = getRegisterStore(PrimitiveType.I16, a);
+                out = LLVMAMD64XaddwNodeGen.create(getUpdateFlagsNode(), src, srcA, srcB);
+                break;
+            }
+            case "xaddl": {
+                LLVMAMD64WriteI32RegisterNode src = getRegisterStore(PrimitiveType.I32, a);
+                out = LLVMAMD64XaddlNodeGen.create(getUpdateFlagsNode(), src, srcA, srcB);
+                break;
+            }
+            case "xaddq": {
+                LLVMAMD64WriteI64RegisterNode src = getRegisterStore(PrimitiveType.I64, a);
+                out = LLVMAMD64XaddqNodeGen.create(getUpdateFlagsNode(), src, srcA, srcB);
+                break;
+            }
             case "xorb":
                 out = LLVMAMD64XorbNodeGen.create(srcA, srcB);
                 break;
@@ -887,6 +1424,24 @@ class AsmFactory {
             case "xorq":
                 out = LLVMAMD64XorqNodeGen.create(srcA, srcB);
                 break;
+            case "bsrw":
+                out = LLVMAMD64BsrwNodeGen.create(getFlagWrite(LLVMAMD64Flags.ZF), srcA, srcB);
+                break;
+            case "bsrl":
+                out = LLVMAMD64BsrlNodeGen.create(getFlagWrite(LLVMAMD64Flags.ZF), srcA, srcB);
+                break;
+            case "bsrq":
+                out = LLVMAMD64BsrqNodeGen.create(getFlagWrite(LLVMAMD64Flags.ZF), srcA, srcB);
+                break;
+            case "bsfw":
+                out = LLVMAMD64BsfwNodeGen.create(getFlagWrite(LLVMAMD64Flags.ZF), srcA, srcB);
+                break;
+            case "bsfl":
+                out = LLVMAMD64BsflNodeGen.create(getFlagWrite(LLVMAMD64Flags.ZF), srcA, srcB);
+                break;
+            case "bsfq":
+                out = LLVMAMD64BsfqNodeGen.create(getFlagWrite(LLVMAMD64Flags.ZF), srcA, srcB);
+                break;
             default:
                 statements.add(new LLVMI32UnsupportedInlineAssemblerNode(null));
                 return;
@@ -896,7 +1451,37 @@ class AsmFactory {
     }
 
     @SuppressWarnings("unused")
-    public void createTernaryOperation(String op, AsmOperand a, AsmOperand b, AsmOperand c) {
+    public void createTernaryOperation(String operation, AsmOperand a, AsmOperand b, AsmOperand c) {
+        AsmOperand dst = c;
+        LLVMExpressionNode srcA;
+        LLVMExpressionNode srcB;
+        LLVMExpressionNode out;
+        Type dstType;
+        assert a != null && b != null && c != null;
+        char suffix = operation.charAt(operation.length() - 1);
+        dstType = getPrimitiveTypeFromSuffix(suffix);
+        srcB = getOperandLoad(dstType, b);
+        srcA = getOperandLoad(dstType, a);
+        PrimitiveType.PrimitiveKind dstPrimitiveType = (dstType instanceof PrimitiveType) ? ((PrimitiveType) dstType).getPrimitiveKind() : null;
+        switch (operation) {
+            case "imulw":
+                out = LLVMAMD64Imulw3NodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), srcA, srcB);
+                break;
+            case "imull":
+                out = LLVMAMD64Imull3NodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), srcA, srcB);
+                break;
+            case "imulq":
+                out = LLVMAMD64Imulq3NodeGen.create(getFlagWrite(LLVMAMD64Flags.CF), getFlagWrite(LLVMAMD64Flags.PF), getFlagWrite(LLVMAMD64Flags.AF), getFlagWrite(LLVMAMD64Flags.ZF),
+                                getFlagWrite(LLVMAMD64Flags.SF), getFlagWrite(LLVMAMD64Flags.OF), srcA, srcB);
+                break;
+            default:
+                statements.add(new LLVMI32UnsupportedInlineAssemblerNode(null));
+                return;
+        }
+        LLVMExpressionNode write = getOperandStore(dstType, dst, out);
+        statements.add(write);
     }
 
     void addFrameSlot(String reg, Type type) {
@@ -928,6 +1513,24 @@ class AsmFactory {
         }
     }
 
+    private static PrimitiveKind getPrimitiveKind(Argument arg) {
+        PrimitiveKind primitiveKind;
+        if (arg.getType() instanceof PrimitiveType) {
+            primitiveKind = ((PrimitiveType) arg.getType()).getPrimitiveKind();
+        } else if (arg.getType() instanceof PointerType) {
+            PointerType ptr = (PointerType) arg.getType();
+            Type type = ptr.getPointeeType();
+            if (type instanceof PrimitiveType) {
+                primitiveKind = ((PrimitiveType) type).getPrimitiveKind();
+            } else {
+                throw new AsmParseException("cannot handle return type " + type);
+            }
+        } else {
+            throw new AsmParseException("cannot handle return type " + arg.getType());
+        }
+        return primitiveKind;
+    }
+
     private void getArguments() {
         LLVMStructWriteNode[] writeNodes = null;
         LLVMExpressionNode[] valueNodes = null;
@@ -943,10 +1546,10 @@ class AsmFactory {
                 FrameSlot slot = null;
                 if (arg.isRegister()) {
                     slot = getRegisterSlot(arg.getRegister());
-                    LLVMExpressionNode register = LLVMI64ReadNodeGen.create(slot);
+                    LLVMExpressionNode register = LLVMAMD64ReadRegisterNodeGen.create(slot);
                     if (retType instanceof StructureType) {
                         assert retTypes[arg.getOutIndex()] == arg.getType();
-                        PrimitiveKind primitiveKind = ((PrimitiveType) arg.getType()).getPrimitiveKind();
+                        PrimitiveKind primitiveKind = getPrimitiveKind(arg);
                         switch (primitiveKind) {
                             case I8:
                                 valueNodes[arg.getOutIndex()] = LLVMToI8NoZeroExtNodeGen.create(register);
@@ -971,38 +1574,10 @@ class AsmFactory {
                         result = castResult(register);
                     }
                 } else {
-                    slot = getArgumentSlot(arg.getIndex(), retType);
-                    if (retType instanceof PrimitiveType) {
-                        handlePrimitive(slot);
-                    } else if (retType instanceof StructureType) {
-                        PrimitiveKind primitiveKind = ((PrimitiveType) arg.getType()).getPrimitiveKind();
-                        switch (primitiveKind) {
-                            case I8:
-                                valueNodes[arg.getOutIndex()] = LLVMI8ReadNodeGen.create(slot);
-                                writeNodes[arg.getOutIndex()] = LLVMPrimitiveStructWriteNodeGen.create();
-                                break;
-                            case I16:
-                                valueNodes[arg.getOutIndex()] = LLVMI16ReadNodeGen.create(slot);
-                                writeNodes[arg.getOutIndex()] = LLVMPrimitiveStructWriteNodeGen.create();
-                                break;
-                            case I32:
-                                valueNodes[arg.getOutIndex()] = LLVMI32ReadNodeGen.create(slot);
-                                writeNodes[arg.getOutIndex()] = LLVMPrimitiveStructWriteNodeGen.create();
-                                break;
-                            case I64:
-                                valueNodes[arg.getOutIndex()] = LLVMI64ReadNodeGen.create(slot);
-                                writeNodes[arg.getOutIndex()] = LLVMPrimitiveStructWriteNodeGen.create();
-                                break;
-                            default:
-                                throw new AsmParseException("invalid operand size");
-                        }
-                    } else if (retType instanceof PointerType) {
-                        result = LLVMAddressReadNodeGen.create(slot);
-                    } else if (retType instanceof VoidType) {
-                        result = null;
-                    } else {
-                        throw new AsmParseException("invalid operand size: " + retType);
-                    }
+                    assert arg.isMemory();
+                    slot = getArgumentSlot(arg.getIndex(), argTypes[arg.getOutIndex()]);
+                    LLVMExpressionNode argnode = LLVMArgNodeGen.create(arg.getOutIndex());
+                    arguments.add(LLVMWriteAddressNodeGen.create(argnode, slot, sourceSection));
                 }
             }
 
@@ -1024,7 +1599,8 @@ class AsmFactory {
                 slot = getArgumentSlot(arg.getIndex(), argTypes[arg.getInIndex()]);
                 LLVMExpressionNode argnode = LLVMArgNodeGen.create(arg.getInIndex());
                 if (arg.getType() instanceof PrimitiveType) {
-                    handlePrimitiveArgument(arg.getType(), slot, argnode);
+                    LLVMExpressionNode node = LLVMToI64NoZeroExtNodeGen.create(argnode);
+                    arguments.add(LLVMWriteI64NodeGen.create(node, slot, null));
                 } else if (arg.getType() instanceof PointerType) {
                     arguments.add(LLVMWriteAddressNodeGen.create(argnode, slot, null));
                 } else {
@@ -1052,57 +1628,21 @@ class AsmFactory {
             arguments.add(LLVMWriteI64NodeGen.create(node, slot, null));
         }
 
+        // initialize flags
+        LLVMExpressionNode zero = LLVMAMD64I1NodeGen.create(false);
+        arguments.add(LLVMWriteI1NodeGen.create(zero, getFlagSlot(LLVMAMD64Flags.CF), sourceSection));
+        arguments.add(LLVMWriteI1NodeGen.create(zero, getFlagSlot(LLVMAMD64Flags.PF), sourceSection));
+        arguments.add(LLVMWriteI1NodeGen.create(zero, getFlagSlot(LLVMAMD64Flags.AF), sourceSection));
+        arguments.add(LLVMWriteI1NodeGen.create(zero, getFlagSlot(LLVMAMD64Flags.ZF), sourceSection));
+        arguments.add(LLVMWriteI1NodeGen.create(zero, getFlagSlot(LLVMAMD64Flags.SF), sourceSection));
+        arguments.add(LLVMWriteI1NodeGen.create(zero, getFlagSlot(LLVMAMD64Flags.OF), sourceSection));
+
+        // copy stack pointer
+        LLVMExpressionNode stackPointer = LLVMArgNodeGen.create(0);
+        frameDescriptor.addFrameSlot(LLVMStack.FRAME_ID);
+        arguments.add(LLVMWriteI64NodeGen.create(stackPointer, frameDescriptor.findFrameSlot(LLVMStack.FRAME_ID), sourceSection));
+
         assert retType instanceof VoidType || retType != null;
-    }
-
-    private void handlePrimitiveArgument(Type argType, FrameSlot slot, LLVMExpressionNode argnode) {
-        switch (((PrimitiveType) argType).getPrimitiveKind()) {
-            case I8:
-                arguments.add(LLVMWriteI8NodeGen.create(argnode, slot, null));
-                break;
-            case I16:
-                arguments.add(LLVMWriteI16NodeGen.create(argnode, slot, null));
-                break;
-            case I32:
-                arguments.add(LLVMWriteI32NodeGen.create(argnode, slot, null));
-                break;
-            case I64:
-                arguments.add(LLVMWriteI64NodeGen.create(argnode, slot, null));
-                break;
-            case FLOAT:
-                arguments.add(LLVMWriteFloatNodeGen.create(argnode, slot, null));
-                break;
-            case DOUBLE:
-                arguments.add(LLVMWriteDoubleNodeGen.create(argnode, slot, null));
-                break;
-            default:
-                throw new AsmParseException("invalid operand size: " + argType);
-        }
-    }
-
-    private void handlePrimitive(FrameSlot slot) {
-        switch (((PrimitiveType) retType).getPrimitiveKind()) {
-            case I8:
-                result = LLVMI8ReadNodeGen.create(slot);
-                break;
-            case I16:
-                result = LLVMI16ReadNodeGen.create(slot);
-                break;
-            case I32:
-                result = LLVMI32ReadNodeGen.create(slot);
-                break;
-            case I64:
-                result = LLVMI64ReadNodeGen.create(slot);
-                break;
-            case FLOAT:
-                result = LLVMFloatReadNodeGen.create(slot);
-                break;
-            case DOUBLE:
-                result = LLVMDoubleReadNodeGen.create(slot);
-                break;
-            default:
-                throw new AsmParseException("invalid operand size: " + retType);
-        }
     }
 
     private LLVMExpressionNode castResult(LLVMExpressionNode register) {
@@ -1114,23 +1654,115 @@ class AsmFactory {
             case I32:
                 return LLVMToI32NoZeroExtNodeGen.create(register);
             case I64:
-                return register;
+                return LLVMToI64NoZeroExtNodeGen.create(register);
             default:
                 return new LLVMUnsupportedInlineAssemblerNode(null);
         }
     }
 
-    private LLVMExpressionNode getOperandLoad(Type type, AsmOperand operand) {
+    private boolean isLeaPointer(AsmOperand operand) {
+        if (operand instanceof AsmArgumentOperand) {
+            AsmArgumentOperand op = (AsmArgumentOperand) operand;
+            Argument info = argInfo.get(op.getIndex());
+            if (info.isMemory()) {
+                return true;
+            } else {
+                throw new AsmParseException("not a pointer");
+            }
+        } else if (operand instanceof AsmMemoryOperand) {
+            AsmMemoryOperand op = (AsmMemoryOperand) operand;
+            AsmOperand base = op.getBase();
+            AsmOperand offset = op.getOffset();
+            return base != null || offset != null;
+        } else {
+            throw new AsmParseException("unsupported operand: " + operand);
+        }
+    }
+
+    private LLVMExpressionNode getOperandAddress(AsmOperand operand) {
+        return getOperandAddress(operand.getType(), operand);
+    }
+
+    private LLVMExpressionNode getOperandAddress(Type type, AsmOperand operand) {
         if (operand instanceof AsmRegisterOperand) {
             AsmRegisterOperand op = (AsmRegisterOperand) operand;
             FrameSlot frame = getRegisterSlot(op.getBaseRegister());
-            LLVMExpressionNode register = LLVMI64ReadNodeGen.create(frame);
-            int shift = op.getShift();
-            assert type instanceof PointerType || type == op.getWidth();
             if (type instanceof PointerType) {
                 return LLVMAddressReadNodeGen.create(frame);
+            } else {
+                throw new AsmParseException("not a pointer");
             }
-            switch (((PrimitiveType) op.getWidth()).getPrimitiveKind()) {
+        } else if (operand instanceof AsmArgumentOperand) {
+            AsmArgumentOperand op = (AsmArgumentOperand) operand;
+            Argument info = argInfo.get(op.getIndex());
+            FrameSlot frame = getArgumentSlot(op.getIndex(), type);
+            if (info.isMemory()) {
+                return LLVMAddressReadNodeGen.create(frame);
+            } else {
+                throw new AsmParseException("not a pointer");
+            }
+        } else if (operand instanceof AsmMemoryOperand) {
+            AsmMemoryOperand op = (AsmMemoryOperand) operand;
+            int displacement = op.getDisplacement();
+            AsmOperand base = op.getBase();
+            AsmOperand offset = op.getOffset();
+            int shift = op.getShift();
+            LLVMExpressionNode baseAddress;
+            if (base != null) {
+                baseAddress = getOperandLoad(new PointerType(type), base);
+            } else if (offset != null) {
+                LLVMExpressionNode offsetNode = getOperandLoad(null, offset);
+                return LLVMAMD64AddressNoBaseOffsetComputationNodeGen.create(displacement, shift, offsetNode);
+            } else {
+                if (type instanceof PrimitiveType) {
+                    switch (((PrimitiveType) type).getPrimitiveKind()) {
+                        case I16:
+                            return LLVMAMD64I16NodeGen.create((short) displacement);
+                        case I32:
+                            return LLVMAMD64I32NodeGen.create(displacement);
+                        case I64:
+                            return LLVMAMD64I64NodeGen.create(displacement);
+                        default:
+                            throw new AsmParseException("unknown type: " + type);
+                    }
+                } else {
+                    throw new AsmParseException("invalid type: " + type);
+                }
+            }
+            LLVMExpressionNode address;
+            if (offset == null) {
+                address = LLVMAMD64AddressDisplacementComputationNodeGen.create(displacement, baseAddress);
+            } else {
+                LLVMExpressionNode offsetNode = getOperandLoad(null, offset);
+                address = LLVMAMD64AddressOffsetComputationNodeGen.create(displacement, shift, baseAddress, offsetNode);
+            }
+            return address;
+        } else {
+            throw new AsmParseException("unsupported operand: " + operand);
+        }
+    }
+
+    private LLVMExpressionNode getOperandLoad(Type typeHint, AsmOperand operand) {
+        Type type = typeHint == null ? operand.getType() : typeHint;
+        if (operand instanceof AsmRegisterOperand) {
+            AsmRegisterOperand op = (AsmRegisterOperand) operand;
+            FrameSlot frame = getRegisterSlot(op.getBaseRegister());
+            LLVMExpressionNode register = LLVMAMD64ReadRegisterNodeGen.create(frame);
+            int shift = op.getShift();
+            assert type instanceof PointerType || type == op.getType();
+            if (type instanceof PointerType) {
+                switch (((PrimitiveType) op.getType()).getPrimitiveKind()) {
+                    case I16:
+                        return LLVMToI16NoZeroExtNodeGen.create(register);
+                    case I32:
+                        return LLVMToI32NoZeroExtNodeGen.create(register);
+                    case I64:
+                        return LLVMAMD64ReadAddressNodeGen.create(frame);
+                    default:
+                        throw new AsmParseException("unsupported operand type: " + type);
+                }
+            }
+            switch (((PrimitiveType) op.getType()).getPrimitiveKind()) {
                 case I8:
                     return LLVMAMD64I64ToI8NodeGen.create(shift, register);
                 case I16:
@@ -1138,7 +1770,7 @@ class AsmFactory {
                 case I32:
                     return LLVMToI32NoZeroExtNodeGen.create(register);
                 case I64:
-                    return register;
+                    return LLVMToI64NoZeroExtNodeGen.create(register);
                 default:
                     throw new AsmParseException("unsupported operand type: " + type);
             }
@@ -1178,12 +1810,11 @@ class AsmFactory {
                         throw new AsmParseException("unsupported operand type: " + type);
                 }
             } else if (info.isRegister()) {
-                assert type instanceof PointerType || type == info.getType();
                 frame = getRegisterSlot(info.getRegister());
                 if (type instanceof PointerType) {
-                    return LLVMAddressReadNodeGen.create(frame);
+                    return LLVMAMD64ReadAddressNodeGen.create(frame);
                 }
-                LLVMExpressionNode register = LLVMI64ReadNodeGen.create(frame);
+                LLVMExpressionNode register = LLVMAMD64ReadRegisterNodeGen.create(frame);
                 switch (((PrimitiveType) type).getPrimitiveKind()) {
                     case I8:
                         return LLVMToI8NoZeroExtNodeGen.create(register);
@@ -1192,27 +1823,30 @@ class AsmFactory {
                     case I32:
                         return LLVMToI32NoZeroExtNodeGen.create(register);
                     case I64:
-                        return register;
+                        return LLVMToI64NoZeroExtNodeGen.create(register);
                     default:
                         throw new AsmParseException("unsupported operand type: " + type);
                 }
-            } else {
-                throw new AssertionError("this should not happen; " + info);
+            } else { // constraint "0"-"9"
+                if (type instanceof PointerType) {
+                    return LLVMAMD64ReadAddressNodeGen.create(frame);
+                }
+                LLVMExpressionNode register = LLVMAMD64ReadRegisterNodeGen.create(frame);
+                switch (((PrimitiveType) type).getPrimitiveKind()) {
+                    case I8:
+                        return LLVMToI8NoZeroExtNodeGen.create(register);
+                    case I16:
+                        return LLVMToI16NoZeroExtNodeGen.create(register);
+                    case I32:
+                        return LLVMToI32NoZeroExtNodeGen.create(register);
+                    case I64:
+                        return LLVMToI64NoZeroExtNodeGen.create(register);
+                    default:
+                        throw new AsmParseException("unsupported operand type: " + type);
+                }
             }
         } else if (operand instanceof AsmMemoryOperand) {
-            AsmMemoryOperand op = (AsmMemoryOperand) operand;
-            int displacement = op.getDisplacement();
-            AsmOperand base = op.getBase();
-            AsmOperand offset = op.getOffset();
-            int shift = op.getShift();
-            LLVMExpressionNode baseAddress = getOperandLoad(new PointerType(type), base);
-            LLVMExpressionNode address;
-            if (offset == null) {
-                address = LLVMAMD64AddressDisplacementComputationNodeGen.create(displacement, baseAddress);
-            } else {
-                LLVMExpressionNode offsetNode = getOperandLoad(PrimitiveType.I64, base);
-                address = LLVMAMD64AddressOffsetComputationNodeGen.create(displacement, shift, baseAddress, offsetNode);
-            }
+            LLVMExpressionNode address = getOperandAddress(operand);
             switch (((PrimitiveType) type).getPrimitiveKind()) {
                 case I8:
                     return LLVMI8LoadNodeGen.create(address);
@@ -1233,11 +1867,11 @@ class AsmFactory {
         if (operand instanceof AsmRegisterOperand) {
             AsmRegisterOperand op = (AsmRegisterOperand) operand;
             FrameSlot frame = getRegisterSlot(op.getBaseRegister());
-            LLVMExpressionNode register = LLVMI64ReadNodeGen.create(frame);
+            LLVMExpressionNode register = LLVMAMD64ReadRegisterNodeGen.create(frame);
             int shift = op.getShift();
             LLVMExpressionNode out = null;
-            assert type == op.getWidth();
-            switch (((PrimitiveType) op.getWidth()).getPrimitiveKind()) {
+            assert type == op.getType();
+            switch (((PrimitiveType) op.getType()).getPrimitiveKind()) {
                 case I8:
                     out = LLVMI8ToR64NodeGen.create(shift, register, from);
                     break;
@@ -1245,13 +1879,13 @@ class AsmFactory {
                     out = LLVMI16ToR64NodeGen.create(register, from);
                     break;
                 case I32:
-                    out = LLVMI32ToR64NodeGen.create(register, from);
+                    out = LLVMI32ToR64NodeGen.create(from);
                     break;
                 case I64:
                     out = from;
                     break;
                 default:
-                    throw new AsmParseException("unsupported operand type: " + op.getWidth());
+                    throw new AsmParseException("unsupported operand type: " + op.getType());
             }
             return LLVMWriteI64NodeGen.create(out, frame, null);
         } else if (operand instanceof AsmArgumentOperand) {
@@ -1272,12 +1906,11 @@ class AsmFactory {
                         throw new AsmParseException("unsupported operand type: " + type);
                 }
             } else if (info.isRegister()) {
-                assert type == info.getType() || info.getType() instanceof PointerType;
                 FrameSlot frame = getRegisterSlot(info.getRegister());
-                LLVMExpressionNode register = LLVMI64ReadNodeGen.create(frame);
+                LLVMExpressionNode register = LLVMAMD64ReadRegisterNodeGen.create(frame);
                 LLVMExpressionNode out = null;
-                if (info.getType() instanceof PointerType) {
-                    throw new AsmParseException("not yet implemented: address within register");
+                if (type instanceof PointerType || info.getType() instanceof PointerType) {
+                    return LLVMAMD64WriteAddressRegisterNodeGen.create(from, frame);
                 }
                 switch (((PrimitiveType) type).getPrimitiveKind()) {
                     case I8:
@@ -1287,7 +1920,7 @@ class AsmFactory {
                         out = LLVMI16ToR64NodeGen.create(register, from);
                         break;
                     case I32:
-                        out = LLVMI32ToR64NodeGen.create(register, from);
+                        out = LLVMI32ToR64NodeGen.create(from);
                         break;
                     case I64:
                         out = from;
@@ -1303,18 +1936,44 @@ class AsmFactory {
         throw new AsmParseException("unsupported operand type: " + operand);
     }
 
-    @SuppressWarnings("unchecked")
+    private <T extends LLVMAMD64WriteRegisterNode> T getRegisterStore(Type type, AsmOperand operand) {
+        if (operand instanceof AsmRegisterOperand) {
+            AsmRegisterOperand op = (AsmRegisterOperand) operand;
+            return getRegisterStore(type, op.getRegister());
+        } else if (operand instanceof AsmArgumentOperand) {
+            AsmArgumentOperand op = (AsmArgumentOperand) operand;
+            Argument info = argInfo.get(op.getIndex());
+            if (info.isRegister()) {
+                return getRegisterStore(type, info.getRegister());
+            } else {
+                throw new AsmParseException("unsupported operand: " + info);
+            }
+        } else {
+            throw new AsmParseException("unsupported operand: " + operand);
+        }
+    }
+
     private <T extends LLVMAMD64WriteRegisterNode> T getRegisterStore(String name) {
         AsmRegisterOperand op = new AsmRegisterOperand(name);
+        Type type = name.startsWith(TEMP_REGISTER_PREFIX) ? PrimitiveType.I64 : op.getType();
+        return getRegisterStore(type, name);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends LLVMAMD64WriteRegisterNode> T getRegisterStore(Type type, String name) {
+        AsmRegisterOperand op = new AsmRegisterOperand(name);
         FrameSlot frame = getRegisterSlot(name);
-        LLVMExpressionNode register = LLVMI64ReadNodeGen.create(frame);
+        LLVMExpressionNode register = LLVMAMD64ReadRegisterNodeGen.create(frame);
         LLVMAMD64WriteRegisterNode node = null;
-        switch (((PrimitiveType) op.getWidth()).getPrimitiveKind()) {
+        switch (((PrimitiveType) type).getPrimitiveKind()) {
+            case I8:
+                node = new LLVMAMD64WriteI8RegisterNode(frame, op.getShift(), register);
+                break;
             case I16:
                 node = new LLVMAMD64WriteI16RegisterNode(frame, register);
                 break;
             case I32:
-                node = new LLVMAMD64WriteI32RegisterNode(frame, register);
+                node = new LLVMAMD64WriteI32RegisterNode(frame);
                 break;
             case I64:
                 node = new LLVMAMD64WriteI64RegisterNode(frame);
@@ -1343,10 +2002,12 @@ class AsmFactory {
 
     private FrameSlot getArgumentSlot(int index, Type type) {
         Argument info = argInfo.get(index);
-        assert info.isMemory() || type instanceof StructureType || type instanceof PointerType || type == info.getType() : String.format("arg: %s; %s vs %s", info, type, info.getType());
-
         String name = getArgumentName(index);
-        addFrameSlot(name, info.getType());
+        if (type instanceof StructureType || type instanceof PointerType) {
+            addFrameSlot(name, info.getType());
+        } else {
+            addFrameSlot(name, PrimitiveType.I64);
+        }
         return frameDescriptor.findFrameSlot(name);
     }
 
@@ -1364,8 +2025,12 @@ class AsmFactory {
         return LLVMI1ReadNodeGen.create(getFlagSlot(flag));
     }
 
+    private LLVMAMD64WriteBooleanNode getFlagWrite(long flag) {
+        return new LLVMAMD64WriteBooleanNode(getFlagSlot(flag));
+    }
+
     private LLVMAMD64UpdateFlagsNode getUpdateFlagsNode() {
-        return new LLVMAMD64UpdateFlagsNode(getFlagSlot(LLVMAMD64Flags.CF), getFlagSlot(LLVMAMD64Flags.PF), getFlagSlot(LLVMAMD64Flags.ZF), getFlagSlot(LLVMAMD64Flags.SF),
-                        getFlagSlot(LLVMAMD64Flags.OF));
+        return new LLVMAMD64UpdateFlagsNode(getFlagSlot(LLVMAMD64Flags.CF), getFlagSlot(LLVMAMD64Flags.PF), getFlagSlot(LLVMAMD64Flags.AF), getFlagSlot(LLVMAMD64Flags.ZF),
+                        getFlagSlot(LLVMAMD64Flags.SF), getFlagSlot(LLVMAMD64Flags.OF));
     }
 }

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmImmediateOperand.java
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmImmediateOperand.java
@@ -30,6 +30,7 @@
 package com.oracle.truffle.llvm.asm.amd64;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.llvm.runtime.types.Type;
 
 class AsmImmediateOperand implements AsmOperand {
     private final String val;
@@ -66,6 +67,11 @@ class AsmImmediateOperand implements AsmOperand {
 
     public boolean isLabel() {
         return label;
+    }
+
+    @Override
+    public Type getType() {
+        return null;
     }
 
     @Override

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmMemoryOperand.java
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmMemoryOperand.java
@@ -29,10 +29,13 @@
  */
 package com.oracle.truffle.llvm.asm.amd64;
 
+import com.oracle.truffle.llvm.runtime.types.Type;
+
 class AsmMemoryOperand implements AsmOperand {
     public static final int SCALE_1 = 1;
     public static final int SCALE_2 = 2;
     public static final int SCALE_4 = 4;
+    public static final int SCALE_8 = 8;
 
     private final String displacement;
     private final AsmOperand base;
@@ -47,7 +50,11 @@ class AsmMemoryOperand implements AsmOperand {
     }
 
     public int getDisplacement() {
-        return Integer.decode(displacement);
+        if (displacement == null) {
+            return 0;
+        } else {
+            return Integer.decode(displacement);
+        }
     }
 
     public AsmOperand getBase() {
@@ -70,15 +77,24 @@ class AsmMemoryOperand implements AsmOperand {
                 return 1;
             case SCALE_4:
                 return 2;
+            case SCALE_8:
+                return 3;
             default:
                 throw new AsmParseException("invalid scale: " + scale);
         }
     }
 
     @Override
+    public Type getType() {
+        return null;
+    }
+
+    @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
-        b.append(displacement);
+        if (displacement != null) {
+            b.append(displacement);
+        }
         if (base != null || offset != null) {
             b.append("(");
             if (base != null) {

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmOperand.java
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmOperand.java
@@ -29,5 +29,8 @@
  */
 package com.oracle.truffle.llvm.asm.amd64;
 
+import com.oracle.truffle.llvm.runtime.types.Type;
+
 interface AsmOperand {
+    Type getType();
 }

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmRegisterOperand.java
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmRegisterOperand.java
@@ -299,7 +299,8 @@ class AsmRegisterOperand implements AsmOperand {
         return getBaseRegister(getRegister());
     }
 
-    public Type getWidth() {
+    @Override
+    public Type getType() {
         return getWidth(getRegister());
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64AdcNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64AdcNode.java
@@ -50,7 +50,7 @@ public abstract class LLVMAMD64AdcNode extends LLVMExpressionNode {
         }
 
         @Specialization
-        protected byte executeI16(VirtualFrame frame, byte left, byte right, boolean cf) {
+        protected byte executeI8(VirtualFrame frame, byte left, byte right, boolean cf) {
             byte c = (byte) (cf ? 1 : 0);
             byte result = (byte) (left + right + c);
             boolean overflow = (result < 0 && left > 0 && right > 0) || (result > 0 && left < 0 && right < 0);

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64BreakpointNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64BreakpointNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2017, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -29,41 +29,34 @@
  */
 package com.oracle.truffle.llvm.nodes.asm;
 
-import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeChildren;
-import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.debug.DebuggerTags;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.source.SourceSection;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
-public abstract class LLVMAMD64SarNode extends LLVMExpressionNode {
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarbNode extends LLVMExpressionNode {
-        @Specialization
-        protected byte executeI8(byte left, byte right) {
-            return (byte) (left >> right);
-        }
+public class LLVMAMD64BreakpointNode extends LLVMExpressionNode {
+    private final SourceSection sourceSection;
+
+    public LLVMAMD64BreakpointNode(SourceSection sourceSection) {
+        this.sourceSection = sourceSection;
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarwNode extends LLVMExpressionNode {
-        @Specialization
-        protected short executeI16(short left, byte right) {
-            return (short) (left >> right);
-        }
+    @Override
+    public Object executeGeneric(VirtualFrame frame) {
+        return null;
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarlNode extends LLVMExpressionNode {
-        @Specialization
-        protected int executeI32(int left, byte right) {
-            return left >> right;
-        }
+    @Override
+    public SourceSection getSourceSection() {
+        return sourceSection;
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarqNode extends LLVMExpressionNode {
-        @Specialization
-        protected long executeI64(long left, byte right) {
-            return left >> right;
+    @Override
+    protected boolean isTaggedWith(Class<?> tag) {
+        if (tag == DebuggerTags.AlwaysHalt.class) {
+            return true;
+        } else {
+            return super.isTaggedWith(tag);
         }
     }
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64BsfNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64BsfNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2017, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -33,66 +33,66 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64UpdateFlagsNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteBooleanNode;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
-@NodeChildren({@NodeChild("left"), @NodeChild("right")})
-public abstract class LLVMAMD64AndNode extends LLVMExpressionNode {
-    @Child LLVMAMD64UpdateFlagsNode flags;
+@NodeChildren({@NodeChild("src"), @NodeChild("dst")})
+public abstract class LLVMAMD64BsfNode extends LLVMExpressionNode {
+    @Child protected LLVMAMD64WriteBooleanNode zf;
 
-    private LLVMAMD64AndNode(LLVMAMD64UpdateFlagsNode flags) {
-        this.flags = flags;
+    public LLVMAMD64BsfNode(LLVMAMD64WriteBooleanNode zf) {
+        this.zf = zf;
     }
 
-    public abstract static class LLVMAMD64AndbNode extends LLVMAMD64AndNode {
-        public LLVMAMD64AndbNode(LLVMAMD64UpdateFlagsNode flags) {
-            super(flags);
+    public abstract static class LLVMAMD64BsfwNode extends LLVMAMD64BsfNode {
+        public LLVMAMD64BsfwNode(LLVMAMD64WriteBooleanNode zf) {
+            super(zf);
         }
 
         @Specialization
-        protected byte executeI8(VirtualFrame frame, byte left, byte right) {
-            byte result = (byte) (left & right);
-            flags.execute(frame, result);
-            return result;
+        protected short executeI16(VirtualFrame frame, short src, short dst) {
+            if (src == 0) {
+                zf.execute(frame, true);
+                return dst;
+            } else {
+                zf.execute(frame, false);
+                int val = Short.toUnsignedInt(src);
+                return (short) Integer.numberOfTrailingZeros(val);
+            }
         }
     }
 
-    public abstract static class LLVMAMD64AndwNode extends LLVMAMD64AndNode {
-        public LLVMAMD64AndwNode(LLVMAMD64UpdateFlagsNode flags) {
-            super(flags);
+    public abstract static class LLVMAMD64BsflNode extends LLVMAMD64BsfNode {
+        public LLVMAMD64BsflNode(LLVMAMD64WriteBooleanNode zf) {
+            super(zf);
         }
 
         @Specialization
-        protected short executeI16(VirtualFrame frame, short left, short right) {
-            short result = (short) (left & right);
-            flags.execute(frame, result);
-            return result;
+        protected int executeI32(VirtualFrame frame, int src, int dst) {
+            if (src == 0) {
+                zf.execute(frame, true);
+                return dst;
+            } else {
+                zf.execute(frame, false);
+                return Integer.numberOfTrailingZeros(src);
+            }
         }
     }
 
-    public abstract static class LLVMAMD64AndlNode extends LLVMAMD64AndNode {
-        public LLVMAMD64AndlNode(LLVMAMD64UpdateFlagsNode flags) {
-            super(flags);
+    public abstract static class LLVMAMD64BsfqNode extends LLVMAMD64BsfNode {
+        public LLVMAMD64BsfqNode(LLVMAMD64WriteBooleanNode zf) {
+            super(zf);
         }
 
         @Specialization
-        protected int executeI32(VirtualFrame frame, int left, int right) {
-            int result = left & right;
-            flags.execute(frame, result);
-            return result;
-        }
-    }
-
-    public abstract static class LLVMAMD64AndqNode extends LLVMAMD64AndNode {
-        public LLVMAMD64AndqNode(LLVMAMD64UpdateFlagsNode flags) {
-            super(flags);
-        }
-
-        @Specialization
-        protected long executeI64(VirtualFrame frame, long left, long right) {
-            long result = left & right;
-            flags.execute(frame, result);
-            return result;
+        protected long executeI64(VirtualFrame frame, long src, long dst) {
+            if (src == 0) {
+                zf.execute(frame, true);
+                return dst;
+            } else {
+                zf.execute(frame, false);
+                return Long.numberOfTrailingZeros(src);
+            }
         }
     }
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64BsrNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64BsrNode.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteBooleanNode;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+@NodeChildren({@NodeChild("src"), @NodeChild("dst")})
+public abstract class LLVMAMD64BsrNode extends LLVMExpressionNode {
+    @Child protected LLVMAMD64WriteBooleanNode zf;
+
+    public LLVMAMD64BsrNode(LLVMAMD64WriteBooleanNode zf) {
+        this.zf = zf;
+    }
+
+    public abstract static class LLVMAMD64BsrwNode extends LLVMAMD64BsrNode {
+        public LLVMAMD64BsrwNode(LLVMAMD64WriteBooleanNode zf) {
+            super(zf);
+        }
+
+        @Specialization
+        protected short executeI16(VirtualFrame frame, short src, short dst) {
+            if (src == 0) {
+                zf.execute(frame, true);
+                return dst;
+            } else {
+                zf.execute(frame, false);
+                int val = Short.toUnsignedInt(src);
+                int nlz = Integer.numberOfLeadingZeros(val) - LLVMExpressionNode.I32_SIZE_IN_BITS + LLVMExpressionNode.I16_SIZE_IN_BITS;
+                return (short) (LLVMExpressionNode.I16_SIZE_IN_BITS - nlz - 1);
+            }
+        }
+    }
+
+    public abstract static class LLVMAMD64BsrlNode extends LLVMAMD64BsrNode {
+        public LLVMAMD64BsrlNode(LLVMAMD64WriteBooleanNode zf) {
+            super(zf);
+        }
+
+        @Specialization
+        protected int executeI32(VirtualFrame frame, int src, int dst) {
+            if (src == 0) {
+                zf.execute(frame, true);
+                return dst;
+            } else {
+                zf.execute(frame, false);
+                int nlz = Integer.numberOfLeadingZeros(src);
+                return LLVMExpressionNode.I32_SIZE_IN_BITS - nlz - 1;
+            }
+        }
+    }
+
+    public abstract static class LLVMAMD64BsrqNode extends LLVMAMD64BsrNode {
+        public LLVMAMD64BsrqNode(LLVMAMD64WriteBooleanNode zf) {
+            super(zf);
+        }
+
+        @Specialization
+        protected long executeI64(VirtualFrame frame, long src, long dst) {
+            if (src == 0) {
+                zf.execute(frame, true);
+                return dst;
+            } else {
+                zf.execute(frame, false);
+                int nlz = Long.numberOfLeadingZeros(src);
+                return LLVMExpressionNode.I64_SIZE_IN_BITS - nlz - 1;
+            }
+        }
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64BswapNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64BswapNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2017, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -30,40 +30,22 @@
 package com.oracle.truffle.llvm.nodes.asm;
 
 import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
-public abstract class LLVMAMD64SarNode extends LLVMExpressionNode {
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarbNode extends LLVMExpressionNode {
+@NodeChild("data")
+public abstract class LLVMAMD64BswapNode extends LLVMExpressionNode {
+    public abstract static class LLVMAMD64BswaplNode extends LLVMAMD64BswapNode {
         @Specialization
-        protected byte executeI8(byte left, byte right) {
-            return (byte) (left >> right);
+        protected int executeI32(int data) {
+            return Integer.reverseBytes(data);
         }
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarwNode extends LLVMExpressionNode {
+    public abstract static class LLVMAMD64BswapqNode extends LLVMAMD64BswapNode {
         @Specialization
-        protected short executeI16(short left, byte right) {
-            return (short) (left >> right);
-        }
-    }
-
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarlNode extends LLVMExpressionNode {
-        @Specialization
-        protected int executeI32(int left, byte right) {
-            return left >> right;
-        }
-    }
-
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarqNode extends LLVMExpressionNode {
-        @Specialization
-        protected long executeI64(long left, byte right) {
-            return left >> right;
+        protected long executeI64(long data) {
+            return Long.reverseBytes(data);
         }
     }
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64CmpNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64CmpNode.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64UpdateFlagsNode;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+@NodeChildren({@NodeChild("left"), @NodeChild("right")})
+public abstract class LLVMAMD64CmpNode extends LLVMExpressionNode {
+    @Child protected LLVMAMD64UpdateFlagsNode flags;
+
+    public LLVMAMD64CmpNode(LLVMAMD64UpdateFlagsNode flags) {
+        this.flags = flags;
+    }
+
+    public abstract static class LLVMAMD64CmpbNode extends LLVMAMD64CmpNode {
+        public LLVMAMD64CmpbNode(LLVMAMD64UpdateFlagsNode flags) {
+            super(flags);
+        }
+
+        @Specialization
+        protected Object execute(VirtualFrame frame, byte left, byte right) {
+            int result = left - right;
+            boolean overflow = (byte) ((left ^ right) & (left ^ result)) < 0;
+            boolean carry = Byte.toUnsignedInt(left) < Byte.toUnsignedInt(right);
+            boolean adjust = (((left ^ right) ^ result) & 0x10) != 0;
+            flags.execute(frame, overflow, carry, adjust, result);
+            return null;
+        }
+    }
+
+    public abstract static class LLVMAMD64CmpwNode extends LLVMAMD64CmpNode {
+        public LLVMAMD64CmpwNode(LLVMAMD64UpdateFlagsNode flags) {
+            super(flags);
+        }
+
+        @Specialization
+        protected Object execute(VirtualFrame frame, short left, short right) {
+            int result = left - right;
+            boolean overflow = (short) ((left ^ right) & (left ^ result)) < 0;
+            boolean carry = Short.toUnsignedInt(left) < Short.toUnsignedInt(right);
+            boolean adjust = (((left ^ right) ^ result) & 0x10) != 0;
+            flags.execute(frame, overflow, carry, adjust, result);
+            return null;
+        }
+    }
+
+    public abstract static class LLVMAMD64CmplNode extends LLVMAMD64CmpNode {
+        public LLVMAMD64CmplNode(LLVMAMD64UpdateFlagsNode flags) {
+            super(flags);
+        }
+
+        @Specialization
+        protected Object execute(VirtualFrame frame, int left, int right) {
+            int result = left - right;
+            boolean overflow = ((left ^ right) & (left ^ result)) < 0;
+            boolean carry = Integer.compareUnsigned(left, right) < 0;
+            boolean adjust = (((left ^ right) ^ result) & 0x10) != 0;
+            flags.execute(frame, overflow, carry, adjust, result);
+            return null;
+        }
+    }
+
+    public abstract static class LLVMAMD64CmpqNode extends LLVMAMD64CmpNode {
+        public LLVMAMD64CmpqNode(LLVMAMD64UpdateFlagsNode flags) {
+            super(flags);
+        }
+
+        @Specialization
+        protected Object execute(VirtualFrame frame, long left, long right) {
+            long result = left - right;
+            boolean overflow = ((left ^ right) & (left ^ result)) < 0;
+            boolean carry = Long.compareUnsigned(left, right) < 0;
+            boolean adjust = (((left ^ right) ^ result) & 0x10) != 0;
+            flags.execute(frame, overflow, carry, adjust, result);
+            return null;
+        }
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64CmpXchgNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64CmpXchgNode.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64UpdateFlagsNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI16RegisterNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI32RegisterNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI64RegisterNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI8RegisterNode;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+@NodeChildren({@NodeChild("a"), @NodeChild("src"), @NodeChild("dst")})
+public abstract class LLVMAMD64CmpXchgNode extends LLVMExpressionNode {
+    @Child LLVMAMD64UpdateFlagsNode flags;
+
+    private LLVMAMD64CmpXchgNode(LLVMAMD64UpdateFlagsNode flags) {
+        this.flags = flags;
+    }
+
+    public abstract static class LLVMAMD64CmpXchgbNode extends LLVMAMD64CmpXchgNode {
+        @Child LLVMAMD64WriteI8RegisterNode out2;
+
+        public LLVMAMD64CmpXchgbNode(LLVMAMD64UpdateFlagsNode flags, LLVMAMD64WriteI8RegisterNode out2) {
+            super(flags);
+            this.out2 = out2;
+        }
+
+        @Specialization
+        protected byte executeI8(VirtualFrame frame, byte a, byte src, byte dst) {
+            int result = a - dst;
+            boolean carry = Byte.toUnsignedInt(a) < Byte.toUnsignedInt(dst);
+            boolean adjust = (((a ^ dst) ^ result) & 0x10) != 0;
+            flags.execute(frame, false, carry, adjust, result);
+            if (a == dst) {
+                return src;
+            } else {
+                out2.execute(frame, dst);
+                return dst;
+            }
+        }
+    }
+
+    public abstract static class LLVMAMD64CmpXchgwNode extends LLVMAMD64CmpXchgNode {
+        @Child LLVMAMD64WriteI16RegisterNode out2;
+
+        public LLVMAMD64CmpXchgwNode(LLVMAMD64UpdateFlagsNode flags, LLVMAMD64WriteI16RegisterNode out2) {
+            super(flags);
+            this.out2 = out2;
+        }
+
+        @Specialization
+        protected short executeI16(VirtualFrame frame, short a, short src, short dst) {
+            int result = a - dst;
+            boolean carry = Short.toUnsignedInt(a) < Short.toUnsignedInt(dst);
+            boolean adjust = (((a ^ dst) ^ result) & 0x10) != 0;
+            flags.execute(frame, false, carry, adjust, result);
+            if (a == dst) {
+                return src;
+            } else {
+                out2.execute(frame, dst);
+                return dst;
+            }
+        }
+    }
+
+    public abstract static class LLVMAMD64CmpXchglNode extends LLVMAMD64CmpXchgNode {
+        @Child LLVMAMD64WriteI32RegisterNode out2;
+
+        public LLVMAMD64CmpXchglNode(LLVMAMD64UpdateFlagsNode flags, LLVMAMD64WriteI32RegisterNode out2) {
+            super(flags);
+            this.out2 = out2;
+        }
+
+        @Specialization
+        protected int executeI32(VirtualFrame frame, int a, int src, int dst) {
+            int result = a - dst;
+            boolean carry = Integer.compareUnsigned(a, dst) < 0;
+            boolean adjust = (((a ^ dst) ^ result) & 0x10) != 0;
+            flags.execute(frame, false, carry, adjust, result);
+            if (a == dst) {
+                return src;
+            } else {
+                out2.execute(frame, dst);
+                return dst;
+            }
+        }
+    }
+
+    public abstract static class LLVMAMD64CmpXchglrNode extends LLVMAMD64CmpXchgNode {
+        @Child LLVMAMD64WriteI32RegisterNode out1;
+        @Child LLVMAMD64WriteI32RegisterNode out2;
+
+        public LLVMAMD64CmpXchglrNode(LLVMAMD64UpdateFlagsNode flags, LLVMAMD64WriteI32RegisterNode out1, LLVMAMD64WriteI32RegisterNode out2) {
+            super(flags);
+            this.out1 = out1;
+            this.out2 = out2;
+        }
+
+        @Specialization
+        protected Object executeObject(VirtualFrame frame, int a, int src, int dst) {
+            int result = a - dst;
+            boolean carry = Integer.compareUnsigned(a, dst) < 0;
+            boolean adjust = (((a ^ dst) ^ result) & 0x10) != 0;
+            flags.execute(frame, false, carry, adjust, result);
+            if (a == dst) {
+                out1.execute(frame, src);
+                return null;
+            } else {
+                out2.execute(frame, dst);
+                return null;
+            }
+        }
+    }
+
+    public abstract static class LLVMAMD64CmpXchgqNode extends LLVMAMD64CmpXchgNode {
+        private final LLVMAMD64WriteI64RegisterNode out2;
+
+        public LLVMAMD64CmpXchgqNode(LLVMAMD64UpdateFlagsNode flags, LLVMAMD64WriteI64RegisterNode out2) {
+            super(flags);
+            this.out2 = out2;
+        }
+
+        @Specialization
+        protected long executeI64(VirtualFrame frame, long a, long src, long dst) {
+            long result = a - dst;
+            boolean carry = Long.compareUnsigned(a, dst) < 0;
+            boolean adjust = (((a ^ dst) ^ result) & 0x10) != 0;
+            flags.execute(frame, false, carry, adjust, result);
+            if (a == dst) {
+                return src;
+            } else {
+                out2.execute(frame, dst);
+                return dst;
+            }
+        }
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64CpuidNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64CpuidNode.java
@@ -29,6 +29,7 @@
  */
 package com.oracle.truffle.llvm.nodes.asm;
 
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -37,10 +38,49 @@ import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
 @NodeChild("level")
 public abstract class LLVMAMD64CpuidNode extends LLVMExpressionNode {
+    public static final String BRAND = "Sulong"; // at most 48 characters
+    public static final String VENDOR_ID = "SulongLLVM64"; // exactly 12 characters
+
+    public static final int[] BRAND_I32 = getI32(BRAND, 12);
+    public static final int[] VENDOR_ID_I32 = getI32(VENDOR_ID, 3);
+
+    private static int[] getI32(String s, int len) {
+        CompilerAsserts.neverPartOfCompilation();
+        int[] i32 = new int[len];
+        for (int i = 0; i < len; i++) {
+            byte b1 = getI8(s, i * 4);
+            byte b2 = getI8(s, i * 4 + 1);
+            byte b3 = getI8(s, i * 4 + 2);
+            byte b4 = getI8(s, i * 4 + 3);
+            i32[i] = Byte.toUnsignedInt(b1) | Byte.toUnsignedInt(b2) << 8 | Byte.toUnsignedInt(b3) << 16 | Byte.toUnsignedInt(b4) << 24;
+        }
+        return i32;
+    }
+
+    private static byte getI8(String s, int offset) {
+        CompilerAsserts.neverPartOfCompilation();
+        if (offset >= s.length()) {
+            return 0;
+        } else {
+            return (byte) s.charAt(offset);
+        }
+    }
+
     @Child private LLVMAMD64WriteI32RegisterNode eax;
     @Child private LLVMAMD64WriteI32RegisterNode ebx;
     @Child private LLVMAMD64WriteI32RegisterNode ecx;
     @Child private LLVMAMD64WriteI32RegisterNode edx;
+
+    // FN=1: EDX
+    public static final int TSC = 1 << 4;
+    // FN=1: ECX
+    public static final int RDRND = 1 << 30;
+    // FN=7/0: EBX
+    public static final int RDSEED = 1 << 18;
+    // FN=80000001h: EDX
+    public static final int LM = (1 << 29);
+    // FN=80000001h: ECX
+    public static final int LAHF_LM = 1;
 
     public LLVMAMD64CpuidNode(LLVMAMD64WriteI32RegisterNode eax, LLVMAMD64WriteI32RegisterNode ebx, LLVMAMD64WriteI32RegisterNode ecx, LLVMAMD64WriteI32RegisterNode edx) {
         this.eax = eax;
@@ -58,10 +98,66 @@ public abstract class LLVMAMD64CpuidNode extends LLVMExpressionNode {
         switch (level) {
             case 0:
                 // Get Vendor ID/Highest Function Parameter
-                a = 0; // no functions supported
-                b = 0x6f6c7553; // "Sulo"
-                d = 0x4c4c676e; // "ngLL"
-                c = 0x34364d56; // "VM64"
+                a = 7; // max supported function
+                b = VENDOR_ID_I32[0];
+                d = VENDOR_ID_I32[1];
+                c = VENDOR_ID_I32[2];
+                break;
+            case 1:
+                // Processor Info and Feature Bits
+                // EAX:
+                // 3:0 - Stepping
+                // 7:4 - Model
+                // 11:8 - Family
+                // 13:12 - Processor Type
+                // 19:16 - Extended Model
+                // 27:20 - Extended Family
+                a = 0;
+                b = 0;
+                c = RDRND;
+                d = TSC;
+                break;
+            case 7:
+                // Extended Features (FIXME: assumption is ECX=0)
+                a = 0;
+                b = RDSEED;
+                c = 0;
+                d = 0;
+                break;
+            case 0x80000000:
+                // Get Highest Extended Function Supported
+                a = 0x80000004;
+                b = 0;
+                c = 0;
+                d = 0;
+                break;
+            case 0x80000001:
+                // Extended Processor Info and Feature Bits
+                a = 0;
+                b = 0;
+                c = LAHF_LM;
+                d = LM;
+                break;
+            case 0x80000002:
+                // Processor Brand String
+                a = BRAND_I32[0];
+                b = BRAND_I32[1];
+                c = BRAND_I32[2];
+                d = BRAND_I32[3];
+                break;
+            case 0x80000003:
+                // Processor Brand String
+                a = BRAND_I32[4];
+                b = BRAND_I32[5];
+                c = BRAND_I32[6];
+                d = BRAND_I32[7];
+                break;
+            case 0x80000004:
+                // Processor Brand String
+                a = BRAND_I32[8];
+                b = BRAND_I32[9];
+                c = BRAND_I32[10];
+                d = BRAND_I32[11];
                 break;
             default:
                 // Fallback: bits cleared = feature(s) not available

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64DecNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64DecNode.java
@@ -49,7 +49,7 @@ public abstract class LLVMAMD64DecNode extends LLVMExpressionNode {
         }
 
         @Specialization
-        protected byte executeI16(VirtualFrame frame, byte value) {
+        protected byte executeI8(VirtualFrame frame, byte value) {
             byte result = (byte) (value - 1);
             boolean of = value == Byte.MIN_VALUE;
             flags.execute(frame, of, result);

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64ImmNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64ImmNode.java
@@ -33,6 +33,19 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
 public abstract class LLVMAMD64ImmNode extends LLVMExpressionNode {
+    public abstract static class LLVMAMD64I1Node extends LLVMExpressionNode {
+        private final boolean value;
+
+        public LLVMAMD64I1Node(boolean value) {
+            this.value = value;
+        }
+
+        @Specialization
+        public boolean executeI1() {
+            return value;
+        }
+    }
+
     public abstract static class LLVMAMD64I8Node extends LLVMExpressionNode {
         private final byte value;
 

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64ImulNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64ImulNode.java
@@ -33,6 +33,8 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64UpdateFlagsNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteBooleanNode;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI16RegisterNode;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI32RegisterNode;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI64RegisterNode;
@@ -40,19 +42,57 @@ import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.asm.support.LongMultiplication;
 
 public abstract class LLVMAMD64ImulNode extends LLVMExpressionNode {
+    @Child protected LLVMAMD64WriteBooleanNode cf;
+    @Child protected LLVMAMD64WriteBooleanNode pf;
+    @Child protected LLVMAMD64WriteBooleanNode af;
+    @Child protected LLVMAMD64WriteBooleanNode zf;
+    @Child protected LLVMAMD64WriteBooleanNode sf;
+    @Child protected LLVMAMD64WriteBooleanNode of;
+
+    protected void setFlags(VirtualFrame frame, byte value, boolean overflow, boolean sign) {
+        cf.execute(frame, overflow);
+        pf.execute(frame, LLVMAMD64UpdateFlagsNode.getParity(value));
+        af.execute(frame, false);
+        zf.execute(frame, false);
+        sf.execute(frame, sign);
+        of.execute(frame, overflow);
+    }
+
+    public LLVMAMD64ImulNode(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                    LLVMAMD64WriteBooleanNode of) {
+        this.cf = cf;
+        this.pf = pf;
+        this.af = af;
+        this.zf = zf;
+        this.sf = sf;
+        this.of = of;
+    }
+
     @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class)})
-    public abstract static class LLVMAMD64ImulbNode extends LLVMExpressionNode {
+    public abstract static class LLVMAMD64ImulbNode extends LLVMAMD64ImulNode {
+        public LLVMAMD64ImulbNode(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                        LLVMAMD64WriteBooleanNode of) {
+            super(cf, pf, af, zf, sf, of);
+        }
+
         @Specialization
-        protected short executeI16(byte left, byte right) {
-            return (short) (left * right);
+        protected short executeI8(VirtualFrame frame, byte left, byte right) {
+            short value = (short) (left * right);
+            byte valueb = (byte) value;
+            boolean overflow = valueb != value;
+            boolean sign = valueb < 0;
+            setFlags(frame, valueb, overflow, sign);
+            return value;
         }
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64ImulwNode extends LLVMExpressionNode {
-        private final LLVMAMD64WriteI16RegisterNode high;
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMAMD64ImulwNode extends LLVMAMD64ImulNode {
+        @Child private LLVMAMD64WriteI16RegisterNode high;
 
-        public LLVMAMD64ImulwNode(LLVMAMD64WriteI16RegisterNode high) {
+        public LLVMAMD64ImulwNode(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                        LLVMAMD64WriteBooleanNode of, LLVMAMD64WriteI16RegisterNode high) {
+            super(cf, pf, af, zf, sf, of);
             this.high = high;
         }
 
@@ -60,16 +100,41 @@ public abstract class LLVMAMD64ImulNode extends LLVMExpressionNode {
         protected short executeI16(VirtualFrame frame, short left, short right) {
             int value = left * right;
             short hi = (short) (value >> LLVMExpressionNode.I16_SIZE_IN_BITS);
+            short valuew = (short) value;
+            boolean overflow = valuew != value;
+            boolean sign = valuew < 0;
+            setFlags(frame, (byte) value, overflow, sign);
             high.execute(frame, hi);
-            return (short) value;
+            return valuew;
         }
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64ImullNode extends LLVMExpressionNode {
-        private final LLVMAMD64WriteI32RegisterNode high;
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMAMD64Imulw3Node extends LLVMAMD64ImulNode {
 
-        public LLVMAMD64ImullNode(LLVMAMD64WriteI32RegisterNode high) {
+        public LLVMAMD64Imulw3Node(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                        LLVMAMD64WriteBooleanNode of) {
+            super(cf, pf, af, zf, sf, of);
+        }
+
+        @Specialization
+        protected short executeI16(VirtualFrame frame, short left, short right) {
+            int value = left * right;
+            short valuew = (short) value;
+            boolean overflow = valuew != value;
+            boolean sign = valuew < 0;
+            setFlags(frame, (byte) value, overflow, sign);
+            return valuew;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMAMD64ImullNode extends LLVMAMD64ImulNode {
+        @Child private LLVMAMD64WriteI32RegisterNode high;
+
+        public LLVMAMD64ImullNode(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                        LLVMAMD64WriteBooleanNode of, LLVMAMD64WriteI32RegisterNode high) {
+            super(cf, pf, af, zf, sf, of);
             this.high = high;
         }
 
@@ -77,24 +142,72 @@ public abstract class LLVMAMD64ImulNode extends LLVMExpressionNode {
         protected int executeI32(VirtualFrame frame, int left, int right) {
             long value = (long) left * (long) right;
             int hi = (int) (value >> LLVMExpressionNode.I32_SIZE_IN_BITS);
+            int valuel = (int) value;
+            boolean overflow = valuel != value;
+            boolean sign = valuel < 0;
+            setFlags(frame, (byte) value, overflow, sign);
             high.execute(frame, hi);
-            return (int) value;
+            return valuel;
         }
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64ImulqNode extends LLVMExpressionNode {
-        private final LLVMAMD64WriteI64RegisterNode high;
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMAMD64Imull3Node extends LLVMAMD64ImulNode {
 
-        public LLVMAMD64ImulqNode(LLVMAMD64WriteI64RegisterNode high) {
+        public LLVMAMD64Imull3Node(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                        LLVMAMD64WriteBooleanNode of) {
+            super(cf, pf, af, zf, sf, of);
+        }
+
+        @Specialization
+        protected int executeI32(VirtualFrame frame, int left, int right) {
+            long value = (long) left * (long) right;
+            int valuel = (int) value;
+            boolean overflow = valuel != value;
+            boolean sign = valuel < 0;
+            setFlags(frame, (byte) value, overflow, sign);
+            return valuel;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMAMD64ImulqNode extends LLVMAMD64ImulNode {
+        @Child private LLVMAMD64WriteI64RegisterNode high;
+
+        public LLVMAMD64ImulqNode(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                        LLVMAMD64WriteBooleanNode of, LLVMAMD64WriteI64RegisterNode high) {
+            super(cf, pf, af, zf, sf, of);
             this.high = high;
         }
 
         @Specialization
         protected long executeI64(VirtualFrame frame, long left, long right) {
+            long value = left * right;
             long hi = LongMultiplication.multiplyHigh(left, right);
+            boolean overflow = !(value < 0 && hi == -1) && !(value > 0 && hi == 0);
+            boolean sign = value < 0;
+            setFlags(frame, (byte) value, overflow, sign);
             high.execute(frame, hi);
-            return left * right;
+            return value;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMAMD64Imulq3Node extends LLVMAMD64ImulNode {
+
+        public LLVMAMD64Imulq3Node(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                        LLVMAMD64WriteBooleanNode of) {
+            super(cf, pf, af, zf, sf, of);
+        }
+
+        @Specialization
+        protected long executeI64(VirtualFrame frame, long left, long right) {
+            long value = left * right;
+            long hi = LongMultiplication.multiplyHigh(left, right);
+            boolean overflow = !(value < 0 && hi == -1) && !(value > 0 && hi == 0);
+            boolean sign = value < 0;
+            setFlags(frame, (byte) value, overflow, sign);
+            return value;
         }
     }
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64IncNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64IncNode.java
@@ -49,7 +49,7 @@ public abstract class LLVMAMD64IncNode extends LLVMExpressionNode {
         }
 
         @Specialization
-        protected byte executeI16(VirtualFrame frame, byte value) {
+        protected byte executeI8(VirtualFrame frame, byte value) {
             byte result = (byte) (value + 1);
             boolean of = value == Byte.MAX_VALUE;
             flags.execute(frame, of, result);

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64LoadFlags.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64LoadFlags.java
@@ -36,11 +36,11 @@ import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64Flags;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
 public abstract class LLVMAMD64LoadFlags extends LLVMExpressionNode {
-    @NodeChildren({@NodeChild(value = "cf", type = LLVMExpressionNode.class), @NodeChild(value = "pf", type = LLVMExpressionNode.class), @NodeChild(value = "zf", type = LLVMExpressionNode.class),
-                    @NodeChild(value = "sf", type = LLVMExpressionNode.class)})
+    @NodeChildren({@NodeChild(value = "cf", type = LLVMExpressionNode.class), @NodeChild(value = "pf", type = LLVMExpressionNode.class), @NodeChild(value = "af", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "zf", type = LLVMExpressionNode.class), @NodeChild(value = "sf", type = LLVMExpressionNode.class)})
     public abstract static class LLVMAMD64LahfNode extends LLVMAMD64LoadFlags {
         @Specialization
-        protected byte executeI8(boolean cf, boolean pf, boolean zf, boolean sf) {
+        protected byte executeI8(boolean cf, boolean pf, boolean af, boolean zf, boolean sf) {
             byte flags = 0;
             if (cf) {
                 flags |= (byte) (1 << LLVMAMD64Flags.CF);
@@ -48,11 +48,42 @@ public abstract class LLVMAMD64LoadFlags extends LLVMExpressionNode {
             if (pf) {
                 flags |= (byte) (1 << LLVMAMD64Flags.PF);
             }
+            if (af) {
+                flags |= (byte) (1 << LLVMAMD64Flags.AF);
+            }
             if (zf) {
                 flags |= (byte) (1 << LLVMAMD64Flags.ZF);
             }
             if (sf) {
                 flags |= (byte) (1 << LLVMAMD64Flags.SF);
+            }
+            return flags;
+        }
+    }
+
+    @NodeChildren({@NodeChild(value = "cf", type = LLVMExpressionNode.class), @NodeChild(value = "pf", type = LLVMExpressionNode.class), @NodeChild(value = "af", type = LLVMExpressionNode.class),
+                    @NodeChild(value = "zf", type = LLVMExpressionNode.class), @NodeChild(value = "sf", type = LLVMExpressionNode.class), @NodeChild(value = "of", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMAMD64ReadFlagswNode extends LLVMAMD64LoadFlags {
+        @Specialization
+        protected short executeI16(boolean cf, boolean pf, boolean af, boolean zf, boolean sf, boolean of) {
+            short flags = 0;
+            if (cf) {
+                flags |= (short) (1 << LLVMAMD64Flags.CF);
+            }
+            if (pf) {
+                flags |= (short) (1 << LLVMAMD64Flags.PF);
+            }
+            if (af) {
+                flags |= (short) (1 << LLVMAMD64Flags.AF);
+            }
+            if (zf) {
+                flags |= (short) (1 << LLVMAMD64Flags.ZF);
+            }
+            if (sf) {
+                flags |= (short) (1 << LLVMAMD64Flags.SF);
+            }
+            if (of) {
+                flags |= (short) (1 << LLVMAMD64Flags.OF);
             }
             return flags;
         }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64MulNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64MulNode.java
@@ -33,6 +33,8 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64UpdateFlagsNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteBooleanNode;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI16RegisterNode;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI32RegisterNode;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI64RegisterNode;
@@ -40,19 +42,57 @@ import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 import com.oracle.truffle.llvm.nodes.asm.support.LongMultiplication;
 
 public abstract class LLVMAMD64MulNode extends LLVMExpressionNode {
+    @Child protected LLVMAMD64WriteBooleanNode cf;
+    @Child protected LLVMAMD64WriteBooleanNode pf;
+    @Child protected LLVMAMD64WriteBooleanNode af;
+    @Child protected LLVMAMD64WriteBooleanNode zf;
+    @Child protected LLVMAMD64WriteBooleanNode sf;
+    @Child protected LLVMAMD64WriteBooleanNode of;
+
+    protected void setFlags(VirtualFrame frame, byte value, boolean overflow, boolean sign) {
+        cf.execute(frame, overflow);
+        pf.execute(frame, LLVMAMD64UpdateFlagsNode.getParity(value));
+        af.execute(frame, false);
+        zf.execute(frame, false);
+        sf.execute(frame, sign);
+        of.execute(frame, overflow);
+    }
+
+    public LLVMAMD64MulNode(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                    LLVMAMD64WriteBooleanNode of) {
+        this.cf = cf;
+        this.pf = pf;
+        this.af = af;
+        this.zf = zf;
+        this.sf = sf;
+        this.of = of;
+    }
+
     @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class)})
-    public abstract static class LLVMAMD64MulbNode extends LLVMExpressionNode {
+    public abstract static class LLVMAMD64MulbNode extends LLVMAMD64MulNode {
+        public LLVMAMD64MulbNode(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                        LLVMAMD64WriteBooleanNode of) {
+            super(cf, pf, af, zf, sf, of);
+        }
+
         @Specialization
-        protected short executeI16(byte left, byte right) {
-            return (short) (Byte.toUnsignedInt(left) * Byte.toUnsignedInt(right));
+        protected short executeI8(VirtualFrame frame, byte left, byte right) {
+            short value = (short) (Byte.toUnsignedInt(left) * Byte.toUnsignedInt(right));
+            byte valueb = (byte) value;
+            boolean overflow = ((value >> LLVMExpressionNode.I8_SIZE_IN_BITS) & LLVMExpressionNode.I8_MASK) != 0;
+            boolean sign = valueb < 0;
+            setFlags(frame, valueb, overflow, sign);
+            return value;
         }
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64MulwNode extends LLVMExpressionNode {
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMAMD64MulwNode extends LLVMAMD64MulNode {
         private final LLVMAMD64WriteI16RegisterNode high;
 
-        public LLVMAMD64MulwNode(LLVMAMD64WriteI16RegisterNode high) {
+        public LLVMAMD64MulwNode(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                        LLVMAMD64WriteBooleanNode of, LLVMAMD64WriteI16RegisterNode high) {
+            super(cf, pf, af, zf, sf, of);
             this.high = high;
         }
 
@@ -60,16 +100,19 @@ public abstract class LLVMAMD64MulNode extends LLVMExpressionNode {
         protected short executeI16(VirtualFrame frame, short left, short right) {
             int value = Short.toUnsignedInt(left) * Short.toUnsignedInt(right);
             short hi = (short) (value >> LLVMExpressionNode.I16_SIZE_IN_BITS);
+            setFlags(frame, (byte) value, hi != 0, (short) value < 0);
             high.execute(frame, hi);
             return (short) value;
         }
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64MullNode extends LLVMExpressionNode {
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMAMD64MullNode extends LLVMAMD64MulNode {
         private final LLVMAMD64WriteI32RegisterNode high;
 
-        public LLVMAMD64MullNode(LLVMAMD64WriteI32RegisterNode high) {
+        public LLVMAMD64MullNode(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                        LLVMAMD64WriteBooleanNode of, LLVMAMD64WriteI32RegisterNode high) {
+            super(cf, pf, af, zf, sf, of);
             this.high = high;
         }
 
@@ -77,24 +120,29 @@ public abstract class LLVMAMD64MulNode extends LLVMExpressionNode {
         protected int executeI32(VirtualFrame frame, int left, int right) {
             long value = Integer.toUnsignedLong(left) * Integer.toUnsignedLong(right);
             int hi = (int) (value >> LLVMExpressionNode.I32_SIZE_IN_BITS);
+            setFlags(frame, (byte) value, hi != 0, (int) value < 0);
             high.execute(frame, hi);
             return (int) value;
         }
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64MulqNode extends LLVMExpressionNode {
+    @NodeChildren({@NodeChild(value = "left", type = LLVMExpressionNode.class), @NodeChild(value = "right", type = LLVMExpressionNode.class)})
+    public abstract static class LLVMAMD64MulqNode extends LLVMAMD64MulNode {
         private final LLVMAMD64WriteI64RegisterNode high;
 
-        public LLVMAMD64MulqNode(LLVMAMD64WriteI64RegisterNode high) {
+        public LLVMAMD64MulqNode(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                        LLVMAMD64WriteBooleanNode of, LLVMAMD64WriteI64RegisterNode high) {
+            super(cf, pf, af, zf, sf, of);
             this.high = high;
         }
 
         @Specialization
         protected long executeI64(VirtualFrame frame, long left, long right) {
+            long value = left * right;
             long hi = LongMultiplication.multiplyHighUnsigned(left, right);
+            setFlags(frame, (byte) value, hi != 0, value < 0);
             high.execute(frame, hi);
-            return left * right;
+            return value;
         }
     }
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64NegNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64NegNode.java
@@ -49,7 +49,7 @@ public abstract class LLVMAMD64NegNode extends LLVMExpressionNode {
         }
 
         @Specialization
-        protected byte executeI16(VirtualFrame frame, byte value) {
+        protected byte executeI8(VirtualFrame frame, byte value) {
             byte result = (byte) -value;
             boolean cf = value != 0;
             boolean of = false;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64NotNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64NotNode.java
@@ -37,7 +37,7 @@ public abstract class LLVMAMD64NotNode extends LLVMExpressionNode {
     @NodeChild("valueNode")
     public abstract static class LLVMAMD64NotbNode extends LLVMExpressionNode {
         @Specialization
-        protected byte executeI16(byte value) {
+        protected byte executeI8(byte value) {
             return (byte) ~value;
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64OrNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64OrNode.java
@@ -38,7 +38,7 @@ public abstract class LLVMAMD64OrNode extends LLVMExpressionNode {
     @NodeChildren({@NodeChild("left"), @NodeChild("right")})
     public abstract static class LLVMAMD64OrbNode extends LLVMExpressionNode {
         @Specialization
-        protected byte executeI16(byte left, byte right) {
+        protected byte executeI8(byte left, byte right) {
             return (byte) (left | right);
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64PopNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64PopNode.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.frame.FrameUtil;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
+import com.oracle.truffle.llvm.runtime.memory.LLVMStack;
+import com.oracle.truffle.llvm.runtime.memory.LLVMStack.NeedsStack;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+@NeedsStack
+public abstract class LLVMAMD64PopNode extends LLVMExpressionNode {
+    @CompilationFinal private FrameSlot stackPointer;
+
+    protected FrameSlot getStackPointerSlot() {
+        if (stackPointer == null) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            stackPointer = getRootNode().getFrameDescriptor().findFrameSlot(LLVMStack.FRAME_ID);
+        }
+        return stackPointer;
+    }
+
+    public abstract static class LLVMAMD64PopwNode extends LLVMAMD64PopNode {
+        @Override
+        @Specialization
+        public short executeI16(VirtualFrame frame) {
+            FrameSlot slot = getStackPointerSlot();
+            long sp = FrameUtil.getLongSafe(frame, slot);
+            short value = LLVMMemory.getI16(sp);
+            sp += 2;
+            frame.setLong(slot, sp);
+            return value;
+        }
+    }
+
+    public abstract static class LLVMAMD64PoplNode extends LLVMAMD64PopNode {
+        @Override
+        @Specialization
+        public int executeI32(VirtualFrame frame) {
+            FrameSlot slot = getStackPointerSlot();
+            long sp = FrameUtil.getLongSafe(frame, slot);
+            int value = LLVMMemory.getI32(sp);
+            sp += 4;
+            frame.setLong(slot, sp);
+            return value;
+        }
+    }
+
+    public abstract static class LLVMAMD64PopqNode extends LLVMAMD64PopNode {
+        @Override
+        @Specialization
+        public long executeI64(VirtualFrame frame) {
+            FrameSlot slot = getStackPointerSlot();
+            long sp = FrameUtil.getLongSafe(frame, slot);
+            long value = LLVMMemory.getI64(sp);
+            sp += 8;
+            frame.setLong(slot, sp);
+            return value;
+        }
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64PushNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64PushNode.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.frame.FrameUtil;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
+import com.oracle.truffle.llvm.runtime.memory.LLVMStack;
+import com.oracle.truffle.llvm.runtime.memory.LLVMStack.NeedsStack;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+@NeedsStack
+@NodeChild("value")
+public abstract class LLVMAMD64PushNode extends LLVMExpressionNode {
+    @CompilationFinal private FrameSlot stackPointer;
+
+    protected FrameSlot getStackPointerSlot() {
+        if (stackPointer == null) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            stackPointer = getRootNode().getFrameDescriptor().findFrameSlot(LLVMStack.FRAME_ID);
+            assert stackPointer != null;
+        }
+        return stackPointer;
+    }
+
+    public abstract static class LLVMAMD64PushwNode extends LLVMAMD64PushNode {
+        @Specialization
+        protected Object executeVoid(VirtualFrame frame, short value) {
+            FrameSlot slot = getStackPointerSlot();
+            long sp = FrameUtil.getLongSafe(frame, slot);
+            sp -= 2;
+            frame.setLong(slot, sp);
+            LLVMMemory.putI16(sp, value);
+            return null;
+        }
+    }
+
+    public abstract static class LLVMAMD64PushlNode extends LLVMAMD64PushNode {
+        @Specialization
+        protected Object executeVoid(VirtualFrame frame, int value) {
+            FrameSlot slot = getStackPointerSlot();
+            long sp = FrameUtil.getLongSafe(frame, slot);
+            sp -= 4;
+            frame.setLong(slot, sp);
+            LLVMMemory.putI32(sp, value);
+            return null;
+        }
+    }
+
+    public abstract static class LLVMAMD64PushqNode extends LLVMAMD64PushNode {
+        @Specialization
+        protected Object executeVoid(VirtualFrame frame, long value) {
+            FrameSlot slot = getStackPointerSlot();
+            long sp = FrameUtil.getLongSafe(frame, slot);
+            sp -= 8;
+            frame.setLong(slot, sp);
+            LLVMMemory.putI64(sp, value);
+            return null;
+        }
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64RdSeedNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64RdSeedNode.java
@@ -59,8 +59,8 @@ public abstract class LLVMAMD64RdSeedNode extends LLVMExpressionNode {
     @TruffleBoundary
     protected long getSeedI64() {
         byte[] seed = rng.generateSeed(8);
-        return Byte.toUnsignedInt(seed[0]) << 56 | Byte.toUnsignedInt(seed[1]) << 48 | Byte.toUnsignedInt(seed[2]) << 40 | Byte.toUnsignedInt(seed[3]) << 32 | Byte.toUnsignedInt(seed[4]) << 24 |
-                        Byte.toUnsignedInt(seed[5]) << 16 | Byte.toUnsignedInt(seed[6]) << 8 | Byte.toUnsignedInt(seed[7]);
+        return Byte.toUnsignedLong(seed[0]) << 56 | Byte.toUnsignedLong(seed[1]) << 48 | Byte.toUnsignedLong(seed[2]) << 40 | Byte.toUnsignedLong(seed[3]) << 32 | Byte.toUnsignedLong(seed[4]) << 24 |
+                        Byte.toUnsignedLong(seed[5]) << 16 | Byte.toUnsignedLong(seed[6]) << 8 | Byte.toUnsignedLong(seed[7]);
     }
 
     public LLVMAMD64RdSeedNode(LLVMAMD64WriteBooleanNode cf) {

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64RdSeedNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64RdSeedNode.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm;
+
+import java.security.SecureRandom;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteBooleanNode;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+public abstract class LLVMAMD64RdSeedNode extends LLVMExpressionNode {
+    private final SecureRandom rng = new SecureRandom();
+
+    @Child protected LLVMAMD64WriteBooleanNode cf;
+
+    // TODO: OF, SF, ZF, AF, PF = 0
+
+    @TruffleBoundary
+    protected short getSeedI16() {
+        byte[] seed = rng.generateSeed(2);
+        return (short) (Byte.toUnsignedInt(seed[0]) << 8 | Byte.toUnsignedInt(seed[1]));
+    }
+
+    @TruffleBoundary
+    protected int getSeedI32() {
+        byte[] seed = rng.generateSeed(4);
+        return Byte.toUnsignedInt(seed[0]) << 24 | Byte.toUnsignedInt(seed[1]) << 16 | Byte.toUnsignedInt(seed[2]) << 8 | Byte.toUnsignedInt(seed[3]);
+    }
+
+    @TruffleBoundary
+    protected long getSeedI64() {
+        byte[] seed = rng.generateSeed(8);
+        return Byte.toUnsignedInt(seed[0]) << 56 | Byte.toUnsignedInt(seed[1]) << 48 | Byte.toUnsignedInt(seed[2]) << 40 | Byte.toUnsignedInt(seed[3]) << 32 | Byte.toUnsignedInt(seed[4]) << 24 |
+                        Byte.toUnsignedInt(seed[5]) << 16 | Byte.toUnsignedInt(seed[6]) << 8 | Byte.toUnsignedInt(seed[7]);
+    }
+
+    public LLVMAMD64RdSeedNode(LLVMAMD64WriteBooleanNode cf) {
+        this.cf = cf;
+    }
+
+    public abstract static class LLVMAMD64RdSeedwNode extends LLVMAMD64RdSeedNode {
+        public LLVMAMD64RdSeedwNode(LLVMAMD64WriteBooleanNode cf) {
+            super(cf);
+        }
+
+        @Override
+        @Specialization
+        public short executeI16(VirtualFrame frame) {
+            cf.execute(frame, true);
+            return getSeedI16();
+        }
+    }
+
+    public abstract static class LLVMAMD64RdSeedlNode extends LLVMAMD64RdSeedNode {
+        public LLVMAMD64RdSeedlNode(LLVMAMD64WriteBooleanNode cf) {
+            super(cf);
+        }
+
+        @Override
+        @Specialization
+        public int executeI32(VirtualFrame frame) {
+            cf.execute(frame, true);
+            return getSeedI32();
+        }
+    }
+
+    public abstract static class LLVMAMD64RdSeedqNode extends LLVMAMD64RdSeedNode {
+        public LLVMAMD64RdSeedqNode(LLVMAMD64WriteBooleanNode cf) {
+            super(cf);
+        }
+
+        @Override
+        @Specialization
+        public long executeI64(VirtualFrame frame) {
+            cf.execute(frame, true);
+            return getSeedI64();
+        }
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64RdtscNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64RdtscNode.java
@@ -37,9 +37,9 @@ import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVM
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
 public abstract class LLVMAMD64RdtscNode extends LLVMExpressionNode {
-    private final LLVMAMD64WriteI64RegisterNode low;
-    private final LLVMAMD64WriteI64RegisterNode high;
-    private final LLVMExpressionNode rdtsc;
+    @Child private LLVMAMD64WriteI64RegisterNode low;
+    @Child private LLVMAMD64WriteI64RegisterNode high;
+    @Child private LLVMExpressionNode rdtsc;
 
     public LLVMAMD64RdtscNode(LLVMAMD64WriteI64RegisterNode low, LLVMAMD64WriteI64RegisterNode high) {
         this.low = low;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64RolNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64RolNode.java
@@ -39,7 +39,7 @@ public abstract class LLVMAMD64RolNode extends LLVMExpressionNode {
     @NodeChildren({@NodeChild("left"), @NodeChild("right")})
     public abstract static class LLVMAMD64RolbNode extends LLVMExpressionNode {
         @Specialization
-        protected byte executeI16(byte left, byte right) {
+        protected byte executeI8(byte left, byte right) {
             return LLVMAMD64BarrelShifter.rol(left, right);
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64RorNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64RorNode.java
@@ -39,7 +39,7 @@ public abstract class LLVMAMD64RorNode extends LLVMExpressionNode {
     @NodeChildren({@NodeChild("left"), @NodeChild("right")})
     public abstract static class LLVMAMD64RorbNode extends LLVMExpressionNode {
         @Specialization
-        protected byte executeI16(byte left, byte right) {
+        protected byte executeI8(byte left, byte right) {
             return LLVMAMD64BarrelShifter.ror(left, right);
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64SalNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64SalNode.java
@@ -38,7 +38,7 @@ public abstract class LLVMAMD64SalNode extends LLVMExpressionNode {
     @NodeChildren({@NodeChild("left"), @NodeChild("right")})
     public abstract static class LLVMAMD64SalbNode extends LLVMExpressionNode {
         @Specialization
-        protected byte executeI16(byte left, byte right) {
+        protected byte executeI8(byte left, byte right) {
             return (byte) (left << right);
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64SetNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64SetNode.java
@@ -42,31 +42,71 @@ public abstract class LLVMAMD64SetNode {
     public abstract static class LLVMAMD64SetaNode extends LLVMExpressionNode {
         @Specialization
         protected byte executeI8(boolean cf, boolean zf) {
-            return (!cf && !zf) ? ONE : ZERO;
+            return !cf && !zf ? ONE : ZERO;
         }
     }
 
-    @NodeChildren({@NodeChild("cf")})
-    public abstract static class LLVMAMD64SetaeNode extends LLVMExpressionNode {
+    @NodeChildren({@NodeChild("zf")})
+    public abstract static class LLVMAMD64SetzNode extends LLVMExpressionNode {
         @Specialization
-        protected byte executeI8(boolean cf) {
-            return !cf ? ONE : ZERO;
+        protected byte executeI8(boolean zf) {
+            return zf ? ONE : ZERO;
         }
     }
 
-    @NodeChildren({@NodeChild("cf")})
-    public abstract static class LLVMAMD64SetbNode extends LLVMExpressionNode {
+    @NodeChildren({@NodeChild("zf")})
+    public abstract static class LLVMAMD64SetnzNode extends LLVMExpressionNode {
         @Specialization
-        protected byte executeI8(boolean cf) {
-            return cf ? ONE : ZERO;
+        protected byte executeI8(boolean zf) {
+            return zf ? ONE : ZERO;
         }
     }
 
     @NodeChildren({@NodeChild("cf"), @NodeChild("zf")})
-    public abstract static class LLVMAMD64SetbeNode extends LLVMExpressionNode {
+    public abstract static class LLVMAMD64SetorNode extends LLVMExpressionNode {
         @Specialization
         protected byte executeI8(boolean cf, boolean zf) {
-            return (cf || zf) ? ONE : ZERO;
+            return cf || zf ? ONE : ZERO;
+        }
+    }
+
+    @NodeChildren({@NodeChild("zf"), @NodeChild("sf"), @NodeChild("of")})
+    public abstract static class LLVMAMD64SetgNode extends LLVMExpressionNode {
+        @Specialization
+        protected byte executeI8(boolean zf, boolean sf, boolean of) {
+            return !zf && sf == of ? ONE : ZERO;
+        }
+    }
+
+    @NodeChildren({@NodeChild("sf"), @NodeChild("of")})
+    public abstract static class LLVMAMD64SeteqNode extends LLVMExpressionNode {
+        @Specialization
+        protected byte executeI8(boolean sf, boolean of) {
+            return sf == of ? ONE : ZERO;
+        }
+    }
+
+    @NodeChildren({@NodeChild("sf"), @NodeChild("of")})
+    public abstract static class LLVMAMD64SetneNode extends LLVMExpressionNode {
+        @Specialization
+        protected byte executeI8(boolean sf, boolean of) {
+            return sf != of ? ONE : ZERO;
+        }
+    }
+
+    @NodeChildren({@NodeChild("zf"), @NodeChild("sf"), @NodeChild("of")})
+    public abstract static class LLVMAMD64SetleNode extends LLVMExpressionNode {
+        @Specialization
+        protected byte executeI8(boolean zf, boolean sf, boolean of) {
+            return zf || sf != of ? ONE : ZERO;
+        }
+    }
+
+    @NodeChildren({@NodeChild("cf"), @NodeChild("zf")})
+    public abstract static class LLVMAMD64SetandNode extends LLVMExpressionNode {
+        @Specialization
+        protected byte executeI8(boolean cf, boolean zf) {
+            return cf && zf ? ONE : ZERO;
         }
     }
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64ShlNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64ShlNode.java
@@ -38,7 +38,7 @@ public abstract class LLVMAMD64ShlNode extends LLVMExpressionNode {
     @NodeChildren({@NodeChild("left"), @NodeChild("right")})
     public abstract static class LLVMAMD64ShlbNode extends LLVMExpressionNode {
         @Specialization
-        protected byte executeI16(byte left, byte right) {
+        protected byte executeI8(byte left, byte right) {
             return (byte) (left << right);
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64ShrNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64ShrNode.java
@@ -38,7 +38,7 @@ public abstract class LLVMAMD64ShrNode extends LLVMExpressionNode {
     @NodeChildren({@NodeChild("left"), @NodeChild("right")})
     public abstract static class LLVMAMD64ShrbNode extends LLVMExpressionNode {
         @Specialization
-        protected byte executeI16(byte left, byte right) {
+        protected byte executeI8(byte left, byte right) {
             return (byte) (left >>> right);
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64StoreFlags.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64StoreFlags.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64Flags;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteBooleanNode;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+public abstract class LLVMAMD64StoreFlags extends LLVMExpressionNode {
+    @Child protected LLVMAMD64WriteBooleanNode cf;
+    @Child protected LLVMAMD64WriteBooleanNode pf;
+    @Child protected LLVMAMD64WriteBooleanNode af;
+    @Child protected LLVMAMD64WriteBooleanNode zf;
+    @Child protected LLVMAMD64WriteBooleanNode sf;
+    @Child protected LLVMAMD64WriteBooleanNode of;
+
+    public LLVMAMD64StoreFlags(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                    LLVMAMD64WriteBooleanNode of) {
+        this.cf = cf;
+        this.pf = pf;
+        this.af = af;
+        this.zf = zf;
+        this.sf = sf;
+        this.of = of;
+    }
+
+    protected static boolean set(long value, long flag) {
+        return (value & (1 << flag)) != 0;
+    }
+
+    @NodeChild(value = "flags", type = LLVMExpressionNode.class)
+    public abstract static class LLVMAMD64SahfNode extends LLVMAMD64StoreFlags {
+        public LLVMAMD64SahfNode(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                        LLVMAMD64WriteBooleanNode of) {
+            super(cf, pf, af, zf, sf, of);
+        }
+
+        @Specialization
+        protected Object executeObject(VirtualFrame frame, byte flags) {
+            cf.execute(frame, set(flags, LLVMAMD64Flags.CF));
+            pf.execute(frame, set(flags, LLVMAMD64Flags.PF));
+            af.execute(frame, set(flags, LLVMAMD64Flags.AF));
+            zf.execute(frame, set(flags, LLVMAMD64Flags.ZF));
+            sf.execute(frame, set(flags, LLVMAMD64Flags.SF));
+            return null;
+        }
+    }
+
+    @NodeChild(value = "flags", type = LLVMExpressionNode.class)
+    public abstract static class LLVMAMD64WriteFlagswNode extends LLVMAMD64StoreFlags {
+        public LLVMAMD64WriteFlagswNode(LLVMAMD64WriteBooleanNode cf, LLVMAMD64WriteBooleanNode pf, LLVMAMD64WriteBooleanNode af, LLVMAMD64WriteBooleanNode zf, LLVMAMD64WriteBooleanNode sf,
+                        LLVMAMD64WriteBooleanNode of) {
+            super(cf, pf, af, zf, sf, of);
+        }
+
+        @Specialization
+        protected Object executeObject(VirtualFrame frame, short flags) {
+            cf.execute(frame, set(flags, LLVMAMD64Flags.CF));
+            pf.execute(frame, set(flags, LLVMAMD64Flags.PF));
+            af.execute(frame, set(flags, LLVMAMD64Flags.AF));
+            zf.execute(frame, set(flags, LLVMAMD64Flags.ZF));
+            sf.execute(frame, set(flags, LLVMAMD64Flags.SF));
+            of.execute(frame, set(flags, LLVMAMD64Flags.OF));
+            return null;
+        }
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64SubNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64SubNode.java
@@ -38,7 +38,7 @@ public abstract class LLVMAMD64SubNode extends LLVMExpressionNode {
     @NodeChildren({@NodeChild("left"), @NodeChild("right")})
     public abstract static class LLVMAMD64SubbNode extends LLVMExpressionNode {
         @Specialization
-        protected byte executeI16(byte left, byte right) {
+        protected byte executeI8(byte left, byte right) {
             return (byte) (left - right);
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64Ud2Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64Ud2Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2017, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -29,41 +29,14 @@
  */
 package com.oracle.truffle.llvm.nodes.asm;
 
-import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeChildren;
-import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
-public abstract class LLVMAMD64SarNode extends LLVMExpressionNode {
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarbNode extends LLVMExpressionNode {
-        @Specialization
-        protected byte executeI8(byte left, byte right) {
-            return (byte) (left >> right);
-        }
-    }
-
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarwNode extends LLVMExpressionNode {
-        @Specialization
-        protected short executeI16(short left, byte right) {
-            return (short) (left >> right);
-        }
-    }
-
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarlNode extends LLVMExpressionNode {
-        @Specialization
-        protected int executeI32(int left, byte right) {
-            return left >> right;
-        }
-    }
-
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarqNode extends LLVMExpressionNode {
-        @Specialization
-        protected long executeI64(long left, byte right) {
-            return left >> right;
-        }
+public class LLVMAMD64Ud2Node extends LLVMExpressionNode {
+    @Override
+    public Object executeGeneric(VirtualFrame frame) {
+        CompilerDirectives.transferToInterpreter();
+        throw new RuntimeException("Illegal opcode");
     }
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64XaddNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64XaddNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2017, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -34,19 +34,26 @@ import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64UpdateFlagsNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI16RegisterNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI32RegisterNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI64RegisterNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI8RegisterNode;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
 @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-public abstract class LLVMAMD64AddNode extends LLVMExpressionNode {
+public abstract class LLVMAMD64XaddNode extends LLVMExpressionNode {
     @Child LLVMAMD64UpdateFlagsNode flags;
 
-    private LLVMAMD64AddNode(LLVMAMD64UpdateFlagsNode flags) {
+    private LLVMAMD64XaddNode(LLVMAMD64UpdateFlagsNode flags) {
         this.flags = flags;
     }
 
-    public abstract static class LLVMAMD64AddbNode extends LLVMAMD64AddNode {
-        public LLVMAMD64AddbNode(LLVMAMD64UpdateFlagsNode flags) {
+    public abstract static class LLVMAMD64XaddbNode extends LLVMAMD64XaddNode {
+        @Child LLVMAMD64WriteI8RegisterNode src;
+
+        public LLVMAMD64XaddbNode(LLVMAMD64UpdateFlagsNode flags, LLVMAMD64WriteI8RegisterNode src) {
             super(flags);
+            this.src = src;
         }
 
         @Specialization
@@ -55,13 +62,17 @@ public abstract class LLVMAMD64AddNode extends LLVMExpressionNode {
             boolean overflow = (result < 0 && left > 0 && right > 0) || (result > 0 && left < 0 && right < 0);
             boolean carry = ((left < 0 || right < 0) && result > 0) || (left < 0 && right < 0);
             flags.execute(frame, overflow, carry, result);
+            src.execute(frame, right);
             return result;
         }
     }
 
-    public abstract static class LLVMAMD64AddwNode extends LLVMAMD64AddNode {
-        public LLVMAMD64AddwNode(LLVMAMD64UpdateFlagsNode flags) {
+    public abstract static class LLVMAMD64XaddwNode extends LLVMAMD64XaddNode {
+        @Child LLVMAMD64WriteI16RegisterNode src;
+
+        public LLVMAMD64XaddwNode(LLVMAMD64UpdateFlagsNode flags, LLVMAMD64WriteI16RegisterNode src) {
             super(flags);
+            this.src = src;
         }
 
         @Specialization
@@ -70,13 +81,17 @@ public abstract class LLVMAMD64AddNode extends LLVMExpressionNode {
             boolean overflow = (result < 0 && left > 0 && right > 0) || (result > 0 && left < 0 && right < 0);
             boolean carry = ((left < 0 || right < 0) && result > 0) || (left < 0 && right < 0);
             flags.execute(frame, overflow, carry, result);
+            src.execute(frame, right);
             return result;
         }
     }
 
-    public abstract static class LLVMAMD64AddlNode extends LLVMAMD64AddNode {
-        public LLVMAMD64AddlNode(LLVMAMD64UpdateFlagsNode flags) {
+    public abstract static class LLVMAMD64XaddlNode extends LLVMAMD64XaddNode {
+        @Child LLVMAMD64WriteI32RegisterNode src;
+
+        public LLVMAMD64XaddlNode(LLVMAMD64UpdateFlagsNode flags, LLVMAMD64WriteI32RegisterNode src) {
             super(flags);
+            this.src = src;
         }
 
         @Specialization
@@ -85,13 +100,17 @@ public abstract class LLVMAMD64AddNode extends LLVMExpressionNode {
             boolean overflow = (result < 0 && left > 0 && right > 0) || (result > 0 && left < 0 && right < 0);
             boolean carry = ((left < 0 || right < 0) && result > 0) || (left < 0 && right < 0);
             flags.execute(frame, overflow, carry, result);
+            src.execute(frame, right);
             return result;
         }
     }
 
-    public abstract static class LLVMAMD64AddqNode extends LLVMAMD64AddNode {
-        public LLVMAMD64AddqNode(LLVMAMD64UpdateFlagsNode flags) {
+    public abstract static class LLVMAMD64XaddqNode extends LLVMAMD64XaddNode {
+        @Child LLVMAMD64WriteI64RegisterNode src;
+
+        public LLVMAMD64XaddqNode(LLVMAMD64UpdateFlagsNode flags, LLVMAMD64WriteI64RegisterNode src) {
             super(flags);
+            this.src = src;
         }
 
         @Specialization
@@ -100,6 +119,7 @@ public abstract class LLVMAMD64AddNode extends LLVMExpressionNode {
             boolean overflow = (result < 0 && left > 0 && right > 0) || (result > 0 && left < 0 && right < 0);
             boolean carry = ((left < 0 || right < 0) && result > 0) || (left < 0 && right < 0);
             flags.execute(frame, overflow, carry, result);
+            src.execute(frame, right);
             return result;
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64XchgNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64XchgNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2017, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -33,66 +33,67 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64UpdateFlagsNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI16RegisterNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI32RegisterNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI64RegisterNode;
+import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteRegisterNode.LLVMAMD64WriteI8RegisterNode;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
 @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-public abstract class LLVMAMD64AndNode extends LLVMExpressionNode {
-    @Child LLVMAMD64UpdateFlagsNode flags;
+public abstract class LLVMAMD64XchgNode extends LLVMExpressionNode {
+    public abstract static class LLVMAMD64XchgbNode extends LLVMAMD64XchgNode {
+        @Child private LLVMAMD64WriteI8RegisterNode out2;
 
-    private LLVMAMD64AndNode(LLVMAMD64UpdateFlagsNode flags) {
-        this.flags = flags;
-    }
-
-    public abstract static class LLVMAMD64AndbNode extends LLVMAMD64AndNode {
-        public LLVMAMD64AndbNode(LLVMAMD64UpdateFlagsNode flags) {
-            super(flags);
+        public LLVMAMD64XchgbNode(LLVMAMD64WriteI8RegisterNode out2) {
+            this.out2 = out2;
         }
 
         @Specialization
-        protected byte executeI8(VirtualFrame frame, byte left, byte right) {
-            byte result = (byte) (left & right);
-            flags.execute(frame, result);
-            return result;
+        protected byte executeI8(VirtualFrame frame, byte a, byte b) {
+            out2.execute(frame, a);
+            return b;
         }
     }
 
-    public abstract static class LLVMAMD64AndwNode extends LLVMAMD64AndNode {
-        public LLVMAMD64AndwNode(LLVMAMD64UpdateFlagsNode flags) {
-            super(flags);
+    public abstract static class LLVMAMD64XchgwNode extends LLVMAMD64XchgNode {
+        @Child private LLVMAMD64WriteI16RegisterNode out2;
+
+        public LLVMAMD64XchgwNode(LLVMAMD64WriteI16RegisterNode out2) {
+            this.out2 = out2;
         }
 
         @Specialization
-        protected short executeI16(VirtualFrame frame, short left, short right) {
-            short result = (short) (left & right);
-            flags.execute(frame, result);
-            return result;
+        protected short executeI16(VirtualFrame frame, short a, short b) {
+            out2.execute(frame, a);
+            return b;
         }
     }
 
-    public abstract static class LLVMAMD64AndlNode extends LLVMAMD64AndNode {
-        public LLVMAMD64AndlNode(LLVMAMD64UpdateFlagsNode flags) {
-            super(flags);
+    public abstract static class LLVMAMD64XchglNode extends LLVMAMD64XchgNode {
+        @Child private LLVMAMD64WriteI32RegisterNode out2;
+
+        public LLVMAMD64XchglNode(LLVMAMD64WriteI32RegisterNode out2) {
+            this.out2 = out2;
         }
 
         @Specialization
-        protected int executeI32(VirtualFrame frame, int left, int right) {
-            int result = left & right;
-            flags.execute(frame, result);
-            return result;
+        protected int executeI32(VirtualFrame frame, int a, int b) {
+            out2.execute(frame, a);
+            return b;
         }
     }
 
-    public abstract static class LLVMAMD64AndqNode extends LLVMAMD64AndNode {
-        public LLVMAMD64AndqNode(LLVMAMD64UpdateFlagsNode flags) {
-            super(flags);
+    public abstract static class LLVMAMD64XchgqNode extends LLVMAMD64XchgNode {
+        @Child private LLVMAMD64WriteI64RegisterNode out2;
+
+        public LLVMAMD64XchgqNode(LLVMAMD64WriteI64RegisterNode out2) {
+            this.out2 = out2;
         }
 
         @Specialization
-        protected long executeI64(VirtualFrame frame, long left, long right) {
-            long result = left & right;
-            flags.execute(frame, result);
-            return result;
+        protected long executeI64(VirtualFrame frame, long a, long b) {
+            out2.execute(frame, a);
+            return b;
         }
     }
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64XorNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/LLVMAMD64XorNode.java
@@ -38,7 +38,7 @@ public abstract class LLVMAMD64XorNode extends LLVMExpressionNode {
     @NodeChildren({@NodeChild("left"), @NodeChild("right")})
     public abstract static class LLVMAMD64XorbNode extends LLVMExpressionNode {
         @Specialization
-        protected byte executeI16(byte left, byte right) {
+        protected byte executeI8(byte left, byte right) {
             return (byte) (left ^ right);
         }
     }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LLVMAMD64ReadRegisterNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LLVMAMD64ReadRegisterNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2017, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -27,43 +27,32 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.oracle.truffle.llvm.nodes.asm;
+package com.oracle.truffle.llvm.nodes.asm.support;
 
-import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.frame.FrameSlotTypeException;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
-public abstract class LLVMAMD64SarNode extends LLVMExpressionNode {
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarbNode extends LLVMExpressionNode {
-        @Specialization
-        protected byte executeI8(byte left, byte right) {
-            return (byte) (left >> right);
-        }
+@NodeField(name = "slot", type = FrameSlot.class)
+public abstract class LLVMAMD64ReadRegisterNode extends LLVMExpressionNode {
+    protected abstract FrameSlot getSlot();
+
+    @Specialization(rewriteOn = FrameSlotTypeException.class)
+    protected long readI64(VirtualFrame frame) throws FrameSlotTypeException {
+        return frame.getLong(getSlot());
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarwNode extends LLVMExpressionNode {
-        @Specialization
-        protected short executeI16(short left, byte right) {
-            return (short) (left >> right);
-        }
+    @Specialization(rewriteOn = FrameSlotTypeException.class)
+    protected LLVMAddress readAddress(VirtualFrame frame) throws FrameSlotTypeException {
+        return (LLVMAddress) frame.getObject(getSlot());
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarlNode extends LLVMExpressionNode {
-        @Specialization
-        protected int executeI32(int left, byte right) {
-            return left >> right;
-        }
-    }
-
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarqNode extends LLVMExpressionNode {
-        @Specialization
-        protected long executeI64(long left, byte right) {
-            return left >> right;
-        }
+    @Specialization(replaces = {"readI64", "readAddress"})
+    protected Object readObject(VirtualFrame frame) {
+        return frame.getValue(getSlot());
     }
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LLVMAMD64ToRegisterNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LLVMAMD64ToRegisterNode.java
@@ -32,95 +32,104 @@ package com.oracle.truffle.llvm.nodes.asm.support;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
 public abstract class LLVMAMD64ToRegisterNode extends LLVMExpressionNode {
-    @NodeChildren({@NodeChild(value = "register", type = LLVMExpressionNode.class), @NodeChild(value = "from", type = LLVMExpressionNode.class)})
+    @NodeChildren({@NodeChild(value = "from", type = LLVMExpressionNode.class)})
     public abstract static class LLVMI8ToR64 extends LLVMAMD64ToRegisterNode {
+        @Child private LLVMExpressionNode register;
         private final int shift;
         private final long mask;
 
-        public LLVMI8ToR64(int shift) {
+        public LLVMI8ToR64(int shift, LLVMExpressionNode register) {
             this.shift = shift;
             this.mask = ~((long) LLVMExpressionNode.I8_MASK << shift);
+            this.register = register;
         }
 
         @Specialization
-        public long executeI64(long register, byte from) {
-            return (register & mask) | Byte.toUnsignedLong(from) << shift;
+        public long executeI64(VirtualFrame frame, byte from) {
+            long reg = register.executeI64(frame);
+            return (reg & mask) | Byte.toUnsignedLong(from) << shift;
         }
 
         @Specialization
-        public long executeI64(long register, short from) {
-            return (register & mask) | (from & ~mask) << shift;
+        public long executeI64(VirtualFrame frame, short from) {
+            long reg = register.executeI64(frame);
+            return (reg & mask) | (from & ~mask) << shift;
         }
 
         @Specialization
-        public long executeI64(long register, int from) {
-            return (register & mask) | (from & ~mask) << shift;
+        public long executeI64(VirtualFrame frame, int from) {
+            long reg = register.executeI64(frame);
+            return (reg & mask) | (from & ~mask) << shift;
         }
 
         @Specialization
-        public long executeI64(long register, long from) {
-            return (register & mask) | (from & ~mask) << shift;
+        public long executeI64(VirtualFrame frame, long from) {
+            long reg = register.executeI64(frame);
+            return (reg & mask) | (from & ~mask) << shift;
         }
     }
 
-    @NodeChildren({@NodeChild(value = "register", type = LLVMExpressionNode.class), @NodeChild(value = "from", type = LLVMExpressionNode.class)})
+    @NodeChildren({@NodeChild(value = "from", type = LLVMExpressionNode.class)})
     public abstract static class LLVMI16ToR64 extends LLVMAMD64ToRegisterNode {
+        @Child private LLVMExpressionNode register;
         private final long mask;
 
-        public LLVMI16ToR64() {
+        public LLVMI16ToR64(LLVMExpressionNode register) {
+            this.register = register;
             this.mask = ~(long) LLVMExpressionNode.I16_MASK;
         }
 
         @Specialization
-        public long executeI64(long register, byte from) {
-            return (register & mask) | Byte.toUnsignedLong(from);
+        public long executeI64(VirtualFrame frame, byte from) {
+            long reg = register.executeI64(frame);
+            return (reg & mask) | Byte.toUnsignedLong(from);
         }
 
         @Specialization
-        public long executeI64(long register, short from) {
-            return (register & mask) | Short.toUnsignedLong(from);
+        public long executeI64(VirtualFrame frame, short from) {
+            long reg = register.executeI64(frame);
+            return (reg & mask) | Short.toUnsignedLong(from);
         }
 
         @Specialization
-        public long executeI64(long register, int from) {
-            return (register & mask) | (from & ~mask);
+        public long executeI64(VirtualFrame frame, int from) {
+            long reg = register.executeI64(frame);
+            return (reg & mask) | (from & ~mask);
         }
 
         @Specialization
-        public long executeI64(long register, long from) {
-            return (register & mask) | (from & ~mask);
+        public long executeI64(VirtualFrame frame, long from) {
+            long reg = register.executeI64(frame);
+            return (reg & mask) | (from & ~mask);
         }
     }
 
-    @NodeChildren({@NodeChild(value = "register", type = LLVMExpressionNode.class), @NodeChild(value = "from", type = LLVMExpressionNode.class)})
+    @NodeChildren({@NodeChild(value = "from", type = LLVMExpressionNode.class)})
     public abstract static class LLVMI32ToR64 extends LLVMAMD64ToRegisterNode {
-        private final int mask;
+        private static final long mask = 0xFFFFFFFFL;
 
-        public LLVMI32ToR64() {
-            this.mask = ~0xFFFFFFFF;
+        @Specialization
+        public long executeI64(byte from) {
+            return Byte.toUnsignedLong(from);
         }
 
         @Specialization
-        public long executeI64(long register, byte from) {
-            return (register & mask) | Byte.toUnsignedLong(from);
+        public long executeI64(short from) {
+            return Short.toUnsignedLong(from);
         }
 
         @Specialization
-        public long executeI64(long register, short from) {
-            return (register & mask) | Short.toUnsignedLong(from);
+        public long executeI64(int from) {
+            return Integer.toUnsignedLong(from);
         }
 
         @Specialization
-        public long executeI64(long register, int from) {
-            return (register & mask) | Integer.toUnsignedLong(from);
-        }
-
-        @Specialization
-        public long executeI64(long register, long from) {
-            return (register & mask) | (from & ~mask);
+        public long executeI64(long from) {
+            return from & mask;
         }
     }
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LLVMAMD64UpdateFlagsNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LLVMAMD64UpdateFlagsNode.java
@@ -38,16 +38,18 @@ public class LLVMAMD64UpdateFlagsNode extends Node {
     // flags
     private final FrameSlot cf;
     private final FrameSlot pf;
+    private final FrameSlot af;
     private final FrameSlot zf;
     private final FrameSlot sf;
     private final FrameSlot of;
 
-    public LLVMAMD64UpdateFlagsNode(FrameSlot cf, FrameSlot pf, FrameSlot zf, FrameSlot sf, FrameSlot of) {
+    public LLVMAMD64UpdateFlagsNode(FrameSlot cf, FrameSlot pf, FrameSlot af, FrameSlot zf, FrameSlot sf, FrameSlot of) {
         this.cf = cf;
         this.pf = pf;
-        this.of = of;
+        this.af = af;
         this.zf = zf;
         this.sf = sf;
+        this.of = of;
     }
 
     public void execute(VirtualFrame frame, byte value) {
@@ -134,7 +136,43 @@ public class LLVMAMD64UpdateFlagsNode extends Node {
         frame.setBoolean(pf, getParity((byte) value));
     }
 
-    private static boolean getParity(byte value) {
+    public void execute(VirtualFrame frame, boolean overflow, boolean carry, boolean adjust, byte value) {
+        frame.setBoolean(of, overflow);
+        frame.setBoolean(cf, carry);
+        frame.setBoolean(af, adjust);
+        frame.setBoolean(sf, value < 0);
+        frame.setBoolean(zf, value == 0);
+        frame.setBoolean(pf, getParity(value));
+    }
+
+    public void execute(VirtualFrame frame, boolean overflow, boolean carry, boolean adjust, short value) {
+        frame.setBoolean(of, overflow);
+        frame.setBoolean(cf, carry);
+        frame.setBoolean(af, adjust);
+        frame.setBoolean(sf, value < 0);
+        frame.setBoolean(zf, value == 0);
+        frame.setBoolean(pf, getParity((byte) value));
+    }
+
+    public void execute(VirtualFrame frame, boolean overflow, boolean carry, boolean adjust, int value) {
+        frame.setBoolean(of, overflow);
+        frame.setBoolean(cf, carry);
+        frame.setBoolean(af, adjust);
+        frame.setBoolean(sf, value < 0);
+        frame.setBoolean(zf, value == 0);
+        frame.setBoolean(pf, getParity((byte) value));
+    }
+
+    public void execute(VirtualFrame frame, boolean overflow, boolean carry, boolean adjust, long value) {
+        frame.setBoolean(of, overflow);
+        frame.setBoolean(cf, carry);
+        frame.setBoolean(af, adjust);
+        frame.setBoolean(sf, value < 0);
+        frame.setBoolean(zf, value == 0);
+        frame.setBoolean(pf, getParity((byte) value));
+    }
+
+    public static boolean getParity(byte value) {
         boolean result = true;
         for (int i = 0; i < LLVMExpressionNode.I8_SIZE_IN_BITS; i++) {
             if ((value & (1 << i)) != 0) {

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LLVMAMD64WriteAddressRegisterNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LLVMAMD64WriteAddressRegisterNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2017, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -27,43 +27,54 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.oracle.truffle.llvm.nodes.asm;
+package com.oracle.truffle.llvm.nodes.asm.support;
 
 import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.frame.FrameSlotKind;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 
-public abstract class LLVMAMD64SarNode extends LLVMExpressionNode {
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarbNode extends LLVMExpressionNode {
-        @Specialization
-        protected byte executeI8(byte left, byte right) {
-            return (byte) (left >> right);
-        }
+@NodeChild("value")
+@NodeField(name = "slot", type = FrameSlot.class)
+public abstract class LLVMAMD64WriteAddressRegisterNode extends LLVMExpressionNode {
+    public abstract FrameSlot getSlot();
+
+    @Specialization
+    protected Object executeI8(VirtualFrame frame, byte value) {
+        getSlot().setKind(FrameSlotKind.Long);
+        frame.setLong(getSlot(), value);
+        return null;
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarwNode extends LLVMExpressionNode {
-        @Specialization
-        protected short executeI16(short left, byte right) {
-            return (short) (left >> right);
-        }
+    @Specialization
+    protected Object executeI16(VirtualFrame frame, short value) {
+        getSlot().setKind(FrameSlotKind.Long);
+        frame.setLong(getSlot(), value);
+        return null;
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarlNode extends LLVMExpressionNode {
-        @Specialization
-        protected int executeI32(int left, byte right) {
-            return left >> right;
-        }
+    @Specialization
+    protected Object executeI32(VirtualFrame frame, int value) {
+        getSlot().setKind(FrameSlotKind.Long);
+        frame.setLong(getSlot(), value);
+        return null;
     }
 
-    @NodeChildren({@NodeChild("left"), @NodeChild("right")})
-    public abstract static class LLVMAMD64SarqNode extends LLVMExpressionNode {
-        @Specialization
-        protected long executeI64(long left, byte right) {
-            return left >> right;
-        }
+    @Specialization
+    protected Object executeI64(VirtualFrame frame, long value) {
+        getSlot().setKind(FrameSlotKind.Long);
+        frame.setLong(getSlot(), value);
+        return null;
+    }
+
+    @Specialization
+    protected Object executeAddress(VirtualFrame frame, LLVMAddress value) {
+        getSlot().setKind(FrameSlotKind.Object);
+        frame.setObject(getSlot(), value);
+        return null;
     }
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LLVMAMD64WriteBooleanNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LLVMAMD64WriteBooleanNode.java
@@ -29,13 +29,11 @@
  */
 package com.oracle.truffle.llvm.nodes.asm.support;
 
-import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 
-@NodeField(name = "slot", type = FrameSlot.class)
-public abstract class LLVMAMD64WriteBooleanNode extends Node {
+public class LLVMAMD64WriteBooleanNode extends Node {
     private final FrameSlot slot;
 
     public LLVMAMD64WriteBooleanNode(FrameSlot slot) {

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LongDivision.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LongDivision.java
@@ -31,6 +31,8 @@ package com.oracle.truffle.llvm.nodes.asm.support;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+
 public class LongDivision {
     public static class Result {
         private static final long INVALID = 0x8000000000000000L;
@@ -72,6 +74,7 @@ public class LongDivision {
         }
     }
 
+    @TruffleBoundary
     public static Result divu128by64(long a1, long a0, long b) {
         if (a1 == 0 && a0 > 0 && b > 0) {
             return new Result(a0 / b, a0 % b);
@@ -90,6 +93,7 @@ public class LongDivision {
         }
     }
 
+    @TruffleBoundary
     public static Result divs128by64(long a1, long a0, long b) {
         if (a1 == 0 && a0 > 0) {
             return new Result(a0 / b, a0 % b);

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LongDivision.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LongDivision.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.support;
+
+import java.math.BigInteger;
+
+public class LongDivision {
+    public static class Result {
+        private static final long INVALID = 0x8000000000000000L;
+
+        public static final Result OVERFLOW = new Result(INVALID, INVALID);
+
+        public final long quotient;
+        public final long remainder;
+
+        Result(long quotient, long remainder) {
+            this.quotient = quotient;
+            this.remainder = remainder;
+        }
+
+        public boolean invalid() {
+            return quotient == INVALID && remainder == INVALID;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null) {
+                return false;
+            }
+            if (!(o instanceof Result)) {
+                return false;
+            }
+            Result r = (Result) o;
+            return r.quotient == quotient && r.remainder == remainder;
+        }
+
+        @Override
+        public int hashCode() {
+            return (int) (quotient ^ remainder);
+        }
+
+        @Override
+        public String toString() {
+            return "Result[q=" + quotient + ",r=" + remainder + "]";
+        }
+    }
+
+    public static Result divu128by64(long a1, long a0, long b) {
+        if (a1 == 0 && a0 > 0 && b > 0) {
+            return new Result(a0 / b, a0 % b);
+        }
+
+        BigInteger x = u128(a1, a0);
+        BigInteger y = u64(b);
+        BigInteger[] result = x.divideAndRemainder(y);
+
+        BigInteger q = result[0];
+        BigInteger r = result[1];
+        if (q.bitLength() > 64) {
+            return Result.OVERFLOW;
+        } else {
+            return new Result(q.longValue(), r.longValue());
+        }
+    }
+
+    public static Result divs128by64(long a1, long a0, long b) {
+        if (a1 == 0 && a0 > 0) {
+            return new Result(a0 / b, a0 % b);
+        }
+
+        BigInteger x = s128(a1, a0);
+        BigInteger y = BigInteger.valueOf(b);
+        BigInteger[] result = x.divideAndRemainder(y);
+
+        BigInteger q = result[0];
+        BigInteger r = result[1];
+        if (q.bitCount() > 64) {
+            return Result.OVERFLOW;
+        } else {
+            return new Result(q.longValue(), r.longValue());
+        }
+    }
+
+    private static BigInteger u64(long x) {
+        byte[] bytes = new byte[]{
+                        (byte) 0,
+                        (byte) (x >> 56),
+                        (byte) (x >> 48),
+                        (byte) (x >> 40),
+                        (byte) (x >> 32),
+                        (byte) (x >> 24),
+                        (byte) (x >> 16),
+                        (byte) (x >> 8),
+                        (byte) (x)
+        };
+        return new BigInteger(bytes);
+    }
+
+    private static BigInteger u128(long h, long l) {
+        byte[] bytes = new byte[]{
+                        (byte) 0,
+                        (byte) (h >> 56),
+                        (byte) (h >> 48),
+                        (byte) (h >> 40),
+                        (byte) (h >> 32),
+                        (byte) (h >> 24),
+                        (byte) (h >> 16),
+                        (byte) (h >> 8),
+                        (byte) (h),
+                        (byte) (l >> 56),
+                        (byte) (l >> 48),
+                        (byte) (l >> 40),
+                        (byte) (l >> 32),
+                        (byte) (l >> 24),
+                        (byte) (l >> 16),
+                        (byte) (l >> 8),
+                        (byte) (l)
+        };
+        return new BigInteger(bytes);
+    }
+
+    private static BigInteger s128(long h, long l) {
+        byte[] bytes = new byte[]{
+                        (byte) (h >> 56),
+                        (byte) (h >> 48),
+                        (byte) (h >> 40),
+                        (byte) (h >> 32),
+                        (byte) (h >> 24),
+                        (byte) (h >> 16),
+                        (byte) (h >> 8),
+                        (byte) (h),
+                        (byte) (l >> 56),
+                        (byte) (l >> 48),
+                        (byte) (l >> 40),
+                        (byte) (l >> 32),
+                        (byte) (l >> 24),
+                        (byte) (l >> 16),
+                        (byte) (l >> 8),
+                        (byte) (l)
+        };
+        return new BigInteger(bytes);
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LongMultiplication.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LongMultiplication.java
@@ -29,48 +29,23 @@
  */
 package com.oracle.truffle.llvm.nodes.asm.support;
 
+import java.math.BigInteger;
+
 /*
  * This functionality is in the standard class library since Java 9:
  * https://bugs.openjdk.java.net/browse/JDK-5100935
  */
 public class LongMultiplication {
-    private static final long MASK32 = 0xFFFFFFFFL;
-    private static final int SHIFT32 = 32;
+    private static long high(BigInteger x) {
+        BigInteger hi = x.shiftRight(64);
+        return hi.longValue();
+    }
 
-    /**
-     * Returns as a {@code long} the most significant 64 bits of the 128-bit product of two 64-bit
-     * factors.
-     *
-     * @param x the first value
-     * @param y the second value
-     * @return the result
-     */
-    public static long multiplyHigh(long x, long y) {
-        if (x < 0 || y < 0) {
-            // Use technique from section 8-2 of Henry S. Warren, Jr.,
-            // Hacker's Delight (2nd ed.) (Addison Wesley, 2013), 173-174.
-            long x1 = x >> SHIFT32;
-            long x2 = x & MASK32;
-            long y1 = y >> SHIFT32;
-            long y2 = y & MASK32;
-            long z2 = x2 * y2;
-            long t = x1 * y2 + (z2 >>> SHIFT32);
-            long z1 = t & MASK32;
-            long z0 = t >> SHIFT32;
-            z1 += x2 * y1;
-            return x1 * y1 + z0 + (z1 >> SHIFT32);
-        } else {
-            // Use Karatsuba technique with two base 2^32 digits.
-            long x1 = x >>> SHIFT32;
-            long y1 = y >>> SHIFT32;
-            long x2 = x & MASK32;
-            long y2 = y & MASK32;
-            long a = x1 * y1;
-            long b = x2 * y2;
-            long c = (x1 + x2) * (y1 + y2);
-            long k = c - a - b;
-            return (((b >>> SHIFT32) + k) >>> SHIFT32) + a;
-        }
+    public static long multiplyHigh(long u, long v) {
+        BigInteger x = BigInteger.valueOf(u);
+        BigInteger y = BigInteger.valueOf(v);
+        BigInteger z = x.multiply(y);
+        return high(z);
     }
 
     public static long multiplyHighUnsigned(long x, long y) {

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LongMultiplication.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LongMultiplication.java
@@ -31,6 +31,8 @@ package com.oracle.truffle.llvm.nodes.asm.support;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+
 /*
  * This functionality is in the standard class library since Java 9:
  * https://bugs.openjdk.java.net/browse/JDK-5100935
@@ -41,6 +43,7 @@ public class LongMultiplication {
         return hi.longValue();
     }
 
+    @TruffleBoundary
     public static long multiplyHigh(long u, long v) {
         BigInteger x = BigInteger.valueOf(u);
         BigInteger y = BigInteger.valueOf(v);

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
@@ -466,7 +466,7 @@ public class BasicNodeFactory implements NodeFactory {
             retOffsets = alloca.getOffsets();
         }
 
-        Parser asmParser = new Parser(asmExpression, asmFlags, argTypes, retType, retTypes, retOffsets);
+        Parser asmParser = new Parser(asmExpression, asmFlags, argTypes, retType, retTypes, retOffsets, sourceSection);
         LLVMInlineAssemblyRootNode assemblyRoot = asmParser.Parse();
         LLVMFunctionDescriptor asm = LLVMFunctionDescriptor.createDescriptor(runtime.getContext(), "<asm>", new FunctionType(MetaType.UNKNOWN, new Type[0], false), -1);
         asm.declareInSulong(Truffle.getRuntime().createCallTarget(assemblyRoot), false);
@@ -582,9 +582,9 @@ public class BasicNodeFactory implements NodeFactory {
     @Override
     public LLVMExpressionNode createLLVMBuiltin(LLVMParserRuntime runtime, Symbol target, LLVMExpressionNode[] args, int callerArgumentCount, SourceSection sourceSection) {
         /*
-         * This LLVM Builtins are *not* function intrinsics. Builtins replace statements that look
-         * like function calls but are actually LLVM intrinsics. An example is llvm.stackpointer.
-         * Also, it is not possible to retrieve the functionpointer of such pseudo-call-targets.
+         * This LLVM Builtins are *not* function intrinsics. Builtins replace statements that look like
+         * function calls but are actually LLVM intrinsics. An example is llvm.stackpointer. Also, it is not
+         * possible to retrieve the functionpointer of such pseudo-call-targets.
          *
          * This builtins shall not be used for regular function intrinsification!
          */

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
@@ -582,9 +582,9 @@ public class BasicNodeFactory implements NodeFactory {
     @Override
     public LLVMExpressionNode createLLVMBuiltin(LLVMParserRuntime runtime, Symbol target, LLVMExpressionNode[] args, int callerArgumentCount, SourceSection sourceSection) {
         /*
-         * This LLVM Builtins are *not* function intrinsics. Builtins replace statements that look like
-         * function calls but are actually LLVM intrinsics. An example is llvm.stackpointer. Also, it is not
-         * possible to retrieve the functionpointer of such pseudo-call-targets.
+         * This LLVM Builtins are *not* function intrinsics. Builtins replace statements that look
+         * like function calls but are actually LLVM intrinsics. An example is llvm.stackpointer.
+         * Also, it is not possible to retrieve the functionpointer of such pseudo-call-targets.
          *
          * This builtins shall not be used for regular function intrinsification!
          */

--- a/tests/inlineassemblytests/bsf001.c
+++ b/tests/inlineassemblytests/bsf001.c
@@ -1,0 +1,6 @@
+int main() {
+  unsigned short arg = 0x1234;
+  unsigned short out = 0;
+  __asm__("bsfw %%ax, %%cx" : "=c"(out) : "a"(arg));
+  return (out == 2);
+}

--- a/tests/inlineassemblytests/bsf002.c
+++ b/tests/inlineassemblytests/bsf002.c
@@ -1,0 +1,6 @@
+int main() {
+  unsigned int arg = 0x12345678;
+  unsigned int out = 0;
+  __asm__("bsfl %%eax, %%ecx" : "=c"(out) : "a"(arg));
+  return (out == 3);
+}

--- a/tests/inlineassemblytests/bsf003.c
+++ b/tests/inlineassemblytests/bsf003.c
@@ -1,0 +1,6 @@
+int main() {
+  unsigned long arg = 0x0123456789ABCD00;
+  unsigned long out = 0;
+  __asm__("bsfq %%rax, %%rcx" : "=c"(out) : "a"(arg));
+  return (out == 8);
+}

--- a/tests/inlineassemblytests/bsr001.c
+++ b/tests/inlineassemblytests/bsr001.c
@@ -1,0 +1,6 @@
+int main() {
+  unsigned short arg = 0x1234;
+  unsigned short out = 0;
+  __asm__("bsrw %%ax, %%cx" : "=c"(out) : "a"(arg));
+  return (out == 12);
+}

--- a/tests/inlineassemblytests/bsr002.c
+++ b/tests/inlineassemblytests/bsr002.c
@@ -1,0 +1,6 @@
+int main() {
+  unsigned int arg = 0x12345678;
+  unsigned int out = 0;
+  __asm__("bsrl %%eax, %%ecx" : "=c"(out) : "a"(arg));
+  return (out == 28);
+}

--- a/tests/inlineassemblytests/bsr003.c
+++ b/tests/inlineassemblytests/bsr003.c
@@ -1,0 +1,6 @@
+int main() {
+  unsigned long arg = 0x0123456789ABCDEF;
+  unsigned long out = 0;
+  __asm__("bsrq %%rax, %%rcx" : "=c"(out) : "a"(arg));
+  return (out == 56);
+}

--- a/tests/inlineassemblytests/bswap001.c
+++ b/tests/inlineassemblytests/bswap001.c
@@ -1,0 +1,6 @@
+int main() {
+  unsigned int arg = 0x12345678;
+  unsigned int out = 0;
+  __asm__("bswapl %%eax" : "=a"(out) : "a"(arg));
+  return (out == 0x78563412);
+}

--- a/tests/inlineassemblytests/bswap002.c
+++ b/tests/inlineassemblytests/bswap002.c
@@ -1,0 +1,6 @@
+int main() {
+  unsigned long arg = 0x123456789ABCDEF0;
+  unsigned long out = 0;
+  __asm__("bswapq %%rax" : "=a"(out) : "a"(arg));
+  return (out == 0xF0DEBC9A78563412);
+}

--- a/tests/inlineassemblytests/cmp001.c
+++ b/tests/inlineassemblytests/cmp001.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include "flags.h"
+
+int main() {
+  char flags;
+  __asm__("movb $0xFF, %%al; cmpb $0x02, %%al; lahf; movb %%ah, %%al" : "=a"(flags));
+  printf("%02X\n", flags & CC_MASK8);
+}

--- a/tests/inlineassemblytests/cmpxchg001.c
+++ b/tests/inlineassemblytests/cmpxchg001.c
@@ -1,0 +1,9 @@
+int main() {
+  unsigned char arg1 = 0x55;
+  unsigned char arg2 = 0xAA;
+  unsigned char arg3 = 0x55;
+  unsigned char out1 = 0;
+  unsigned char out2 = 0;
+  __asm__("cmpxchgb %%cl, %%dl" : "=a"(out1), "=d"(out2) : "a"(arg1), "c"(arg2), "d"(arg3));
+  return (out1 == 0x55) && (out2 == 0xAA);
+}

--- a/tests/inlineassemblytests/cmpxchg002.c
+++ b/tests/inlineassemblytests/cmpxchg002.c
@@ -1,0 +1,9 @@
+int main() {
+  unsigned char arg1 = 0x55;
+  unsigned char arg2 = 0x55;
+  unsigned char arg3 = 0xAA;
+  unsigned char out1 = 0;
+  unsigned char out2 = 0;
+  __asm__("cmpxchgb %%cl, %%dl" : "=a"(out1), "=d"(out2) : "a"(arg1), "c"(arg2), "d"(arg3));
+  return (out1 == 0xAA) && (out2 == 0xAA);
+}

--- a/tests/inlineassemblytests/cpuid.h
+++ b/tests/inlineassemblytests/cpuid.h
@@ -1,0 +1,24 @@
+#include <cpuid.h>
+
+#define	RDRND	(1 << 30)
+#define	RDSEED	(1 << 18)
+
+static inline int has_rdrand() {
+  unsigned int a;
+  unsigned int b;
+  unsigned int c;
+  unsigned int d;
+  if(!__get_cpuid(0x1, &a, &b, &c, &d))
+    return 0;
+  return c & RDRND;
+}
+
+static inline int has_rdseed() {
+  unsigned int a;
+  unsigned int b;
+  unsigned int c;
+  unsigned int d;
+  if(!__get_cpuid(0x7, &a, &b, &c, &d))
+    return 0;
+  return b & RDSEED;
+}

--- a/tests/inlineassemblytests/cpuid001.c
+++ b/tests/inlineassemblytests/cpuid001.c
@@ -1,0 +1,5 @@
+#include "cpuid.h"
+
+int main() {
+  return has_rdrand() ? 1 : 0;
+}

--- a/tests/inlineassemblytests/cpuid002.c
+++ b/tests/inlineassemblytests/cpuid002.c
@@ -1,0 +1,26 @@
+#include <cpuid.h>
+#include <string.h>
+
+typedef union {
+  struct {
+    unsigned int b, d, c;
+  };
+  char str[13];
+} VENDOR;
+
+int main(void)
+{
+  VENDOR vendor;
+  unsigned int a, b, c, d;
+
+  __cpuid(0, a, vendor.b, vendor.c, vendor.d);
+  vendor.str[12] = 0;
+  if(!strcmp(vendor.str, "GenuineIntel")) {
+    return 1;
+  }
+  if(!strcmp(vendor.str, "SulongLLVM64")) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/tests/inlineassemblytests/flags.h
+++ b/tests/inlineassemblytests/flags.h
@@ -1,0 +1,14 @@
+#ifndef __FLAGS_H__
+#define __FLAGS_H__
+
+#define CC_C 0x0001
+#define CC_P 0x0004
+#define CC_A 0x0010
+#define CC_Z 0x0040
+#define CC_S 0x0080
+#define CC_O 0x0800
+
+#define CC_MASK (CC_C | CC_P | CC_Z | CC_S | CC_O | CC_A)
+#define CC_MASK8 (CC_C | CC_P | CC_Z | CC_S | CC_A)
+
+#endif

--- a/tests/inlineassemblytests/lea001.c
+++ b/tests/inlineassemblytests/lea001.c
@@ -1,0 +1,6 @@
+int main() {
+  unsigned long ptr = 0;
+  unsigned long out = 0;
+  __asm__("lea %1, %0" : "=r"(out) : "m"(ptr));
+  return &ptr == (unsigned long*) out;
+}

--- a/tests/inlineassemblytests/push001.c
+++ b/tests/inlineassemblytests/push001.c
@@ -1,0 +1,5 @@
+int main() {
+  unsigned short value = 0;
+  __asm__("pushw $0x1234; popw %0" : "=r"(value));
+  return value == 0x1234;
+}

--- a/tests/inlineassemblytests/push002.c
+++ b/tests/inlineassemblytests/push002.c
@@ -1,0 +1,5 @@
+int main() {
+  unsigned long value = 0;
+  __asm__("movq $0x123456789ABCDEF, %%rax; pushq %%rax; popq %0" : "=r"(value) : : "%rax");
+  return value == 0x123456789ABCDEF;
+}

--- a/tests/inlineassemblytests/rdrand001.c
+++ b/tests/inlineassemblytests/rdrand001.c
@@ -1,0 +1,26 @@
+#include "cpuid.h"
+
+int main() {
+  unsigned short out = 0;
+  unsigned int i;
+  unsigned char cf;
+  unsigned short old = out;
+
+  if(!has_rdrand())
+    return 1;
+
+  for(i = 0; i < 32; i++) {
+    unsigned short tmp = out;
+    __asm__("rdrand %%ax; setc %%dl" : "=a"(out), "=d"(cf));
+    if(cf)
+      old = tmp;
+    else {
+      i--;
+      continue;
+    }
+    if(old != out)
+      return 1;
+  }
+
+  return 0;
+}

--- a/tests/inlineassemblytests/rdrand002.c
+++ b/tests/inlineassemblytests/rdrand002.c
@@ -1,0 +1,26 @@
+#include "cpuid.h"
+
+int main() {
+  unsigned int out = 0;
+  unsigned int i;
+  unsigned char cf;
+  unsigned int old = out;
+
+  if(!has_rdrand())
+    return 1;
+
+  for(i = 0; i < 32; i++) {
+    unsigned int tmp = out;
+    __asm__("rdrand %%eax; setc %%dl" : "=a"(out), "=d"(cf));
+    if(cf)
+      old = tmp;
+    else {
+      i--;
+      continue;
+    }
+    if(old != out)
+      return 1;
+  }
+
+  return 0;
+}

--- a/tests/inlineassemblytests/rdrand003.c
+++ b/tests/inlineassemblytests/rdrand003.c
@@ -1,0 +1,26 @@
+#include "cpuid.h"
+
+int main() {
+  unsigned long out = 0;
+  unsigned int i;
+  unsigned char cf;
+  unsigned long old = out;
+
+  if(!has_rdrand())
+    return 1;
+
+  for(i = 0; i < 32; i++) {
+    unsigned long tmp = out;
+    __asm__("rdrand %%rax; setc %%dl" : "=a"(out), "=d"(cf));
+    if(cf)
+      old = tmp;
+    else {
+      i--;
+      continue;
+    }
+    if(old != out)
+      return 1;
+  }
+
+  return 0;
+}

--- a/tests/inlineassemblytests/rdseed001.c
+++ b/tests/inlineassemblytests/rdseed001.c
@@ -1,0 +1,26 @@
+#include "cpuid.h"
+
+int main() {
+  unsigned short out = 0;
+  unsigned int i;
+  unsigned char cf;
+  unsigned short old = out;
+
+  if(!has_rdseed())
+    return 1;
+
+  for(i = 0; i < 4; i++) {
+    unsigned short tmp = out;
+    __asm__("rdseed %%ax; setc %%dl" : "=a"(out), "=d"(cf));
+    if(cf)
+      old = tmp;
+    else {
+      i--;
+      continue;
+    }
+    if(old != out)
+      return 1;
+  }
+
+  return 0;
+}

--- a/tests/inlineassemblytests/rdseed002.c
+++ b/tests/inlineassemblytests/rdseed002.c
@@ -1,0 +1,26 @@
+#include "cpuid.h"
+
+int main() {
+  unsigned int out = 0;
+  unsigned int i;
+  unsigned char cf;
+  unsigned int old = out;
+
+  if(!has_rdseed())
+    return 1;
+
+  for(i = 0; i < 2; i++) {
+    unsigned int tmp = out;
+    __asm__("rdseed %%eax; setc %%dl" : "=a"(out), "=d"(cf));
+    if(cf)
+      old = tmp;
+    else {
+      i--;
+      continue;
+    }
+    if(old != out)
+      return 1;
+  }
+
+  return 0;
+}

--- a/tests/inlineassemblytests/rdseed003.c
+++ b/tests/inlineassemblytests/rdseed003.c
@@ -1,0 +1,26 @@
+#include "cpuid.h"
+
+int main() {
+  unsigned int out = 0;
+  unsigned int i;
+  unsigned char cf;
+  unsigned int old = out;
+
+  if(!has_rdseed())
+    return 1;
+
+  for(i = 0; i < 2; i++) {
+    unsigned int tmp = out;
+    __asm__("rdseed %%rax; setc %%dl" : "=a"(out), "=d"(cf));
+    if(cf)
+      old = tmp;
+    else {
+      i--;
+      continue;
+    }
+    if(old != out)
+      return 1;
+  }
+
+  return 0;
+}

--- a/tests/inlineassemblytests/setc001.c
+++ b/tests/inlineassemblytests/setc001.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movl $0x42, %%eax; cmpl $0x24, %%eax; setc %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/setc002.c
+++ b/tests/inlineassemblytests/setc002.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movl $0x42, %%eax; cmpl $0x84, %%eax; setc %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/setc003.c
+++ b/tests/inlineassemblytests/setc003.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movl $0x42, %%eax; cmpl $0x42, %%eax; setc %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/setc004.c
+++ b/tests/inlineassemblytests/setc004.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movb $0xFE, %%al; cmpb $0xFF, %%al; setc %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/setc005.c
+++ b/tests/inlineassemblytests/setc005.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movb $0xFF, %%al; cmpb $0xFE, %%al; setc %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/setc006.c
+++ b/tests/inlineassemblytests/setc006.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movb $0xFF, %%al; cmpb $0x02, %%al; setc %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/setc007.c
+++ b/tests/inlineassemblytests/setc007.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movb $0x02, %%al; cmpb $0xFF, %%al; setc %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/seto001.c
+++ b/tests/inlineassemblytests/seto001.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movl $0x42, %%eax; cmpl $0x24, %%eax; seto %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/seto002.c
+++ b/tests/inlineassemblytests/seto002.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movl $0x42, %%eax; cmpl $0x84, %%eax; seto %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/seto003.c
+++ b/tests/inlineassemblytests/seto003.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movl $0x42, %%eax; cmpl $0x42, %%eax; seto %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/seto004.c
+++ b/tests/inlineassemblytests/seto004.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movb $0xFE, %%al; cmpb $0xFF, %%al; seto %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/seto005.c
+++ b/tests/inlineassemblytests/seto005.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movb $0xFF, %%al; cmpb $0xFE, %%al; seto %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/seto006.c
+++ b/tests/inlineassemblytests/seto006.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movb $0xFF, %%al; cmpb $0x02, %%al; seto %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/seto007.c
+++ b/tests/inlineassemblytests/seto007.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movb $0x02, %%al; cmpb $0xFF, %%al; seto %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/seto008.c
+++ b/tests/inlineassemblytests/seto008.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movb $0x7F, %%al; cmpb $0x7F, %%al; seto %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/seto009.c
+++ b/tests/inlineassemblytests/seto009.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movb $0x7F, %%al; cmpb $0x80, %%al; seto %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/seto010.c
+++ b/tests/inlineassemblytests/seto010.c
@@ -1,0 +1,5 @@
+int main() {
+  char out = 0x55;
+  __asm__("movb $0x80, %%al; cmpb $0x7F, %%al; seto %%al" : "=a"(out));
+  return out;
+}

--- a/tests/inlineassemblytests/xadd001.c
+++ b/tests/inlineassemblytests/xadd001.c
@@ -1,0 +1,8 @@
+int main() {
+  unsigned char arg1 = 0x12;
+  unsigned char arg2 = 0x34;
+  unsigned char out1 = 0;
+  unsigned char out2 = 0;
+  __asm__("xaddb %%al, %%cl" : "=a"(out1), "=c"(out2) : "a"(arg1), "c"(arg2));
+  return (out1 == 0x34) && (out2 == 0x46);
+}

--- a/tests/inlineassemblytests/xadd002.c
+++ b/tests/inlineassemblytests/xadd002.c
@@ -1,0 +1,8 @@
+int main() {
+  unsigned short arg1 = 0x1234;
+  unsigned short arg2 = 0x5678;
+  unsigned short out1 = 0;
+  unsigned short out2 = 0;
+  __asm__("xaddw %%ax, %%cx" : "=a"(out1), "=c"(out2) : "a"(arg1), "c"(arg2));
+  return (out1 == 0x5678) && (out2 == 0x68AC);
+}

--- a/tests/inlineassemblytests/xadd003.c
+++ b/tests/inlineassemblytests/xadd003.c
@@ -1,0 +1,8 @@
+int main() {
+  unsigned int arg1 = 0x12345678;
+  unsigned int arg2 = 0x9ABCDEF0;
+  unsigned int out1 = 0;
+  unsigned int out2 = 0;
+  __asm__("xaddl %%eax, %%ecx" : "=a"(out1), "=c"(out2) : "a"(arg1), "c"(arg2));
+  return (out1 == 0x9ABCDEF0) && (out2 == 0xACf13568);
+}

--- a/tests/inlineassemblytests/xadd004.c
+++ b/tests/inlineassemblytests/xadd004.c
@@ -1,0 +1,8 @@
+int main() {
+  unsigned long arg1 = 0x123456789ABCDEF0;
+  unsigned long arg2 = 0xFEDCBA9876543210;
+  unsigned long out1 = 0;
+  unsigned long out2 = 0;
+  __asm__("xaddq %%rax, %%rcx" : "=a"(out1), "=c"(out2) : "a"(arg1), "c"(arg2));
+  return (out1 == 0xFEDCBA9876543210) && (out2 == 0x1111111111111100);
+}

--- a/tests/inlineassemblytests/xchg001.c
+++ b/tests/inlineassemblytests/xchg001.c
@@ -1,0 +1,8 @@
+int main() {
+  unsigned char arg1 = 0x55;
+  unsigned char arg2 = 0xAA;
+  unsigned char out1 = 0;
+  unsigned char out2 = 0;
+  __asm__("xchgb %%al, %%cl" : "=a"(out1), "=c"(out2) : "a"(arg1), "c"(arg2));
+  return (out1 == 0xAA) && (out2 == 0x55);
+}

--- a/tests/inlineassemblytests/xchg002.c
+++ b/tests/inlineassemblytests/xchg002.c
@@ -1,0 +1,8 @@
+int main() {
+  unsigned short arg1 = 0x1234;
+  unsigned short arg2 = 0x5678;
+  unsigned short out1 = 0;
+  unsigned short out2 = 0;
+  __asm__("xchgw %%ax, %%cx" : "=a"(out1), "=c"(out2) : "a"(arg1), "c"(arg2));
+  return (out1 == 0x5678) && (out2 == 0x1234);
+}

--- a/tests/inlineassemblytests/xchg003.c
+++ b/tests/inlineassemblytests/xchg003.c
@@ -1,0 +1,8 @@
+int main() {
+  unsigned int arg1 = 0x12345678;
+  unsigned int arg2 = 0x87654321;
+  unsigned int out1 = 0;
+  unsigned int out2 = 0;
+  __asm__("xchgl %%eax, %%ecx" : "=a"(out1), "=c"(out2) : "a"(arg1), "c"(arg2));
+  return (out1 == 0x87654321) && (out2 == 0x12345678);
+}

--- a/tests/inlineassemblytests/xchg004.c
+++ b/tests/inlineassemblytests/xchg004.c
@@ -1,0 +1,6 @@
+int main() {
+  unsigned int arg = 0x1234;
+  unsigned int out = 0;
+  __asm__("xchgb %%al, %%ah" : "=a"(out) : "a"(arg));
+  return (out == 0x3412);
+}


### PR DESCRIPTION
New instructions:
- `push`
- `pop`
- `ud2`
- `set…`
- `rdrand`
- `rdseed`
- `lea`
- `xchg`
- `cmp`
- `cmpxchg`
- `xadd`
- `bsr`
- `bsf`
- `int 3`

Instructions with bugfixes:
- `imul`
- `idiv`
- `mul`
- `div`