### PR TITLE
More x86_64 Linux syscalls

### DIFF
--- a/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
+++ b/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
@@ -41,6 +41,7 @@
 #include <sys/socket.h>
 
 #ifdef __linux__
+#include <sys/vfs.h>
 #include <sys/klog.h>
 #include <sys/syscall.h>
 #endif
@@ -317,6 +318,27 @@ int __sulong_posix_syslog(int type, char* bufp, int len)
 #endif
 }
 
+int __sulong_posix_statfs(const char* path, struct statfs* buf)
+{
+#ifdef __linux__
+	CALL(int, statfs, path, buf);
+#else
+	fprintf(stderr, "statfs is not supported on this OS.\n");
+	return -ENOSYS;
+#endif
+}
+
+int __sulong_posix_fstatfs(int fd, struct statfs* buf)
+{
+#ifdef __linux__
+	CALL(int, fstatfs, fd, buf);
+#else
+	fprintf(stderr, "fstatfs is not supported on this OS.\n");
+	return -ENOSYS;
+#endif
+}
+
+
 
 #else
 
@@ -543,6 +565,16 @@ int __sulong_posix_getgroups(int gidsetsize, gid_t grouplist[])
 }
 
 int __sulong_posix_syslog(int type, char* bufp, int len)
+{
+	ERROR();
+}
+
+int __sulong_posix_statfs(const char* path, struct statfs* buf)
+{
+	ERROR();
+}
+
+int __sulong_posix_fstatfs(int fd, struct statfs* buf)
 {
 	ERROR();
 }

--- a/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
+++ b/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <poll.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
@@ -338,7 +339,10 @@ int __sulong_posix_fstatfs(int fd, struct statfs* buf)
 #endif
 }
 
-
+int __sulong_posix_poll(struct pollfd* fds, nfds_t nfds, int timeout)
+{
+	CALL(int, poll, fds, nfds, timeout);
+}
 
 #else
 
@@ -575,6 +579,11 @@ int __sulong_posix_statfs(const char* path, struct statfs* buf)
 }
 
 int __sulong_posix_fstatfs(int fd, struct statfs* buf)
+{
+	ERROR();
+}
+
+int __sulong_posix_poll(struct pollfd* fds, nfds_t nfds, int timeout)
 {
 	ERROR();
 }

--- a/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
+++ b/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
@@ -301,6 +301,11 @@ int __sulong_posix_getdents64(unsigned int fd, void* dirp, unsigned int count)
 #endif
 }
 
+int __sulong_posix_getgroups(int gidsetsize, gid_t grouplist[])
+{
+	CALL(int, getgroups, gidsetsize, grouplist);
+}
+
 
 #else
 
@@ -517,6 +522,11 @@ int __sulong_posix_renameat(int oldfd, const char* old, int newfd, const char* n
 }
 
 int __sulong_posix_getdents64(unsigned int fd, void* dirp, unsigned int count)
+{
+	ERROR();
+}
+
+int __sulong_posix_getgroups(int gidsetsize, gid_t grouplist[])
 {
 	ERROR();
 }

--- a/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
+++ b/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
@@ -344,6 +344,11 @@ int __sulong_posix_poll(struct pollfd* fds, nfds_t nfds, int timeout)
 	CALL(int, poll, fds, nfds, timeout);
 }
 
+pid_t __sulong_posix_getpgid(pid_t pid)
+{
+	CALL(pid_t, getpgid, pid);
+}
+
 #else
 
 #include <stdio.h>
@@ -584,6 +589,11 @@ int __sulong_posix_fstatfs(int fd, struct statfs* buf)
 }
 
 int __sulong_posix_poll(struct pollfd* fds, nfds_t nfds, int timeout)
+{
+	ERROR();
+}
+
+pid_t __sulong_posix_getpgid(pid_t pid)
 {
 	ERROR();
 }

--- a/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
+++ b/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
@@ -40,6 +40,10 @@
 #include <sys/mman.h>
 #include <sys/socket.h>
 
+#ifdef __linux__
+#include <sys/syscall.h>
+#endif
+
 
 #ifdef __linux__
 
@@ -287,6 +291,17 @@ int __sulong_posix_renameat(int oldfd, const char* old, int newfd, const char* n
 	CALL(int, renameat, oldfd, old, newfd, new);
 }
 
