### PR TITLE
Build LAUNCHER_COMMON in travis gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,11 +81,11 @@ matrix:
     jdk: oraclejdk8
   - env: TEST_COMMAND='mx gate --tags parser' COMPILE_COMMAND='mx build'
     jdk: oraclejdk8
-  - env: TEST_COMMAND='mx gate --tags gcc_c' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON,WORD_API'
+  - env: TEST_COMMAND='mx gate --tags gcc_c' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON,WORD_API,TRUFFLE_DEBUG'
     jdk: oraclejdk8
-  - env: TEST_COMMAND='mx gate --tags gcc_cpp' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON,WORD_API'
+  - env: TEST_COMMAND='mx gate --tags gcc_cpp' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON,WORD_API,TRUFFLE_DEBUG'
     jdk: oraclejdk8
-  - env: TEST_COMMAND='mx gate --tags gcc_fortran' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON,WORD_API'
+  - env: TEST_COMMAND='mx gate --tags gcc_fortran' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON,WORD_API,TRUFFLE_DEBUG'
     jdk: oraclejdk8
 after_failure:
   - find . -iname "*.log" -print0 | xargs -0 cat

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,11 +81,11 @@ matrix:
     jdk: oraclejdk8
   - env: TEST_COMMAND='mx gate --tags parser' COMPILE_COMMAND='mx build'
     jdk: oraclejdk8
-  - env: TEST_COMMAND='mx gate --tags gcc_c' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON'
+  - env: TEST_COMMAND='mx gate --tags gcc_c' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON,WORD_API'
     jdk: oraclejdk8
-  - env: TEST_COMMAND='mx gate --tags gcc_cpp' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON'
+  - env: TEST_COMMAND='mx gate --tags gcc_cpp' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON,WORD_API'
     jdk: oraclejdk8
-  - env: TEST_COMMAND='mx gate --tags gcc_fortran' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON'
+  - env: TEST_COMMAND='mx gate --tags gcc_fortran' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON,WORD_API'
     jdk: oraclejdk8
 after_failure:
   - find . -iname "*.log" -print0 | xargs -0 cat

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,11 +81,11 @@ matrix:
     jdk: oraclejdk8
   - env: TEST_COMMAND='mx gate --tags parser' COMPILE_COMMAND='mx build'
     jdk: oraclejdk8
-  - env: TEST_COMMAND='mx gate --tags gcc_c' COMPILE_COMMAND='mx build --dependencies SULONG_TEST'
+  - env: TEST_COMMAND='mx gate --tags gcc_c' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON'
     jdk: oraclejdk8
-  - env: TEST_COMMAND='mx gate --tags gcc_cpp' COMPILE_COMMAND='mx build --dependencies SULONG_TEST'
+  - env: TEST_COMMAND='mx gate --tags gcc_cpp' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON'
     jdk: oraclejdk8
-  - env: TEST_COMMAND='mx gate --tags gcc_fortran' COMPILE_COMMAND='mx build --dependencies SULONG_TEST'
+  - env: TEST_COMMAND='mx gate --tags gcc_fortran' COMPILE_COMMAND='mx build --dependencies SULONG_TEST,LAUNCHER_COMMON'
     jdk: oraclejdk8
 after_failure:
   - find . -iname "*.log" -print0 | xargs -0 cat


