### PR TITLE
Fix Typo in Parameterattribute

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/attributes/Attribute.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/attributes/Attribute.java
@@ -84,7 +84,7 @@ public abstract class Attribute {
         SWIFTERROR,
         NORECURSE,
         INACCESSIBLEMEMONLY,
-        INACCESSIBLEMEMONLY_OR_ARGMEMONLY,
+        INACCESSIBLEMEM_OR_ARGMEMONLY,
         ALLOCSIZE,
         WRITEONLY,
         SPECULATABLE;


### PR DESCRIPTION
There is a little typo in one of the ParameterAttributes, causes wrong return values of the ```getIrString``` method. This was caused by a typo in to original documentation:

* Correct Spelling: https://llvm.org/docs/LangRef.html#function-attributes
* Incorrect Spelling: https://llvm.org/docs/BitCodeFormat.html#paramattr-grp-code-entry-record