+int __sulong_posix_getdents64(unsigned int fd, void* dirp, unsigned int count)
+{
+#ifdef __linux__
+	CALL(int, syscall, __NR_getdents64, fd, dirp, count);
+#else
+	fprintf(stderr, "getdents64 is not supported on this OS.\n");
+	return -ENOSYS;
+#endif
+}
+
+
 #else
 
 #include <stdio.h>
@@ -497,6 +512,11 @@ int __sulong_posix_rename(const char* old, const char* new)
 }
 
 int __sulong_posix_renameat(int oldfd, const char* old, int newfd, const char* new)
+{
+	ERROR();
+}
+
+int __sulong_posix_getdents64(unsigned int fd, void* dirp, unsigned int count)
 {
 	ERROR();
 }

--- a/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
+++ b/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
@@ -41,6 +41,7 @@
 #include <sys/socket.h>
 
 #ifdef __linux__
+#include <sys/klog.h>
 #include <sys/syscall.h>
 #endif
 
@@ -306,6 +307,16 @@ int __sulong_posix_getgroups(int gidsetsize, gid_t grouplist[])
 	CALL(int, getgroups, gidsetsize, grouplist);
 }
 
+int __sulong_posix_syslog(int type, char* bufp, int len)
+{
+#ifdef __linux__
+	CALL(int, klogctl, type, bufp, len);
+#else
+	fprintf(stderr, "klogctl is not supported on this OS.\n");
+	return -ENOSYS;
+#endif
+}
+
 
 #else
 
@@ -527,6 +538,11 @@ int __sulong_posix_getdents64(unsigned int fd, void* dirp, unsigned int count)
 }
 
 int __sulong_posix_getgroups(int gidsetsize, gid_t grouplist[])
