### PR TITLE
Fix some bugs in the x86 fp80 implementation

### DIFF
--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/floating/LLVM80BitFloat.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/floating/LLVM80BitFloat.java
@@ -401,7 +401,9 @@ public final class LLVM80BitFloat {
                 return expDifference;
             }
         } else {
-            if (getSign()) {
+            if (isZero() && val.isZero()) {
+                return 0;
+            } else if (getSign()) {
                 return -1;
             } else {
                 return 1;

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/floating/LLVM80BitFloat.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/floating/LLVM80BitFloat.java
@@ -354,12 +354,12 @@ public final class LLVM80BitFloat {
         return isPositiveInfinity() || isNegativeInfinity();
     }
 
-    public boolean isQNaN() {
+    public boolean isSNaN() {
         // Checkstyle: stop magic number name check
         if (getExponent() == ALL_ONE_EXPONENT) {
-            if (!getBit(63, getFraction())) {
-                if (getBit(62, getFraction())) {
-                    return true;
+            if (getBit(63, getFraction())) {
+                if (!getBit(62, getFraction())) {
+                    return (getFraction() & 0x3FFFFFFF_FFFFFFFFL) != 0L;
                 }
             }
         }
@@ -367,8 +367,27 @@ public final class LLVM80BitFloat {
         return false;
     }
 
+    public boolean isQNaN() {
+        // Checkstyle: stop magic number name check
+        if (getExponent() == ALL_ONE_EXPONENT) {
+            if (getBit(63, getFraction())) {
+                if (getBit(62, getFraction())) {
+                    return true;
+                }
+            } else {
+                return true; // Handle Pseudo NaN as quiet NaN
+            }
+        }
+        // Checkstyle: resume magic number name check
+        return false;
+    }
+
+    public boolean isNaN() {
+        return isSNaN() || isQNaN();
+    }
+
     public boolean isOrdered() {
-        return !isQNaN();
+        return !isNaN();
     }
 
     int compareOrdered(LLVM80BitFloat val) {
@@ -488,7 +507,7 @@ public final class LLVM80BitFloat {
     // get value
 
     public byte getByteValue() {
-        if (isQNaN() || isInfinity()) {
+        if (isNaN() || isInfinity()) {
             return UNDEFINED_FLOAT_TO_BYTE_VALUE;
         } else {
             long value = getFractionAsLong();
@@ -497,7 +516,7 @@ public final class LLVM80BitFloat {
     }
 
     public short getShortValue() {
-        if (isQNaN() || isInfinity()) {
+        if (isNaN() || isInfinity()) {
             return UNDEFINED_FLOAT_TO_SHORT_VALUE;
         } else {
             long value = getFractionAsLong();
@@ -506,7 +525,7 @@ public final class LLVM80BitFloat {
     }
 
     public int getIntValue() {
-        if (isQNaN() || isInfinity()) {
+        if (isNaN() || isInfinity()) {
             return UNDEFINED_FLOAT_TO_INT_VALUE;
         }
         int value = (int) getFractionAsLong();
@@ -514,7 +533,7 @@ public final class LLVM80BitFloat {
     }
 
     public long getLongValue() {
-        if (isQNaN() || isInfinity()) {
+        if (isNaN() || isInfinity()) {
             return UNDEFINED_FLOAT_TO_LONG_VALUE;
         } else {
             long value = getFractionAsLong();
@@ -531,7 +550,7 @@ public final class LLVM80BitFloat {
             return FloatHelper.POSITIVE_INFINITY;
         } else if (isNegativeInfinity()) {
             return FloatHelper.NEGATIVE_INFINITY;
-        } else if (isQNaN()) {
+        } else if (isNaN()) {
             return FloatHelper.NaN;
         } else {
             int floatExponent = getUnbiasedExponent() + FLOAT_EXPONENT_BIAS;
@@ -553,7 +572,7 @@ public final class LLVM80BitFloat {
             return DoubleHelper.POSITIVE_INFINITY;
         } else if (isNegativeInfinity()) {
             return DoubleHelper.NEGATIVE_INFINITY;
-        } else if (isQNaN()) {
+        } else if (isNaN()) {
             return DoubleHelper.NaN;
         } else {
             int doubleExponent = getUnbiasedExponent() + DoubleHelper.DOUBLE_EXPONENT_BIAS;


### PR DESCRIPTION
I found some bugs with x86 fp80 handling:

* ```0.0 == -0.00``` was not evaluated correctly
* NaN check didn't worked and was incomplete

---

Problems were found and tested using  https://github.com/pointhi/java-llvm-ir-builder

Test can be executed with ```mx irbuilder-testgen38 float_compare```