### PR TITLE
Add missing cast instructions to the InlineAssembly parser

### DIFF
--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/InlineAssembly.atg
@@ -597,6 +597,10 @@ BinOp64<> =						(. String op; AsmOperand a, b; .)
   | "movzwq"
   )							(. op = t.val; .)
   Operand16<out a> "," Operand64<out b>			(. factory.createBinaryOperation(op, a, b); .)
+  |							(. String op; AsmOperand a, b; .)
+  ( "movslq"
+  )							(. op = t.val; .)
+  Operand32<out a> "," Operand64<out b>			(. factory.createBinaryOperation(op, a, b); .)
   .
 
 BinOp<> =						(. String op; AsmOperand a, b; .)

--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
@@ -202,7 +202,10 @@ import com.oracle.truffle.llvm.nodes.asm.support.LLVMAMD64WriteValueNodeGen;
 import com.oracle.truffle.llvm.nodes.asm.syscall.LLVMAMD64SyscallNodeGen;
 import com.oracle.truffle.llvm.nodes.cast.LLVMToAddressNodeGen;
 import com.oracle.truffle.llvm.nodes.cast.LLVMToI16NodeFactory.LLVMToI16NoZeroExtNodeGen;
+import com.oracle.truffle.llvm.nodes.cast.LLVMToI16NodeFactory.LLVMToI16ZeroExtNodeGen;
+import com.oracle.truffle.llvm.nodes.cast.LLVMToI1NodeGen.LLVMToI1NoZeroExtNodeGen;
 import com.oracle.truffle.llvm.nodes.cast.LLVMToI32NodeGen.LLVMToI32NoZeroExtNodeGen;
+import com.oracle.truffle.llvm.nodes.cast.LLVMToI32NodeGen.LLVMToI32ZeroExtNodeGen;
 import com.oracle.truffle.llvm.nodes.cast.LLVMToI64NodeGen.LLVMToI64NoZeroExtNodeGen;
 import com.oracle.truffle.llvm.nodes.cast.LLVMToI64NodeGen.LLVMToI64ZeroExtNodeGen;
 import com.oracle.truffle.llvm.nodes.cast.LLVMToI8NodeGen.LLVMToI8NoZeroExtNodeGen;
@@ -1322,17 +1325,45 @@ class AsmFactory {
             case "movq":
                 out = srcA;
                 break;
+            case "movsbw":
+                srcA = getOperandLoad(PrimitiveType.I8, a);
+                out = LLVMToI16NoZeroExtNodeGen.create(srcA);
+                break;
+            case "movsbl":
+                srcA = getOperandLoad(PrimitiveType.I8, a);
+                out = LLVMToI32NoZeroExtNodeGen.create(srcA);
+                break;
             case "movsbq":
                 srcA = getOperandLoad(PrimitiveType.I8, a);
                 out = LLVMToI64NoZeroExtNodeGen.create(srcA);
+                break;
+            case "movswl":
+                srcA = getOperandLoad(PrimitiveType.I16, a);
+                out = LLVMToI32NoZeroExtNodeGen.create(srcA);
                 break;
             case "movswq":
                 srcA = getOperandLoad(PrimitiveType.I16, a);
                 out = LLVMToI64NoZeroExtNodeGen.create(srcA);
                 break;
+            case "movslq":
+                srcA = getOperandLoad(PrimitiveType.I32, a);
+                out = LLVMToI64NoZeroExtNodeGen.create(srcA);
+                break;
+            case "movzbw":
+                srcA = getOperandLoad(PrimitiveType.I8, a);
+                out = LLVMToI16ZeroExtNodeGen.create(srcA);
+                break;
+            case "movzbl":
+                srcA = getOperandLoad(PrimitiveType.I8, a);
+                out = LLVMToI32ZeroExtNodeGen.create(srcA);
+                break;
             case "movzbq":
                 srcA = getOperandLoad(PrimitiveType.I8, a);
                 out = LLVMToI64ZeroExtNodeGen.create(srcA);
+                break;
+            case "movzwl":
+                srcA = getOperandLoad(PrimitiveType.I16, a);
+                out = LLVMToI32ZeroExtNodeGen.create(srcA);
                 break;
             case "movzwq":
                 srcA = getOperandLoad(PrimitiveType.I16, a);
@@ -1774,6 +1805,8 @@ class AsmFactory {
             return LLVMToAddressNodeGen.create(register, PrimitiveType.I64);
         }
         switch (((PrimitiveType) retType).getPrimitiveKind()) {
+            case I1:
+                return LLVMToI1NoZeroExtNodeGen.create(register);
             case I8:
                 return LLVMToI8NoZeroExtNodeGen.create(register);
             case I16:


### PR DESCRIPTION
Please note, there only exists a signed cast from 32bit to 64bit in x86 assembly. The unsigned counterpart has to be done in a different way.