### PR TITLE
Add some testcases for builtins, little bugfixes

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/c/LLVMCMathsIntrinsics.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/c/LLVMCMathsIntrinsics.java
@@ -141,6 +141,11 @@ public abstract class LLVMCMathsIntrinsics {
             return Math.abs(value);
         }
 
+        @Specialization
+        public LLVM80BitFloat executeIntrinsic(LLVM80BitFloat value) {
+            return value.abs();
+        }
+
         @Override
         public abstract SourceSection getSourceSection();
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
@@ -1624,6 +1624,7 @@ public class BasicNodeFactory implements NodeFactory {
                 return LLVMMemSetNodeGen.create(createMemSet(), args[1], args[2], args[3], args[4], args[5], sourceSection);
             case "@llvm.assume":
                 return LLVMAssumeNodeGen.create(args[1], sourceSection);
+            case "@llvm.clear_cache": // STUB
             case "@llvm.donothing":
                 return LLVMNoOpNodeGen.create(sourceSection);
             case "@llvm.prefetch":

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
@@ -1682,6 +1682,7 @@ public class BasicNodeFactory implements NodeFactory {
                 return LLVMPowNodeGen.create(args[1], args[2], sourceSection);
             case "@llvm.fabs.f32":
             case "@llvm.fabs.f64":
+            case "@llvm.fabs.f80":
                 return LLVMFAbsNodeGen.create(args[1], sourceSection);
             case "@llvm.returnaddress":
                 return LLVMReturnAddressNodeGen.create(args[1], sourceSection);

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/metadata/MDLexicalBlockFile.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/metadata/MDLexicalBlockFile.java
@@ -54,6 +54,10 @@ public final class MDLexicalBlockFile implements MDBaseNode {
         return file;
     }
 
+    public MDBaseNode getScope() {
+        return scope;
+    }
+
     public long getDiscriminator() {
         return discriminator;
     }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/floating/LLVM80BitFloat.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/floating/LLVM80BitFloat.java
@@ -342,6 +342,10 @@ public final class LLVM80BitFloat {
         return fromDouble(Math.pow(getDoubleValue(), right.getDoubleValue()));
     }
 
+    public LLVM80BitFloat abs() {
+        return LLVM80BitFloat.fromRawValues(false, biasedExponent, fraction);
+    }
+
     public boolean isPositiveInfinity() {
         return this.equals(POSITIVE_INFINITY);
     }

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin__clear_cache.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin__clear_cache.c
@@ -1,0 +1,5 @@
+int main() {
+  char a[100];
+  __builtin___clear_cache(a, a + 100);
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_abs.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_abs.c
@@ -1,0 +1,11 @@
+int main() {
+  volatile int a = 123456;
+  if(__builtin_abs(a) != 123456) {
+    return 1;
+  }
+  volatile int b = -123456;
+  if(__builtin_abs(b) != 123456) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_alloca.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_alloca.c
@@ -1,0 +1,12 @@
+int main() {
+  int *a [2];
+  {
+    a[0] = __builtin_alloca (sizeof(int) * 8);
+    a[0][0] = 2;
+  }
+  {
+    a[1] = __builtin_alloca (sizeof(int) * 8);
+    a[1][0] = 5;
+  }
+  return a[0][0] + a[1][0];
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_bswap16.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_bswap16.c
@@ -1,0 +1,9 @@
+int main() {
+  volatile short a = 0x0123;
+#ifdef __clang__ // TODO: dragonegg uses incompatibe builtins!
+  if(__builtin_bswap16(a) != 0x2301) {
+    return 1;
+  }
+#endif
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_bswap32.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_bswap32.c
@@ -1,0 +1,7 @@
+int main() {
+  volatile int a = 0x01234567;
+  if(__builtin_bswap32(a) != 0x67452301) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_bswap64.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_bswap64.c
@@ -1,0 +1,7 @@
+int main() {
+  volatile long a = 0x0123456789ABCDEFL;
+  if(__builtin_bswap64(a) != 0xEFCDAB8967452301L) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_clz.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_clz.c
@@ -1,0 +1,15 @@
+int main() {
+  volatile int a = 0x00000001;
+  if(__builtin_clz(a) != sizeof(int)*8-1) {
+    return 1;
+  }
+  volatile int b = 0x6000beef;
+  if(__builtin_clz(b) != sizeof(int)*8-31) {
+    return 1;
+  }
+  volatile int c = 0x8abc0000;
+  if(__builtin_clz(c) != sizeof(int)*8-32) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_clzl.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_clzl.c
@@ -1,0 +1,23 @@
+int main() {
+  volatile long a = 0x0000000000000001L;
+  if(__builtin_clzl(a) != sizeof(long long)*8-1) {
+    return 1;
+  }
+  volatile long b = 0x000000006000beefL;
+  if(__builtin_clzl(b) != sizeof(long long)*8-31) {
+    return 1;
+  }
+  volatile long c = 0x000000008abc0000L;
+  if(__builtin_clzl(c) != sizeof(long long)*8-32) {
+    return 1;
+  }
+  volatile long d = 0x6000beef00000000L;
+  if(__builtin_clzl(d) != sizeof(long long)*8-63) {
+    return 1;
+  }
+  volatile long e = 0x8abc000000000000L;
+  if(__builtin_clzl(e) != sizeof(long long)*8-64) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_clzll.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_clzll.c
@@ -1,0 +1,23 @@
+int main() {
+  volatile long long a = 0x0000000000000001L;
+  if(__builtin_clzll(a) != sizeof(long long)*8-1) {
+    return 1;
+  }
+  volatile long long b = 0x000000006000beefL;
+  if(__builtin_clzll(b) != sizeof(long long)*8-31) {
+    return 1;
+  }
+  volatile long long c = 0x000000008abc0000L;
+  if(__builtin_clzll(c) != sizeof(long long)*8-32) {
+    return 1;
+  }
+  volatile long long d = 0x6000beef00000000L;
+  if(__builtin_clzll(d) != sizeof(long long)*8-63) {
+    return 1;
+  }
+  volatile long long e = 0x8abc000000000000L;
+  if(__builtin_clzll(e) != sizeof(long long)*8-64) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_constant_p.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_constant_p.c
@@ -1,0 +1,13 @@
+volatile int a = 1;
+
+int main() {
+  int res = 0;
+  res += __builtin_constant_p("asdf") ? 1 : 0;
+  res += __builtin_constant_p(12.8) ? 2 : 0;
+  res += __builtin_constant_p(0xffff) ? 4 : 0;
+  res += __builtin_constant_p(2 + 5) ? 8 : 0;
+
+  res += __builtin_constant_p(a) ? 16 : 0;
+
+  return res;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_copysign.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_copysign.c
@@ -1,0 +1,27 @@
+int main() {
+  volatile float fPos = 1.f;
+  volatile float fNeg = -2.f;
+  if(__builtin_copysign(fPos, fNeg) != -1.f) {
+    return 1;
+  }
+  if(__builtin_copysign(fNeg, fPos) != 2.f) {
+    return 1;
+  }
+  volatile double dPos = 1.;
+  volatile double dNeg = -2.;
+  if(__builtin_copysign(dPos, dNeg) != -1.) {
+    return 1;
+  }
+  if(__builtin_copysign(dNeg, dPos) != 2.) {
+    return 1;
+  }
+  volatile long double lPos = 1.;
+  volatile long double lNeg = -2.;
+  if(__builtin_copysign(lPos, lNeg) != -1.) {
+    return 1;
+  }
+  if(__builtin_copysign(lNeg, lPos) != 2.) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_ctz.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_ctz.c
@@ -1,0 +1,15 @@
+int main() {
+  volatile int a = 0x00000001;
+  if(__builtin_ctz(a) != 0) {
+    return 1;
+  }
+  volatile int b = 0x00000002;
+  if(__builtin_ctz(b) != 1) {
+    return 1;
+  }
+  volatile int c = 0x80000000;
+  if(__builtin_ctz(c) != 31) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_ctzl.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_ctzl.c
@@ -1,0 +1,23 @@
+int main() {
+  volatile long a = 0x0000000000000001L;
+  if(__builtin_ctzl(a) != 0) {
+    return 1;
+  }
+  volatile long b = 0x0000000000000002;
+  if(__builtin_ctzl(b) != 1) {
+    return 1;
+  }
+  volatile long c = 0x0000000080000000;
+  if(__builtin_ctzl(c) != 31) {
+    return 1;
+  }
+  volatile long d = 0x0000000100000000;
+  if(__builtin_ctzl(d) != 32) {
+    return 1;
+  }
+  volatile long e = 0x8000000000000000;
+  if(__builtin_ctzl(e) != 63) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_ctzll.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_ctzll.c
@@ -1,0 +1,23 @@
+int main() {
+  volatile long long a = 0x0000000000000001L;
+  if(__builtin_ctzll(a) != 0) {
+    return 1;
+  }
+  volatile long long b = 0x0000000000000002;
+  if(__builtin_ctzll(b) != 1) {
+    return 1;
+  }
+  volatile long long c = 0x0000000080000000;
+  if(__builtin_ctzll(c) != 31) {
+    return 1;
+  }
+  volatile long long d = 0x0000000100000000;
+  if(__builtin_ctzll(d) != 32) {
+    return 1;
+  }
+  volatile long long e = 0x8000000000000000;
+  if(__builtin_ctzll(e) != 63) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_expect.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_expect.c
@@ -1,0 +1,9 @@
+int main() {
+  int res = 0;
+  for(int i = 0; i < 10; i++) {
+    if(__builtin_expect(i % 2, 0)) {
+      res += i;
+    }
+  }
+  return res;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_fabs.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_fabs.c
@@ -1,18 +1,18 @@
 int main() {
-  volatile float a = 0.125;
+  volatile double a = 0.125;
   if(__builtin_fabs(a) != 0.125) {
     return 1;
   }
-  volatile float b = -0.125;
+  volatile double b = -0.125;
   if(__builtin_fabs(b) != 0.125) {
     return 1;
   }
-  volatile float c = 0.;
-  if(__builtin_fabs(c) != 0) {
+  volatile double c = 0.;
+  if(__builtin_fabs(c) != 0.) {
     return 1;
   }
-  volatile float d = -0.;
-  if(__builtin_fabs(d) != 0) {
+  volatile double d = -0.;
+  if(__builtin_fabs(d) != 0.) {
     return 1;
   }
   return 0;

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_fabs.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_fabs.c
@@ -1,0 +1,19 @@
+int main() {
+  volatile float a = 0.125;
+  if(__builtin_fabs(a) != 0.125) {
+    return 1;
+  }
+  volatile float b = -0.125;
+  if(__builtin_fabs(b) != 0.125) {
+    return 1;
+  }
+  volatile float c = 0.;
+  if(__builtin_fabs(c) != 0) {
+    return 1;
+  }
+  volatile float d = -0.;
+  if(__builtin_fabs(d) != 0) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_fabsf.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_fabsf.c
@@ -1,0 +1,19 @@
+int main() {
+  volatile float a = 0.125f;
+  if(__builtin_fabs(a) != 0.125f) {
+    return 1;
+  }
+  volatile float b = -0.125f;
+  if(__builtin_fabs(b) != 0.125f) {
+    return 1;
+  }
+  volatile float c = 0.f;
+  if(__builtin_fabs(c) != 0.f) {
+    return 1;
+  }
+  volatile float d = -0.f;
+  if(__builtin_fabs(d) != 0.f) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_fabsl.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_fabsl.c
@@ -1,0 +1,21 @@
+int main() {
+#ifdef __clang__ // TODO: dragonegg uses native calls which do not work with X86_FP80
+  volatile long double a = 0.125;
+  if(__builtin_fabsl(a) != 0.125) {
+    return 1;
+  }
+  volatile long double b = -0.125;
+  if(__builtin_fabsl(b) != 0.125) {
+    return 1;
+  }
+  volatile long double c = 0.;
+  if(__builtin_fabsl(c) != 0.) {
+    return 1;
+  }
+  volatile long double d = -0.;
+  if(__builtin_fabsl(d) != 0.) {
+    return 1;
+  }
+#endif
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_ffs.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_ffs.c
@@ -1,0 +1,19 @@
+int main() {
+  volatile int a = 0x00000001;
+  if(__builtin_ffs(a) != 1) {
+    return 1;
+  }
+  volatile int b = 0x6000beef;
+  if(__builtin_ffs(b) != 1) {
+    return 1;
+  }
+  volatile int c = 0x8abc0000;
+  if(__builtin_ffs(c) != 19) {
+    return 1;
+  }
+  volatile int d = 0x00000000;
+  if(__builtin_ffs(d) != 0) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_ffsl.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_ffsl.c
@@ -1,0 +1,23 @@
+int main() {
+  volatile long a = 0x0000000000000001L;
+  if(__builtin_ffsl(a) != 1) {
+    return 1;
+  }
+  volatile long b = 0x000000006000beefL;
+  if(__builtin_ffsl(b) != 1) {
+    return 1;
+  }
+  volatile long c = 0x000000008abc0000L;
+  if(__builtin_ffsl(c) != 19) {
+    return 1;
+  }
+  volatile long d = 0x0000010000000000L;
+  if(__builtin_ffsl(d) != 41) {
+    return 1;
+  }
+  volatile long e = 0x0000000000000000L;
+  if(__builtin_ffsl(e) != 0) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_ffsll.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_ffsll.c
@@ -1,0 +1,23 @@
+int main() {
+  volatile long long a = 0x0000000000000001L;
+  if(__builtin_ffsll(a) != 1) {
+    return 1;
+  }
+  volatile long long b = 0x000000006000beefL;
+  if(__builtin_ffsll(b) != 1) {
+    return 1;
+  }
+  volatile long long c = 0x000000008abc0000L;
+  if(__builtin_ffsll(c) != 19) {
+    return 1;
+  }
+  volatile long long d = 0x0000010000000000L;
+  if(__builtin_ffsll(d) != 41) {
+    return 1;
+  }
+  volatile long long e = 0x0000000000000000L;
+  if(__builtin_ffsll(e) != 0) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_fpclassify.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_fpclassify.c
@@ -1,0 +1,53 @@
+int main() {
+  volatile float fNan = __builtin_nanf("");
+  if(__builtin_fpclassify(11,12,13,14,15, fNan) != 11) {
+    return 1;
+  }
+  volatile float fInf = __builtin_inff();
+  if(__builtin_fpclassify(11,12,13,14,15, fInf) != 12) {
+    return 1;
+  }
+  volatile float fOne = 1.f;
+  if(__builtin_fpclassify(11,12,13,14,15, fOne) != 13) {
+    return 1;
+  }
+  volatile float fZero = 0.f;
+  if(__builtin_fpclassify(11,12,13,14,15, fZero) != 15) {
+    return 1;
+  }
+  volatile double dNan = __builtin_nan("");
+  if(__builtin_fpclassify(11,12,13,14,15, dNan) != 11) {
+    return 1;
+  }
+  volatile double dInf = __builtin_inf();
+  if(__builtin_fpclassify(11,12,13,14,15, dInf) != 12) {
+    return 1;
+  }
+  volatile double dOne = 1.;
+  if(__builtin_fpclassify(11,12,13,14,15, dOne) != 13) {
+    return 1;
+  }
+  volatile double dZero = 0.;
+  if(__builtin_fpclassify(11,12,13,14,15, dZero) != 15) {
+    return 1;
+  }
+#ifdef __clang__ // TODO: dragonegg uses native calls which do not work with X86_FP80
+  volatile long double lNan = __builtin_nanl("");
+  if(__builtin_fpclassify(11,12,13,14,15, lNan) != 11) {
+    return 1;
+  }
+  volatile long double lInf = __builtin_infl();
+  if(__builtin_fpclassify(11,12,13,14,15, lInf) != 12) {
+    return 1;
+  }
+  volatile long double lOne = 1.;
+  if(__builtin_fpclassify(11,12,13,14,15, lOne) != 13) {
+    return 1;
+  }
+  volatile long double lZero = 0.;
+  if(__builtin_fpclassify(11,12,13,14,15, lZero) != 15) {
+    return 1;
+  }
+#endif
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isfinite.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isfinite.c
@@ -1,0 +1,43 @@
+int main() {
+  volatile float a = __builtin_nanf("");
+  if(__builtin_isfinite(a)) {
+    return 1;
+  }
+  volatile float b = __builtin_inff();
+  if(__builtin_isfinite(b)) {
+    return 1;
+  }
+  volatile double c = __builtin_nan("");
+  if(__builtin_isfinite(c)) {
+    return 1;
+  }
+  volatile double d = __builtin_inf();
+  if(__builtin_isfinite(d)) {
+    return 1;
+  }
+#ifdef __clang__ // TODO: dragonegg uses native calls which do not work with X86_FP80
+  volatile long double e = __builtin_nanl("");
+  if(__builtin_isfinite(e)) {
+    return 1;
+  }
+  volatile long double f = __builtin_infl();
+  if(__builtin_isfinite(f)) {
+    return 1;
+  }
+#endif
+  volatile float g = 0;
+  if(!__builtin_isfinite(g)) {
+    return 1;
+  }
+  volatile double h = 0;
+  if(!__builtin_isfinite(h)) {
+    return 1;
+  }
+#ifdef __clang__ // TODO: dragonegg uses native calls which do not work with X86_FP80
+  volatile long double i = 0;
+  if(!__builtin_isfinite(i)) {
+    return 1;
+  }
+#endif
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isgreater.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isgreater.c
@@ -1,0 +1,22 @@
+int main() {
+  volatile float pos1 = 1.;
+  volatile float neg1 = -1.;
+  volatile float posZero = 0.;
+  volatile float negZero = -0.;
+  if(__builtin_isgreater(neg1, neg1) != 0) {
+    return 1;
+  }
+  if(__builtin_isgreater(posZero, negZero) != 0) {
+    return 1;
+  }
+  if(__builtin_isgreater(pos1, pos1) != 0) {
+    return 1;
+  }
+  if(__builtin_isgreater(neg1, pos1) != 0) {
+    return 1;
+  }
+  if(__builtin_isgreater(pos1, neg1) == 0) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isgreaterequal.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isgreaterequal.c
@@ -1,0 +1,22 @@
+int main() {
+  volatile float pos1 = 1.;
+  volatile float neg1 = -1.;
+  volatile float posZero = 0.;
+  volatile float negZero = -0.;
+  if(__builtin_isgreaterequal(neg1, neg1) == 0) {
+    return 1;
+  }
+  if(__builtin_isgreaterequal(posZero, negZero) == 0) {
+    return 1;
+  }
+  if(__builtin_isgreaterequal(pos1, pos1) == 0) {
+    return 1;
+  }
+  if(__builtin_isgreaterequal(neg1, pos1) != 0) {
+    return 1;
+  }
+  if(__builtin_isgreaterequal(pos1, neg1) == 0) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isinf.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isinf.c
@@ -1,0 +1,31 @@
+int main() {
+  volatile float a = __builtin_inff();
+  if(!__builtin_isinf(a)) {
+    return 1;
+  }
+  volatile double b = __builtin_inf();
+  if(!__builtin_isinf(b)) {
+    return 1;
+  }
+#ifdef __clang__ // TODO: dragonegg uses native calls which do not work with X86_FP80
+  volatile long double c = __builtin_infl();
+  if(!__builtin_isinf(c)) {
+    return 1;
+  }
+#endif
+  volatile float d = __builtin_nanf("");
+  if(__builtin_isinf(d)) {
+    return 1;
+  }
+  volatile double e = __builtin_nan("");
+  if(__builtin_isinf(e)) {
+    return 1;
+  }
+#ifdef __clang__ // TODO: dragonegg uses native calls which do not work with X86_FP80
+  volatile long double f = __builtin_nanl("");
+  if(__builtin_isinf(f)) {
+    return 1;
+  }
+#endif
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isless.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isless.c
@@ -1,0 +1,22 @@
+int main() {
+  volatile float pos1 = 1.;
+  volatile float neg1 = -1.;
+  volatile float posZero = 0.;
+  volatile float negZero = -0.;
+  if(__builtin_isless(neg1, neg1) != 0) {
+    return 1;
+  }
+  if(__builtin_isless(posZero, negZero) != 0) {
+    return 1;
+  }
+  if(__builtin_isless(pos1, pos1) != 0) {
+    return 1;
+  }
+  if(__builtin_isless(neg1, pos1) == 0) {
+    return 1;
+  }
+  if(__builtin_isless(pos1, neg1) != 0) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_islessequal.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_islessequal.c
@@ -1,0 +1,22 @@
+int main() {
+  volatile float pos1 = 1.;
+  volatile float neg1 = -1.;
+  volatile float posZero = 0.;
+  volatile float negZero = -0.;
+  if(__builtin_islessequal(neg1, neg1) == 0) {
+    return 1;
+  }
+  if(__builtin_islessequal(posZero, negZero) == 0) {
+    return 1;
+  }
+  if(__builtin_islessequal(pos1, pos1) == 0) {
+    return 1;
+  }
+  if(__builtin_islessequal(neg1, pos1) == 0) {
+    return 1;
+  }
+  if(__builtin_islessequal(pos1, neg1) != 0) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_islessgreater.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_islessgreater.c
@@ -1,0 +1,22 @@
+int main() {
+  volatile float pos1 = 1.;
+  volatile float neg1 = -1.;
+  volatile float posZero = 0.;
+  volatile float negZero = -0.;
+  if(__builtin_islessgreater(neg1, neg1) != 0) {
+    return 1;
+  }
+  if(__builtin_islessgreater(posZero, negZero) != 0) {
+    return 1;
+  }
+  if(__builtin_islessgreater(pos1, pos1) != 0) {
+    return 1;
+  }
+  if(__builtin_islessgreater(neg1, pos1) == 0) {
+    return 1;
+  }
+  if(__builtin_islessgreater(pos1, neg1) == 0) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isnan.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isnan.c
@@ -1,0 +1,39 @@
+int main() {
+  volatile float a = __builtin_nanf("");
+  if(!__builtin_isnan(a)) {
+    return 1;
+  }
+  volatile float b = __builtin_nansf("");
+  if(!__builtin_isnan(b)) {
+    return 1;
+  }
+  volatile double c = __builtin_nan("");
+  if(!__builtin_isnan(c)) {
+    return 1;
+  }
+  volatile double d = __builtin_nans("");
+  if(!__builtin_isnan(d)) {
+    return 1;
+  }
+  volatile long double e = __builtin_nanl("");
+  if(!__builtin_isnan(e)) {
+    return 1;
+  }
+  volatile long double f = __builtin_nansl("");
+  if(!__builtin_isnan(f)) {
+    return 1;
+  }
+  volatile float g = 0;
+  if(__builtin_isnan(g)) {
+    return 1;
+  }
+  volatile double h = 0;
+  if(__builtin_isnan(h)) {
+    return 1;
+  }
+  volatile long double i = 0;
+  if(__builtin_isnan(i)) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isnormal.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isnormal.c
@@ -1,0 +1,51 @@
+int main() {
+  volatile float fNan = __builtin_nanf("");
+  if(__builtin_isnormal(fNan)) {
+    return 1;
+  }
+  volatile float fInf = __builtin_inff();
+  if(__builtin_isnormal(fInf)) {
+    return 1;
+  }
+  volatile float fZero = 0.f;
+  if(__builtin_isnormal(fZero)) {
+    return 1;
+  }
+  volatile float fOne = 1.f;
+  if(!__builtin_isnormal(fOne)) {
+    return 1;
+  }
+  volatile double dNan = __builtin_nan("");
+  if(__builtin_isnormal(dNan)) {
+    return 1;
+  }
+  volatile double dInf = __builtin_inf();
+  if(__builtin_isnormal(dInf)) {
+    return 1;
+  }
+  volatile double dZero = 0.;
+  if(__builtin_isnormal(dZero)) {
+    return 1;
+  }
+  volatile double dOne = 1.;
+  if(!__builtin_isnormal(dOne)) {
+    return 1;
+  }
+  volatile double lNan = __builtin_nanl("");
+  if(__builtin_isnormal(lNan)) {
+    return 1;
+  }
+  volatile double lInf = __builtin_infl();
+  if(__builtin_isnormal(lInf)) {
+    return 1;
+  }
+  volatile double lZero = 0.;
+  if(__builtin_isnormal(lZero)) {
+    return 1;
+  }
+  volatile double lOne = 1.;
+  if(!__builtin_isnormal(lOne)) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isunordered.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_isunordered.c
@@ -1,0 +1,23 @@
+int main() {
+  volatile float pos1 = 1.;
+  volatile float neg1 = -1.;
+  volatile float posZero = 0.;
+  volatile float negZero = -0.;
+  volatile float nan = __builtin_nanf("");
+  if(__builtin_isunordered(neg1, neg1) != 0) {
+    return 1;
+  }
+  if(__builtin_isunordered(posZero, negZero) != 0) {
+    return 1;
+  }
+  if(__builtin_isunordered(pos1, nan) == 0) {
+    return 1;
+  }
+  if(__builtin_isunordered(nan, pos1) == 0) {
+    return 1;
+  }
+  if(__builtin_isunordered(nan, nan) == 0) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_memcmp.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_memcmp.c
@@ -1,0 +1,15 @@
+int main() {
+  unsigned int a[10] = {0xFFFFFFFF};
+  unsigned int b[10] = {0xFFFFFFFF};
+  unsigned int c[10] = {0xFFFFFFFE};
+  if(__builtin_memcmp(&a, &a, sizeof(a))) {
+    return 1;
+  }
+  if(__builtin_memcmp(&a, &b, sizeof(a))) {
+    return 1;
+  }
+  if(!__builtin_memcmp(&a, &c, sizeof(a))) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_memcpy.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_memcpy.c
@@ -1,0 +1,6 @@
+int main() {
+  unsigned int a = 0x11223344;
+  unsigned int b = 0;;
+  __builtin_memcpy(&a, &b, sizeof(a));
+  return a != b;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_memmove.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_memmove.c
@@ -1,6 +1,6 @@
 int main() {
   unsigned int a = 0x11223344;
   unsigned int b = 0;
-  __builtin_memcpy(&a, &b, sizeof(a));
+  __builtin_memmove(&a, &b, sizeof(a));
   return a != b;
 }

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_memset.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_memset.c
@@ -1,0 +1,10 @@
+int main() {
+  unsigned int a[10] = {0xFFFFFFFF};
+  __builtin_memset(&a, 0, sizeof(a));
+  for(int i = 0; i < 10; i++) {
+    if(a[i] != 0) {
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_offsetof.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_offsetof.c
@@ -1,0 +1,33 @@
+struct point {
+    short x;
+    int y;
+    long z;
+};
+
+struct __attribute__((__packed__)) pointPacked {
+    short x;
+    int y;
+    long z;
+};
+
+int main() {
+  if(__builtin_offsetof(struct point, x) != 0) {
+    return 1;
+  }
+  if(__builtin_offsetof(struct point, y) != 4) {
+    return 1;
+  }
+  if(__builtin_offsetof(struct point, z) != 8) {
+    return 1;
+  }
+  if(__builtin_offsetof(struct pointPacked, x) != 0) {
+    return 1;
+  }
+  if(__builtin_offsetof(struct pointPacked, y) != 2) {
+    return 1;
+  }
+  if(__builtin_offsetof(struct pointPacked, z) != 6) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_popcount.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_popcount.c
@@ -1,0 +1,15 @@
+int main() {
+  volatile int a = 0x00000000;
+  if(__builtin_popcount(a) != 0) {
+    return 1;
+  }
+  volatile int b = 0x12345678;
+  if(__builtin_popcount(b) != 13) {
+    return 1;
+  }
+  volatile int c = 0xFFFFFFFF;
+  if(__builtin_popcount(c) != 32) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_popcountl.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_popcountl.c
@@ -1,0 +1,23 @@
+int main() {
+  volatile long a = 0x0000000000000000;
+  if(__builtin_popcountl(a) != 0) {
+    return 1;
+  }
+  volatile long b = 0x0000000012345678;
+  if(__builtin_popcountl(b) != 13) {
+    return 1;
+  }
+  volatile long c = 0x00000000FFFFFFFF;
+  if(__builtin_popcountl(c) != 32) {
+    return 1;
+  }
+  volatile long d = 0x0123456789ABCDEF;
+  if(__builtin_popcountl(d) != 32) {
+    return 1;
+  }
+  volatile long e = 0xFFFFFFFFFFFFFFFF;
+  if(__builtin_popcountl(e) != 64) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_popcountll.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_popcountll.c
@@ -1,0 +1,23 @@
+int main() {
+  volatile long long a = 0x0000000000000000;
+  if(__builtin_popcountll(a) != 0) {
+    return 1;
+  }
+  volatile long long b = 0x0000000012345678;
+  if(__builtin_popcountll(b) != 13) {
+    return 1;
+  }
+  volatile long long c = 0x00000000FFFFFFFF;
+  if(__builtin_popcountll(c) != 32) {
+    return 1;
+  }
+  volatile long long d = 0x0123456789ABCDEF;
+  if(__builtin_popcountll(d) != 32) {
+    return 1;
+  }
+  volatile long long e = 0xFFFFFFFFFFFFFFFF;
+  if(__builtin_popcountll(e) != 64) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_prefetch.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_prefetch.c
@@ -1,0 +1,9 @@
+int main() {
+  int a[100], b[100];
+  for (int i = 0; i < 100; i++) {
+    a[i] = a[i] + b[i];
+    __builtin_prefetch (&a[i+1], 1, 1);
+    __builtin_prefetch (&b[i+1], 0, 1);
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_shufflevector.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_shufflevector.c
@@ -1,0 +1,18 @@
+typedef int vec4 __attribute__((vector_size(16)));
+
+int main() {
+#ifdef __clang__ // TODO: dragonegg uses incompatibe builtins!
+  volatile vec4 v1 = { -1, 8, 2, -5 };
+
+  volatile vec4 v3 =__builtin_shufflevector(v1, v1, 3, 2, 1, 0);
+  if(v3[0] != -5 || v3[1] != 2 || v3[2] != 8 || v3[3] != -1) {
+    return 1;
+  }
+
+  volatile vec4 v4 =__builtin_shufflevector(v1, v1, 0, 0, 0, 0);
+  if(v4[0] != -1 || v4[1] != -1 || v4[2] != -1 || v4[3] != -1) {
+    return 1;
+  }
+#endif
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_signbit.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_signbit.c
@@ -1,0 +1,29 @@
+int main() {
+#ifdef __clang__ // TODO: dragonegg uses incompatibe builtins!
+  volatile float a = 1.;
+  if(__builtin_signbit(a)) {
+    return 1;
+  }
+  volatile float b = -1.;
+  if(!__builtin_signbit(b)) {
+    return 1;
+  }
+  volatile double c = 1.;
+  if(__builtin_signbit(c)) {
+    return 1;
+  }
+  volatile double d = -1.;
+  if(!__builtin_signbit(d)) {
+    return 1;
+  }
+  volatile long double e = 1.;
+  if(__builtin_signbit(e)) {
+    return 1;
+  }
+  volatile long double f = -1.;
+  if(!__builtin_signbit(f)) {
+    return 1;
+  }
+#endif
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_signbitf.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_signbitf.c
@@ -1,0 +1,13 @@
+int main() {
+#ifdef __clang__ // TODO: dragonegg uses incompatibe builtins!
+  volatile float a = 1.;
+  if(__builtin_signbitf(a)) {
+    return 1;
+  }
+  volatile float b = -1.;
+  if(!__builtin_signbitf(b)) {
+    return 1;
+  }
+#endif
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_signbitl.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_signbitl.c
@@ -1,0 +1,13 @@
+int main() {
+#ifdef __clang__ // TODO: dragonegg uses incompatibe builtins!
+  volatile long double a = 1.;
+  if(__builtin_signbitl(a)) {
+    return 1;
+  }
+  volatile long double b = -1.;
+  if(!__builtin_signbitl(b)) {
+    return 1;
+  }
+#endif
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_sqrtf.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_sqrtf.c
@@ -1,0 +1,19 @@
+int main() {
+  volatile float a = 0;
+  if(__builtin_sqrtf(a) != 0) {
+    return 1;
+  }
+  volatile float b = 4;
+  if(__builtin_sqrtf(b) != 2) {
+    return 1;
+  }
+  volatile float c = 9;
+  if(__builtin_sqrtf(c) != 3) {
+    return 1;
+  }
+  volatile float d = 100;
+  if(__builtin_sqrtf(d) != 10) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_strcpy.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_strcpy.c
@@ -1,0 +1,19 @@
+int main() {
+  volatile char dst[100];
+  volatile char* a = "";
+  __builtin_strcpy((char*)dst, (char*)a);
+  if(dst[0] != '\0') {
+    return 1;
+  }
+  volatile char* b = "asdf";
+  __builtin_strcpy((char*)dst, (char*)b);
+  if(dst[0] != 'a' || dst[4] != '\0') {
+    return 1;
+  }
+  volatile char* c = "asdf\0asdf";
+  __builtin_strcpy((char*)dst, (char*)c);
+  if(dst[0] != 'a' || dst[4] != '\0') {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_strlen.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_strlen.c
@@ -1,0 +1,19 @@
+int main() {
+  volatile char* a = "";
+  if(__builtin_strlen((char*)a) != 0) {
+    return 1;
+  }
+  volatile char* b = "asdf";
+  if(__builtin_strlen((char*)b) != 4) {
+    return 1;
+  }
+  volatile char* c = "asdf\0asdf";
+  if(__builtin_strlen((char*)c) != 4) {
+    return 1;
+  }
+  volatile char* d = "Hello World\n";
+  if(__builtin_strlen((char*)d) != 12) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_unreachable.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_unreachable.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+
+void exit_application() {
+  exit(11);
+}
+
+int main() {
+  exit_application();
+  __builtin_unreachable();
+}

--- a/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_va_list.c
+++ b/tests/com.oracle.truffle.llvm.tests.sulong/c/builtin_gcc/__builtin_va_list.c
@@ -1,0 +1,32 @@
+#include <stdarg.h>
+
+struct _point {
+  long x;
+  long y;
+  long z;
+};
+
+int foo(int x, ...)
+{
+  __builtin_va_list argp;
+
+  __builtin_va_start(argp, x);
+
+  struct _point res1 = __builtin_va_arg(argp, struct _point);
+
+  int result = res1.x + res1.y + res1.z;
+
+  res1.x = 0;
+  res1.y = 0;
+  res1.z = 0;
+
+  __builtin_va_end(argp);
+
+  return result;
+}
+
+int main() {
+  struct _point p = {19L, 13L, 9L};
+
+  return foo(2, p) + foo(2, p);
+}


### PR DESCRIPTION
With help of @mrigger, I got a list of frequently used gcc builtins.

I'm currently implementing a bunch of tests for those builtins, to be confident non of them are badly broken. While doing so, I found some misbehavior of draggonegg which I mitigated with some preprocessor macros for now:

* ```__builtin_bswap16```: draggonegg is not using the llvm equivalent, as done for the other variants
* ```__builtin_isinf```: draggonegg is using native calls with X86_FP80 type args, see  #803
* ```__builtin_types_compatible_p```: behaves quite different between draggonegg and llvm

Problems found and fixed so far in Sulong:

* ```@llvm.fabs.f80``` not implemented
* ```@llvm.clear_cache``` not implemented. I added a stub because I don't think we need to actually execute code for this builtin in our case
* MDLexicalBlockFile had a missing method (has nothing to do with builtins)

I will update this bugreport as I'm implementing more builtins