### PR TITLE
Fix padding error in StructureType.

### DIFF
--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/StructureType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/StructureType.java
@@ -91,7 +91,7 @@ public final class StructureType extends AggregateType {
 
     @Override
     public int getAlignment(DataSpecConverter targetDataLayout) {
-        return getLargestAlignment(targetDataLayout);
+        return isPacked ? 1 : getLargestAlignment(targetDataLayout);
     }
 
     @Override
@@ -106,7 +106,7 @@ public final class StructureType extends AggregateType {
 
         int padding = 0;
         if (!isPacked && sumByte != 0) {
-            padding = Type.getPadding(sumByte, getLargestAlignment(targetDataLayout));
+            padding = Type.getPadding(sumByte, getAlignment(targetDataLayout));
         }
 
         return sumByte + padding;

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/StructureType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/StructureType.java
@@ -124,10 +124,10 @@ public final class StructureType extends AggregateType {
         int offset = 0;
         for (int i = 0; i < index; i++) {
             final Type elementType = types[i];
-            offset += elementType.getSize(targetDataLayout);
             if (!isPacked) {
                 offset += Type.getPadding(offset, elementType, targetDataLayout);
             }
+            offset += elementType.getSize(targetDataLayout);
         }
         if (!isPacked && getSize(targetDataLayout) > offset) {
             offset += Type.getPadding(offset, types[index], targetDataLayout);

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/struct/packed/packed-nested-padding.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/struct/packed/packed-nested-padding.c
@@ -1,0 +1,33 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+/* 
+ * Tests that the padding of the middle structure does not depend on the largest alignment
+ * of the packed inner structure
+*/
+
+struct innerStruct {
+	double d;
+	int i1;
+	double d1;
+	int i2;
+}__attribute__((packed));
+
+struct middleStruct {
+	struct innerStruct st;
+	int i;
+};
+
+struct outerStruct {
+	struct middleStruct st;
+	int i;
+	char c;
+};
+
+int main() {
+	struct outerStruct st = { {{0.1, 2, 0.3, 4}, 5}, 6, '7'};
+
+	int* addr = (int*)&(st.st);
+	printf("%d", *(addr + 7));
+}
+


### PR DESCRIPTION
The padding for a structure element should be calculated before the element's size is added to the offset.