+{
+	ERROR();
+}
+
+int __sulong_posix_syslog(int type, char* bufp, int len)
 {
 	ERROR();
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
@@ -78,6 +78,7 @@ public class LLVMAMD64Syscall {
     public static final int SYS_rename = 82;
     public static final int SYS_unlink = 87;
     public static final int SYS_getuid = 102;
+    public static final int SYS_syslog = 103;
     public static final int SYS_getgid = 104;
     public static final int SYS_setuid = 105;
     public static final int SYS_setgid = 106;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
@@ -87,6 +87,7 @@ public class LLVMAMD64Syscall {
     public static final int SYS_arch_prctl = 158;
     public static final int SYS_gettid = 186;
     public static final int SYS_futex = 202;
+    public static final int SYS_getdents64 = 217;
     public static final int SYS_set_tid_address = 218;
     public static final int SYS_clock_gettime = 228;
     public static final int SYS_exit_group = 231;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
@@ -86,6 +86,8 @@ public class LLVMAMD64Syscall {
     public static final int SYS_getegid = 108;
     public static final int SYS_getppid = 110;
     public static final int SYS_getgroups = 115;
+    public static final int SYS_statfs = 137;
+    public static final int SYS_fstatfs = 138;
     public static final int SYS_arch_prctl = 158;
     public static final int SYS_gettid = 186;
     public static final int SYS_futex = 202;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
@@ -37,6 +37,7 @@ public class LLVMAMD64Syscall {
     public static final int SYS_stat = 4;
     public static final int SYS_fstat = 5;
     public static final int SYS_lstat = 6;
+    public static final int SYS_poll = 7;
     public static final int SYS_lseek = 8;
     public static final int SYS_mmap = 9;
     public static final int SYS_munmap = 11;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
@@ -87,6 +87,7 @@ public class LLVMAMD64Syscall {
     public static final int SYS_getegid = 108;
     public static final int SYS_getppid = 110;
     public static final int SYS_getgroups = 115;
+    public static final int SYS_getpgid = 121;
     public static final int SYS_statfs = 137;
     public static final int SYS_fstatfs = 138;
     public static final int SYS_arch_prctl = 158;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
@@ -84,6 +84,7 @@ public class LLVMAMD64Syscall {
     public static final int SYS_geteuid = 107;
     public static final int SYS_getegid = 108;
     public static final int SYS_getppid = 110;
+    public static final int SYS_getgroups = 115;
     public static final int SYS_arch_prctl = 158;
     public static final int SYS_gettid = 186;
     public static final int SYS_futex = 202;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallFstatfsNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallFstatfsNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+
+public abstract class LLVMAMD64SyscallFstatfsNode extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode fstatfs;
+
+    public LLVMAMD64SyscallFstatfsNode() {
+        super("fstatfs");
+        fstatfs = LLVMAMD64PosixCallNodeGen.create("fstatfs", "(SINT32,UINT64):SINT32", 2);
+    }
+
+    @Specialization
+    protected long execute(long fd, LLVMAddress buf) {
+        return (int) fstatfs.execute((int) fd, buf.getVal());
+    }
+
+    @Specialization
+    protected long execute(long fd, long buf) {
+        return execute(fd, LLVMAddress.fromLong(buf));
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallGetdents64Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallGetdents64Node.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+
+public abstract class LLVMAMD64SyscallGetdents64Node extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode getdents64;
+
+    public LLVMAMD64SyscallGetdents64Node() {
+        super("getdents64");
+        getdents64 = LLVMAMD64PosixCallNodeGen.create("getdents64", "(UINT32,UINT64,UINT32):SINT32", 3);
+    }
+
+    @Specialization
+    protected long execute(long fd, LLVMAddress dirp, long count) {
+        return (int) getdents64.execute((int) fd, dirp.getVal(), (int) count);
+    }
+
+    @Specialization
+    protected long execute(long fd, long dirp, long count) {
+        return execute(fd, LLVMAddress.fromLong(dirp), count);
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallGetgroupsNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallGetgroupsNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+
+public abstract class LLVMAMD64SyscallGetgroupsNode extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode getgroups;
+
+    public LLVMAMD64SyscallGetgroupsNode() {
+        super("getgroups");
+        getgroups = LLVMAMD64PosixCallNodeGen.create("getgroups", "(SINT32,UINT64):SINT32", 2);
+    }
+
+    @Specialization
+    protected long execute(long gidsetsize, LLVMAddress grouplist) {
+        return (int) getgroups.execute((int) gidsetsize, grouplist.getVal());
+    }
+
+    @Specialization
+    protected long execute(long gidsetsize, long grouplist) {
+        return execute(gidsetsize, LLVMAddress.fromLong(grouplist));
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallGetpgidNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallGetpgidNode.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+
+public class LLVMAMD64SyscallGetpgidNode extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode getpgid;
+
+    public LLVMAMD64SyscallGetpgidNode() {
+        super("getpgid");
+        getpgid = LLVMAMD64PosixCallNodeGen.create("getpgid", "(SINT32):SINT32", 1);
+    }
+
+    @Override
+    public long execute(Object rdi, Object rsi, Object rdx, Object r10, Object r8, Object r9) {
+        int pid = (int) (long) rdi;
+        return (int) getpgid.execute(pid);
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
@@ -135,6 +135,8 @@ public abstract class LLVMAMD64SyscallNode extends LLVMExpressionNode {
                 return LLVMAMD64SyscallUnlinkNodeGen.create();
             case LLVMAMD64Syscall.SYS_getuid:
                 return new LLVMAMD64SyscallGetuidNode();
+            case LLVMAMD64Syscall.SYS_syslog:
+                return LLVMAMD64SyscallSyslogNodeGen.create();
             case LLVMAMD64Syscall.SYS_getgid:
                 return new LLVMAMD64SyscallGetgidNode();
             case LLVMAMD64Syscall.SYS_setuid:

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
@@ -153,6 +153,8 @@ public abstract class LLVMAMD64SyscallNode extends LLVMExpressionNode {
                 return new LLVMAMD64SyscallGetPpidNode();
             case LLVMAMD64Syscall.SYS_getgroups:
                 return LLVMAMD64SyscallGetgroupsNodeGen.create();
+            case LLVMAMD64Syscall.SYS_getpgid:
+                return new LLVMAMD64SyscallGetpgidNode();
             case LLVMAMD64Syscall.SYS_statfs:
                 return LLVMAMD64SyscallStatfsNodeGen.create();
             case LLVMAMD64Syscall.SYS_fstatfs:

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
@@ -153,6 +153,8 @@ public abstract class LLVMAMD64SyscallNode extends LLVMExpressionNode {
                 return new LLVMAMD64SyscallGettidNode();
             case LLVMAMD64Syscall.SYS_futex:
                 return LLVMAMD64SyscallFutexNodeGen.create();
+            case LLVMAMD64Syscall.SYS_getdents64:
+                return LLVMAMD64SyscallGetdents64NodeGen.create();
             case LLVMAMD64Syscall.SYS_set_tid_address:
                 return LLVMAMD64SyscallSetTidAddressNodeGen.create();
             case LLVMAMD64Syscall.SYS_clock_gettime:

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
@@ -151,6 +151,10 @@ public abstract class LLVMAMD64SyscallNode extends LLVMExpressionNode {
                 return new LLVMAMD64SyscallGetPpidNode();
             case LLVMAMD64Syscall.SYS_getgroups:
                 return LLVMAMD64SyscallGetgroupsNodeGen.create();
+            case LLVMAMD64Syscall.SYS_statfs:
+                return LLVMAMD64SyscallStatfsNodeGen.create();
+            case LLVMAMD64Syscall.SYS_fstatfs:
+                return LLVMAMD64SyscallFstatfsNodeGen.create();
             case LLVMAMD64Syscall.SYS_arch_prctl:
                 return LLVMAMD64SyscallArchPrctlNodeGen.create();
             case LLVMAMD64Syscall.SYS_gettid:

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
@@ -147,6 +147,8 @@ public abstract class LLVMAMD64SyscallNode extends LLVMExpressionNode {
                 return new LLVMAMD64SyscallGetegidNode();
             case LLVMAMD64Syscall.SYS_getppid:
                 return new LLVMAMD64SyscallGetPpidNode();
+            case LLVMAMD64Syscall.SYS_getgroups:
+                return LLVMAMD64SyscallGetgroupsNodeGen.create();
             case LLVMAMD64Syscall.SYS_arch_prctl:
                 return LLVMAMD64SyscallArchPrctlNodeGen.create();
             case LLVMAMD64Syscall.SYS_gettid:

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
@@ -66,6 +66,8 @@ public abstract class LLVMAMD64SyscallNode extends LLVMExpressionNode {
                 return LLVMAMD64SyscallFstatNodeGen.create();
             case LLVMAMD64Syscall.SYS_lstat:
                 return LLVMAMD64SyscallLstatNodeGen.create();
+            case LLVMAMD64Syscall.SYS_poll:
+                return LLVMAMD64SyscallPollNodeGen.create();
             case LLVMAMD64Syscall.SYS_lseek:
                 return new LLVMAMD64SyscallLseekNode();
             case LLVMAMD64Syscall.SYS_mmap:

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallPollNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallPollNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+
+public abstract class LLVMAMD64SyscallPollNode extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode poll;
+
+    public LLVMAMD64SyscallPollNode() {
+        super("poll");
+        poll = LLVMAMD64PosixCallNodeGen.create("poll", "(UINT64,UINT64,SINT32):SINT32", 3);
+    }
+
+    @Specialization
+    protected long execute(LLVMAddress fds, long nfds, long timeout) {
+        return (int) poll.execute(fds.getVal(), nfds, (int) timeout);
+    }
+
+    @Specialization
+    protected long execute(long fds, long nfds, long timeout) {
+        return execute(LLVMAddress.fromLong(fds), nfds, timeout);
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallStatfsNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallStatfsNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+
+public abstract class LLVMAMD64SyscallStatfsNode extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode statfs;
+
+    public LLVMAMD64SyscallStatfsNode() {
+        super("statfs");
+        statfs = LLVMAMD64PosixCallNodeGen.create("statfs", "(UINT64,UINT64):SINT32", 2);
+    }
+
+    @Specialization
+    protected long execute(LLVMAddress path, LLVMAddress buf) {
+        return (int) statfs.execute(path.getVal(), buf.getVal());
+    }
+
+    @Specialization
+    protected long execute(long path, long buf) {
+        return execute(LLVMAddress.fromLong(path), LLVMAddress.fromLong(buf));
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallSyslogNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallSyslogNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+
+public abstract class LLVMAMD64SyscallSyslogNode extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode syslog;
+
+    public LLVMAMD64SyscallSyslogNode() {
+        super("syslog");
+        syslog = LLVMAMD64PosixCallNodeGen.create("syslog", "(SINT32,UINT64,SINT32):SINT32", 3);
+    }
+
+    @Specialization
+    protected long execute(long type, LLVMAddress bufp, long len) {
+        return (int) syslog.execute((int) type, bufp.getVal(), (int) len);
+    }
+
+    @Specialization
+    protected long execute(long type, long bufp, long len) {
+        return execute(type, LLVMAddress.fromLong(bufp), len);
+    }
+}


### PR DESCRIPTION
- `getdents64`
- `getgroups`
- `syslog`
- `statfs`
- `fstatfs`
- `poll`
- `getpgid`

makes programs like `ls` and `df` work if they run on top of a libc (e.g. musl).