### PR TITLE
Throw exception if no main method is found

### DIFF
--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/Runner.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/Runner.java
@@ -87,9 +87,6 @@ public final class Runner {
 
             LLVMParserResult parserResult = parseBitcodeFile(code, bytes, language, context);
             mainFunction = parserResult.getMainCallTarget();
-            if (mainFunction == null) {
-                mainFunction = Truffle.getRuntime().createCallTarget(RootNode.createConstantNode(0));
-            }
             handleParserResult(context, parserResult);
             if (context.getEnv().getOptions().get(SulongEngineOption.PARSE_ONLY)) {
                 return Truffle.getRuntime().createCallTarget(RootNode.createConstantNode(0));


### PR DESCRIPTION
LLVM's `lli` fails if there is no main method:
```sh
echo 'int f() { return 42; }' | clang -c -o - -emit-llvm -x c - | lli -
```
```
'main' function not found in module.
```

If a native binary is compiled with `clang`/`gcc`, a linking error occurs:
```
(.text+0x20): undefined reference to `main'
```