### PR TITLE
Do not crash when an asm instruction has no flags specified

### DIFF
--- a/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
+++ b/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
@@ -289,6 +289,9 @@ class AsmFactory {
         int outIndex = 0;
 
         for (String token : tokens) {
+            if (token.isEmpty()) {
+                continue;
+            }
             boolean isTilde = false;
             boolean isInput = true;
             boolean isOutput = false;


### PR DESCRIPTION
FIX #795