### PR DESCRIPTION
This should fix the following error in the travis gate:
```
gate: 14 Nov 2017 14:48:29(+10:07) END:   TestGCC_C [0:10:07.066278] [disk (free/total): 16.8GB/29.5GB]
Traceback (most recent call last):
  File "/home/travis/build/graalvm/sulong/mx/mx_gate.py", line 347, in gate
    _run_gate(cleanArgs, args, tasks)
  File "/home/travis/build/graalvm/sulong/mx/mx_gate.py", line 490, in _run_gate
    runner(args, tasks)
  File "/home/travis/build/graalvm/sulong/mx.sulong/mx_sulong.py", line 103, in _sulong_gate_runner
    if t: mx_testsuites.runSuite('gcc_c')
  File "/home/travis/build/graalvm/sulong/mx.sulong/mx_testsuites.py", line 215, in runSuite
    runCommand([])
  File "/home/travis/build/graalvm/sulong/mx.sulong/mx_testsuites.py", line 67, in runGCCSuite_c
    return run(vmArgs + ['-Dsulongtest.fileExtensionFilter=.c'], "com.oracle.truffle.llvm.test.GCCSuite")
  File "/home/travis/build/graalvm/sulong/mx.sulong/mx_testsuites.py", line 46, in run
    return mx_unittest.unittest(command)
  File "/home/travis/build/graalvm/sulong/mx/mx_unittest.py", line 426, in unittest
    _unittest(args, ['@Test', '@Parameters'], **parsed_args.__dict__)
  File "/home/travis/build/graalvm/sulong/mx/mx_unittest.py", line 315, in _unittest
    _run_tests(args, harness, vmLauncher, annotations, testfile, blacklist, whitelist, regex, mx.suite(suite) if suite else None)
  File "/home/travis/build/graalvm/sulong/mx/mx_unittest.py", line 218, in _run_tests
    harness(depsContainingTests, vmLauncher, vmArgs)
  File "/home/travis/build/graalvm/sulong/mx/mx_unittest.py", line 304, in harness
    config = p(config)
  File "/home/travis/build/graalvm/graal/truffle/mx.truffle/mx_truffle.py", line 227, in _unittest_config_participant_tck
    suite_collector(mx.primary_suite(), create_filter("META-INF/services/org.graalvm.polyglot.tck.LanguageProvider"), providers, javaPropertiesToAdd, set())
  File "/home/travis/build/graalvm/graal/truffle/mx.truffle/mx_truffle.py", line 211, in suite_collector
    suite.visit_imports(import_visitor, predicate=predicate, collector=collector, javaProperties=javaProperties, seenSuites=seenSuites)
  File "/home/travis/build/graalvm/sulong/mx/mx.py", line 7238, in visit_imports
    visitor(self, suite_import, **extra_args)
  File "/home/travis/build/graalvm/graal/truffle/mx.truffle/mx_truffle.py", line 205, in import_visitor
    suite_collector(mx.suite(suite_import.name), predicate, collector, javaProperties, seenSuites)
  File "/home/travis/build/graalvm/graal/truffle/mx.truffle/mx_truffle.py", line 211, in suite_collector
    suite.visit_imports(import_visitor, predicate=predicate, collector=collector, javaProperties=javaProperties, seenSuites=seenSuites)
  File "/home/travis/build/graalvm/sulong/mx/mx.py", line 7238, in visit_imports
    visitor(self, suite_import, **extra_args)
  File "/home/travis/build/graalvm/graal/truffle/mx.truffle/mx_truffle.py", line 205, in import_visitor
    suite_collector(mx.suite(suite_import.name), predicate, collector, javaProperties, seenSuites)
  File "/home/travis/build/graalvm/graal/truffle/mx.truffle/mx_truffle.py", line 213, in suite_collector
    if dist.isJARDistribution() and predicate(dist.path):
  File "/home/travis/build/graalvm/graal/truffle/mx.truffle/mx_truffle.py", line 195, in has_resource
    with zipfile.ZipFile(jar, "r") as zf:
  File "/opt/python/2.7.13/lib/python2.7/zipfile.py", line 756, in __init__
    self.fp = open(file, modeDict[mode])
IOError: [Errno 2] No such file or directory: '/home/travis/build/graalvm/graal/sdk/mxbuild/dists/launcher-common.jar'
gate: 14 Nov 2017 14:48:29(+10:07) ABORT: Gate [0:10:07.178981] [disk (free/total): 16.8GB/29.5GB]
[Errno 2] No such file or directory: '/home/travis/build/graalvm/graal/sdk/mxbuild/dists/launcher-common.jar'
```