### PR TITLE
Fix atexit handling in disposeContext

### DIFF
--- a/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
+++ b/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
@@ -41,6 +41,7 @@
 #include <sys/socket.h>
 
 #ifdef __linux__
+#include <sys/vfs.h>
 #include <sys/klog.h>
 #include <sys/syscall.h>
 #endif
@@ -317,6 +318,27 @@ int __sulong_posix_syslog(int type, char* bufp, int len)
 #endif
 }
 
+int __sulong_posix_statfs(const char* path, struct statfs* buf)
+{
+#ifdef __linux__
+	CALL(int, statfs, path, buf);
+#else
+	fprintf(stderr, "statfs is not supported on this OS.\n");
+	return -ENOSYS;
+#endif
+}
+
+int __sulong_posix_fstatfs(int fd, struct statfs* buf)
+{
+#ifdef __linux__
+	CALL(int, fstatfs, fd, buf);
+#else
+	fprintf(stderr, "fstatfs is not supported on this OS.\n");
+	return -ENOSYS;
+#endif
+}
+
+
 
 #else
 
@@ -543,6 +565,16 @@ int __sulong_posix_getgroups(int gidsetsize, gid_t grouplist[])
 }
 
 int __sulong_posix_syslog(int type, char* bufp, int len)
+{
+	ERROR();
+}
+
+int __sulong_posix_statfs(const char* path, struct statfs* buf)
+{
+	ERROR();
+}
+
+int __sulong_posix_fstatfs(int fd, struct statfs* buf)
 {
 	ERROR();
 }

--- a/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
+++ b/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <poll.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
@@ -338,7 +339,10 @@ int __sulong_posix_fstatfs(int fd, struct statfs* buf)
 #endif
 }
 
-
+int __sulong_posix_poll(struct pollfd* fds, nfds_t nfds, int timeout)
+{
+	CALL(int, poll, fds, nfds, timeout);
+}
 
 #else
 
@@ -575,6 +579,11 @@ int __sulong_posix_statfs(const char* path, struct statfs* buf)
 }
 
 int __sulong_posix_fstatfs(int fd, struct statfs* buf)
+{
+	ERROR();
+}
+
+int __sulong_posix_poll(struct pollfd* fds, nfds_t nfds, int timeout)
 {
 	ERROR();
 }

--- a/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
+++ b/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
@@ -301,6 +301,11 @@ int __sulong_posix_getdents64(unsigned int fd, void* dirp, unsigned int count)
 #endif
 }
 
+int __sulong_posix_getgroups(int gidsetsize, gid_t grouplist[])
+{
+	CALL(int, getgroups, gidsetsize, grouplist);
+}
+
 
 #else
 
@@ -517,6 +522,11 @@ int __sulong_posix_renameat(int oldfd, const char* old, int newfd, const char* n
 }
 
 int __sulong_posix_getdents64(unsigned int fd, void* dirp, unsigned int count)
+{
+	ERROR();
+}
+
+int __sulong_posix_getgroups(int gidsetsize, gid_t grouplist[])
 {
 	ERROR();
 }

--- a/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
+++ b/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
@@ -344,6 +344,11 @@ int __sulong_posix_poll(struct pollfd* fds, nfds_t nfds, int timeout)
 	CALL(int, poll, fds, nfds, timeout);
 }
 
+pid_t __sulong_posix_getpgid(pid_t pid)
+{
+	CALL(pid_t, getpgid, pid);
+}
+
 #else
 
 #include <stdio.h>
@@ -584,6 +589,11 @@ int __sulong_posix_fstatfs(int fd, struct statfs* buf)
 }
 
 int __sulong_posix_poll(struct pollfd* fds, nfds_t nfds, int timeout)
+{
+	ERROR();
+}
+
+pid_t __sulong_posix_getpgid(pid_t pid)
 {
 	ERROR();
 }

--- a/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
+++ b/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
@@ -40,6 +40,10 @@
 #include <sys/mman.h>
 #include <sys/socket.h>
 
+#ifdef __linux__
+#include <sys/syscall.h>
+#endif
+
 
 #ifdef __linux__
 
@@ -287,6 +291,17 @@ int __sulong_posix_renameat(int oldfd, const char* old, int newfd, const char* n
 	CALL(int, renameat, oldfd, old, newfd, new);
 }
 
+int __sulong_posix_getdents64(unsigned int fd, void* dirp, unsigned int count)
+{
+#ifdef __linux__
+	CALL(int, syscall, __NR_getdents64, fd, dirp, count);
+#else
+	fprintf(stderr, "getdents64 is not supported on this OS.\n");
+	return -ENOSYS;
+#endif
+}
+
+
 #else
 
 #include <stdio.h>
@@ -497,6 +512,11 @@ int __sulong_posix_rename(const char* old, const char* new)
 }
 
 int __sulong_posix_renameat(int oldfd, const char* old, int newfd, const char* new)
+{
+	ERROR();
+}
+
+int __sulong_posix_getdents64(unsigned int fd, void* dirp, unsigned int count)
 {
 	ERROR();
 }

--- a/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
+++ b/projects/com.oracle.truffle.llvm.libraries.native/src/posix.c
@@ -41,6 +41,7 @@
 #include <sys/socket.h>
 
 #ifdef __linux__
+#include <sys/klog.h>
 #include <sys/syscall.h>
 #endif
 
@@ -306,6 +307,16 @@ int __sulong_posix_getgroups(int gidsetsize, gid_t grouplist[])
 	CALL(int, getgroups, gidsetsize, grouplist);
 }
 
+int __sulong_posix_syslog(int type, char* bufp, int len)
+{
+#ifdef __linux__
+	CALL(int, klogctl, type, bufp, len);
+#else
+	fprintf(stderr, "klogctl is not supported on this OS.\n");
+	return -ENOSYS;
+#endif
+}
+
 
 #else
 
@@ -527,6 +538,11 @@ int __sulong_posix_getdents64(unsigned int fd, void* dirp, unsigned int count)
 }
 
 int __sulong_posix_getgroups(int gidsetsize, gid_t grouplist[])
+{
+	ERROR();
+}
+
+int __sulong_posix_syslog(int type, char* bufp, int len)
 {
 	ERROR();
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LLVMString.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/support/LLVMString.java
@@ -29,22 +29,12 @@
  */
 package com.oracle.truffle.llvm.nodes.asm.support;
 
-import java.nio.ByteBuffer;
-
-import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.llvm.runtime.LLVMAddress;
 import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
 
-import sun.misc.SharedSecrets;
-
-// All methods except getBuffer can be used without @TruffleBoundary
+// All methods can be used without @TruffleBoundary
 public class LLVMString {
-    public static ByteBuffer getBuffer(LLVMAddress address, int size) {
-        CompilerAsserts.neverPartOfCompilation();
-        return SharedSecrets.getJavaNioAccess().newDirectByteBuffer(address.getVal(), size, null);
-    }
-
     public static byte[] memcpy(LLVMMemory memory, LLVMAddress address, int size) {
         byte[] out = new byte[size];
         LLVMAddress ptr = address;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
@@ -78,6 +78,7 @@ public class LLVMAMD64Syscall {
     public static final int SYS_rename = 82;
     public static final int SYS_unlink = 87;
     public static final int SYS_getuid = 102;
+    public static final int SYS_syslog = 103;
     public static final int SYS_getgid = 104;
     public static final int SYS_setuid = 105;
     public static final int SYS_setgid = 106;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
@@ -87,6 +87,7 @@ public class LLVMAMD64Syscall {
     public static final int SYS_arch_prctl = 158;
     public static final int SYS_gettid = 186;
     public static final int SYS_futex = 202;
+    public static final int SYS_getdents64 = 217;
     public static final int SYS_set_tid_address = 218;
     public static final int SYS_clock_gettime = 228;
     public static final int SYS_exit_group = 231;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
@@ -86,6 +86,8 @@ public class LLVMAMD64Syscall {
     public static final int SYS_getegid = 108;
     public static final int SYS_getppid = 110;
     public static final int SYS_getgroups = 115;
+    public static final int SYS_statfs = 137;
+    public static final int SYS_fstatfs = 138;
     public static final int SYS_arch_prctl = 158;
     public static final int SYS_gettid = 186;
     public static final int SYS_futex = 202;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
@@ -37,6 +37,7 @@ public class LLVMAMD64Syscall {
     public static final int SYS_stat = 4;
     public static final int SYS_fstat = 5;
     public static final int SYS_lstat = 6;
+    public static final int SYS_poll = 7;
     public static final int SYS_lseek = 8;
     public static final int SYS_mmap = 9;
     public static final int SYS_munmap = 11;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
@@ -87,6 +87,7 @@ public class LLVMAMD64Syscall {
     public static final int SYS_getegid = 108;
     public static final int SYS_getppid = 110;
     public static final int SYS_getgroups = 115;
+    public static final int SYS_getpgid = 121;
     public static final int SYS_statfs = 137;
     public static final int SYS_fstatfs = 138;
     public static final int SYS_arch_prctl = 158;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64Syscall.java
@@ -84,6 +84,7 @@ public class LLVMAMD64Syscall {
     public static final int SYS_geteuid = 107;
     public static final int SYS_getegid = 108;
     public static final int SYS_getppid = 110;
+    public static final int SYS_getgroups = 115;
     public static final int SYS_arch_prctl = 158;
     public static final int SYS_gettid = 186;
     public static final int SYS_futex = 202;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallFstatfsNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallFstatfsNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+
+public abstract class LLVMAMD64SyscallFstatfsNode extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode fstatfs;
+
+    public LLVMAMD64SyscallFstatfsNode() {
+        super("fstatfs");
+        fstatfs = LLVMAMD64PosixCallNodeGen.create("fstatfs", "(SINT32,UINT64):SINT32", 2);
+    }
+
+    @Specialization
+    protected long execute(long fd, LLVMAddress buf) {
+        return (int) fstatfs.execute((int) fd, buf.getVal());
+    }
+
+    @Specialization
+    protected long execute(long fd, long buf) {
+        return execute(fd, LLVMAddress.fromLong(buf));
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallGetdents64Node.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallGetdents64Node.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+
+public abstract class LLVMAMD64SyscallGetdents64Node extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode getdents64;
+
+    public LLVMAMD64SyscallGetdents64Node() {
+        super("getdents64");
+        getdents64 = LLVMAMD64PosixCallNodeGen.create("getdents64", "(UINT32,UINT64,UINT32):SINT32", 3);
+    }
+
+    @Specialization
+    protected long execute(long fd, LLVMAddress dirp, long count) {
+        return (int) getdents64.execute((int) fd, dirp.getVal(), (int) count);
+    }
+
+    @Specialization
+    protected long execute(long fd, long dirp, long count) {
+        return execute(fd, LLVMAddress.fromLong(dirp), count);
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallGetgroupsNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallGetgroupsNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+
+public abstract class LLVMAMD64SyscallGetgroupsNode extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode getgroups;
+
+    public LLVMAMD64SyscallGetgroupsNode() {
+        super("getgroups");
+        getgroups = LLVMAMD64PosixCallNodeGen.create("getgroups", "(SINT32,UINT64):SINT32", 2);
+    }
+
+    @Specialization
+    protected long execute(long gidsetsize, LLVMAddress grouplist) {
+        return (int) getgroups.execute((int) gidsetsize, grouplist.getVal());
+    }
+
+    @Specialization
+    protected long execute(long gidsetsize, long grouplist) {
+        return execute(gidsetsize, LLVMAddress.fromLong(grouplist));
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallGetpgidNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallGetpgidNode.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+
+public class LLVMAMD64SyscallGetpgidNode extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode getpgid;
+
+    public LLVMAMD64SyscallGetpgidNode() {
+        super("getpgid");
+        getpgid = LLVMAMD64PosixCallNodeGen.create("getpgid", "(SINT32):SINT32", 1);
+    }
+
+    @Override
+    public long execute(Object rdi, Object rsi, Object rdx, Object r10, Object r8, Object r9) {
+        int pid = (int) (long) rdi;
+        return (int) getpgid.execute(pid);
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
@@ -135,6 +135,8 @@ public abstract class LLVMAMD64SyscallNode extends LLVMExpressionNode {
                 return LLVMAMD64SyscallUnlinkNodeGen.create();
             case LLVMAMD64Syscall.SYS_getuid:
                 return new LLVMAMD64SyscallGetuidNode();
+            case LLVMAMD64Syscall.SYS_syslog:
+                return LLVMAMD64SyscallSyslogNodeGen.create();
             case LLVMAMD64Syscall.SYS_getgid:
                 return new LLVMAMD64SyscallGetgidNode();
             case LLVMAMD64Syscall.SYS_setuid:

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
@@ -153,6 +153,8 @@ public abstract class LLVMAMD64SyscallNode extends LLVMExpressionNode {
                 return new LLVMAMD64SyscallGetPpidNode();
             case LLVMAMD64Syscall.SYS_getgroups:
                 return LLVMAMD64SyscallGetgroupsNodeGen.create();
+            case LLVMAMD64Syscall.SYS_getpgid:
+                return new LLVMAMD64SyscallGetpgidNode();
             case LLVMAMD64Syscall.SYS_statfs:
                 return LLVMAMD64SyscallStatfsNodeGen.create();
             case LLVMAMD64Syscall.SYS_fstatfs:

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
@@ -153,6 +153,8 @@ public abstract class LLVMAMD64SyscallNode extends LLVMExpressionNode {
                 return new LLVMAMD64SyscallGettidNode();
             case LLVMAMD64Syscall.SYS_futex:
                 return LLVMAMD64SyscallFutexNodeGen.create();
+            case LLVMAMD64Syscall.SYS_getdents64:
+                return LLVMAMD64SyscallGetdents64NodeGen.create();
             case LLVMAMD64Syscall.SYS_set_tid_address:
                 return LLVMAMD64SyscallSetTidAddressNodeGen.create();
             case LLVMAMD64Syscall.SYS_clock_gettime:

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
@@ -151,6 +151,10 @@ public abstract class LLVMAMD64SyscallNode extends LLVMExpressionNode {
                 return new LLVMAMD64SyscallGetPpidNode();
             case LLVMAMD64Syscall.SYS_getgroups:
                 return LLVMAMD64SyscallGetgroupsNodeGen.create();
+            case LLVMAMD64Syscall.SYS_statfs:
+                return LLVMAMD64SyscallStatfsNodeGen.create();
+            case LLVMAMD64Syscall.SYS_fstatfs:
+                return LLVMAMD64SyscallFstatfsNodeGen.create();
             case LLVMAMD64Syscall.SYS_arch_prctl:
                 return LLVMAMD64SyscallArchPrctlNodeGen.create();
             case LLVMAMD64Syscall.SYS_gettid:

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
@@ -147,6 +147,8 @@ public abstract class LLVMAMD64SyscallNode extends LLVMExpressionNode {
                 return new LLVMAMD64SyscallGetegidNode();
             case LLVMAMD64Syscall.SYS_getppid:
                 return new LLVMAMD64SyscallGetPpidNode();
+            case LLVMAMD64Syscall.SYS_getgroups:
+                return LLVMAMD64SyscallGetgroupsNodeGen.create();
             case LLVMAMD64Syscall.SYS_arch_prctl:
                 return LLVMAMD64SyscallArchPrctlNodeGen.create();
             case LLVMAMD64Syscall.SYS_gettid:

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallNode.java
@@ -66,6 +66,8 @@ public abstract class LLVMAMD64SyscallNode extends LLVMExpressionNode {
                 return LLVMAMD64SyscallFstatNodeGen.create();
             case LLVMAMD64Syscall.SYS_lstat:
                 return LLVMAMD64SyscallLstatNodeGen.create();
+            case LLVMAMD64Syscall.SYS_poll:
+                return LLVMAMD64SyscallPollNodeGen.create();
             case LLVMAMD64Syscall.SYS_lseek:
                 return new LLVMAMD64SyscallLseekNode();
             case LLVMAMD64Syscall.SYS_mmap:

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallPollNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallPollNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+
+public abstract class LLVMAMD64SyscallPollNode extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode poll;
+
+    public LLVMAMD64SyscallPollNode() {
+        super("poll");
+        poll = LLVMAMD64PosixCallNodeGen.create("poll", "(UINT64,UINT64,SINT32):SINT32", 3);
+    }
+
+    @Specialization
+    protected long execute(LLVMAddress fds, long nfds, long timeout) {
+        return (int) poll.execute(fds.getVal(), nfds, (int) timeout);
+    }
+
+    @Specialization
+    protected long execute(long fds, long nfds, long timeout) {
+        return execute(LLVMAddress.fromLong(fds), nfds, timeout);
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallStatfsNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallStatfsNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+
+public abstract class LLVMAMD64SyscallStatfsNode extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode statfs;
+
+    public LLVMAMD64SyscallStatfsNode() {
+        super("statfs");
+        statfs = LLVMAMD64PosixCallNodeGen.create("statfs", "(UINT64,UINT64):SINT32", 2);
+    }
+
+    @Specialization
+    protected long execute(LLVMAddress path, LLVMAddress buf) {
+        return (int) statfs.execute(path.getVal(), buf.getVal());
+    }
+
+    @Specialization
+    protected long execute(long path, long buf) {
+        return execute(LLVMAddress.fromLong(path), LLVMAddress.fromLong(buf));
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallSyslogNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/asm/syscall/LLVMAMD64SyscallSyslogNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.asm.syscall;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNode;
+import com.oracle.truffle.llvm.nodes.asm.syscall.posix.LLVMAMD64PosixCallNodeGen;
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+
+public abstract class LLVMAMD64SyscallSyslogNode extends LLVMAMD64SyscallOperationNode {
+    @Child private LLVMAMD64PosixCallNode syslog;
+
+    public LLVMAMD64SyscallSyslogNode() {
+        super("syslog");
+        syslog = LLVMAMD64PosixCallNodeGen.create("syslog", "(SINT32,UINT64,SINT32):SINT32", 3);
+    }
+
+    @Specialization
+    protected long execute(long type, LLVMAddress bufp, long len) {
+        return (int) syslog.execute((int) type, bufp.getVal(), (int) len);
+    }
+
+    @Specialization
+    protected long execute(long type, long bufp, long len) {
+        return execute(type, LLVMAddress.fromLong(bufp), len);
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/arith/LLVMArithmetic.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/llvm/arith/LLVMArithmetic.java
@@ -456,11 +456,11 @@ public abstract class LLVMArithmetic extends LLVMBuiltin {
                     @NodeChild(value = "target", type = LLVMExpressionNode.class)})
     public abstract static class LLVMArithmeticWithOverflow extends LLVMArithmetic {
 
-        private final int secondValueOffset;
+        private final long secondValueOffset;
         private final Arithmetic arithmetic;
         @Child private LLVMStoreNode storeI8 = createStoreI1();
 
-        public LLVMArithmeticWithOverflow(Arithmetic arithmetic, int secondValueOffset) {
+        public LLVMArithmeticWithOverflow(Arithmetic arithmetic, long secondValueOffset) {
             this.secondValueOffset = secondValueOffset;
             this.arithmetic = arithmetic;
         }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/rust/LLVMPanic.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/rust/LLVMPanic.java
@@ -69,8 +69,8 @@ public abstract class LLVMPanic extends LLVMIntrinsic {
     static final class PanicLocType {
 
         private final StrSliceType strslice;
-        private final int offsetFilename;
-        private final int offsetLineNr;
+        private final long offsetFilename;
+        private final long offsetLineNr;
 
         private PanicLocType(DataSpecConverter dataLayout, Type type, StrSliceType strslice) {
             this.strslice = strslice;
@@ -97,7 +97,7 @@ public abstract class LLVMPanic extends LLVMIntrinsic {
 
     private static final class StrSliceType {
 
-        private final int lengthOffset;
+        private final long lengthOffset;
         private final Type type;
 
         private StrSliceType(DataSpecConverter dataLayout, Type type) {

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/literals/LLVMVectorLiteralNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/literals/LLVMVectorLiteralNode.java
@@ -35,10 +35,12 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import com.oracle.truffle.llvm.runtime.LLVMAddress;
+import com.oracle.truffle.llvm.runtime.LLVMFunctionDescriptor;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
 import com.oracle.truffle.llvm.runtime.vector.LLVMAddressVector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMDoubleVector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMFloatVector;
+import com.oracle.truffle.llvm.runtime.vector.LLVMFunctionVector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMI16Vector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMI1Vector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMI32Vector;
@@ -203,4 +205,29 @@ public class LLVMVectorLiteralNode {
             return LLVMAddressVector.create(vals);
         }
     }
+
+    public abstract static class LLVMVectorFunctionLiteralNode extends LLVMExpressionNode {
+
+        @Children private final LLVMExpressionNode[] values;
+
+        public LLVMVectorFunctionLiteralNode(LLVMExpressionNode[] values) {
+            this.values = values;
+        }
+
+        @ExplodeLoop
+        @Specialization
+        public LLVMFunctionVector executeFunctionVector(VirtualFrame frame) {
+            LLVMFunctionDescriptor[] vals = new LLVMFunctionDescriptor[values.length];
+            for (int i = 0; i < values.length; i++) {
+                try {
+                    vals[i] = values[i].executeLLVMFunctionDescriptor(frame);
+                } catch (UnexpectedResultException e) {
+                    CompilerDirectives.transferToInterpreter();
+                    throw new IllegalStateException(e);
+                }
+            }
+            return LLVMFunctionVector.create(vals);
+        }
+    }
+
 }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/LLVMAddressGetElementPtrNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/LLVMAddressGetElementPtrNode.java
@@ -50,10 +50,10 @@ import com.oracle.truffle.llvm.runtime.types.PointerType;
 import com.oracle.truffle.llvm.runtime.types.Type;
 
 @NodeChildren({@NodeChild(type = LLVMExpressionNode.class), @NodeChild(type = LLVMExpressionNode.class)})
-@NodeFields({@NodeField(type = int.class, name = "typeWidth"), @NodeField(type = Type.class, name = "targetType")})
+@NodeFields({@NodeField(type = long.class, name = "typeWidth"), @NodeField(type = Type.class, name = "targetType")})
 public abstract class LLVMAddressGetElementPtrNode extends LLVMExpressionNode {
 
-    public abstract int getTypeWidth();
+    public abstract long getTypeWidth();
 
     public abstract Type getTargetType();
 
@@ -64,7 +64,7 @@ public abstract class LLVMAddressGetElementPtrNode extends LLVMExpressionNode {
     @Specialization
     protected Object intIncrement(VirtualFrame frame, Object addr, int val,
                     @Cached("getIncrementPointerNode()") LLVMIncrementPointerNode incrementNode) {
-        int incr = getTypeWidth() * val;
+        long incr = getTypeWidth() * val;
         return incrementNode.executeWithTarget(frame, addr, incr, getTargetType());
     }
 

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/LLVMCompareExchangeNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/LLVMCompareExchangeNode.java
@@ -58,16 +58,16 @@ public abstract class LLVMCompareExchangeNode extends LLVMExpressionNode {
 
     @Child private LLVMCMPXCHInternalNode cmpxch;
 
-    public LLVMCompareExchangeNode(int resultSize, int secondValueOffset) {
+    public LLVMCompareExchangeNode(int resultSize, long secondValueOffset) {
         this.cmpxch = LLVMCMPXCHInternalNodeGen.create(resultSize, secondValueOffset);
     }
 
     abstract static class LLVMCMPXCHInternalNode extends LLVMNode {
 
         private final int resultSize;
-        private final int secondValueOffset;
+        private final long secondValueOffset;
 
-        LLVMCMPXCHInternalNode(int resultSize, int secondValueOffset) {
+        LLVMCMPXCHInternalNode(int resultSize, long secondValueOffset) {
             this.resultSize = resultSize;
             this.secondValueOffset = secondValueOffset;
         }

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/LLVMInsertValueNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/LLVMInsertValueNode.java
@@ -44,12 +44,12 @@ import com.oracle.truffle.llvm.runtime.types.Type;
 public abstract class LLVMInsertValueNode extends LLVMExpressionNode {
 
     protected final long sourceAggregateSize;
-    protected final int offset;
+    protected final long offset;
     @Child private LLVMStoreNode store;
     @Child private LLVMMemMoveNode memMove;
     private final Type type;
 
-    public LLVMInsertValueNode(LLVMStoreNode store, LLVMMemMoveNode memMove, long sourceAggregateSize, int offset, Type type) {
+    public LLVMInsertValueNode(LLVMStoreNode store, LLVMMemMoveNode memMove, long sourceAggregateSize, long offset, Type type) {
         this.sourceAggregateSize = sourceAggregateSize;
         this.offset = offset;
         this.store = store;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/store/LLVMStoreVectorNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/memory/store/LLVMStoreVectorNode.java
@@ -41,6 +41,7 @@ import com.oracle.truffle.llvm.runtime.types.Type;
 import com.oracle.truffle.llvm.runtime.vector.LLVMAddressVector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMDoubleVector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMFloatVector;
+import com.oracle.truffle.llvm.runtime.vector.LLVMFunctionVector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMI16Vector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMI1Vector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMI32Vector;
@@ -167,6 +168,20 @@ public abstract class LLVMStoreVectorNode extends LLVMStoreNode {
 
     @Specialization
     protected Object writeVector(VirtualFrame frame, LLVMGlobal address, LLVMAddressVector value,
+                    @Cached("toNative()") LLVMToNativeNode globalAccess,
+                    @Cached("getLLVMMemory()") LLVMMemory memory) {
+        memory.putVector(globalAccess.executeWithTarget(frame, address), value);
+        return null;
+    }
+
+    @Specialization
+    protected Object writeVector(LLVMAddress address, LLVMFunctionVector value, @Cached("getLLVMMemory()") LLVMMemory memory) {
+        memory.putVector(address, value);
+        return null;
+    }
+
+    @Specialization
+    protected Object writeVector(VirtualFrame frame, LLVMGlobal address, LLVMFunctionVector value,
                     @Cached("toNative()") LLVMToNativeNode globalAccess,
                     @Cached("getLLVMMemory()") LLVMMemory memory) {
         memory.putVector(globalAccess.executeWithTarget(frame, address), value);

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
@@ -1114,7 +1114,7 @@ public class BasicNodeFactory implements NodeFactory {
     }
 
     @Override
-    public LLVMExpressionNode createTypedElementPointer(LLVMParserRuntime runtime, LLVMExpressionNode aggregateAddress, LLVMExpressionNode index, int indexedTypeLength,
+    public LLVMExpressionNode createTypedElementPointer(LLVMParserRuntime runtime, LLVMExpressionNode aggregateAddress, LLVMExpressionNode index, long indexedTypeLength,
                     Type targetType) {
         return LLVMAddressGetElementPtrNodeGen.create(aggregateAddress, index, indexedTypeLength, targetType);
     }
@@ -1355,7 +1355,7 @@ public class BasicNodeFactory implements NodeFactory {
     }
 
     @Override
-    public LLVMExpressionNode createInsertValue(LLVMParserRuntime runtime, LLVMExpressionNode resultAggregate, LLVMExpressionNode sourceAggregate, int size, int offset,
+    public LLVMExpressionNode createInsertValue(LLVMParserRuntime runtime, LLVMExpressionNode resultAggregate, LLVMExpressionNode sourceAggregate, int size, long offset,
                     LLVMExpressionNode valueToInsert, Type llvmType) {
         LLVMStoreNode store;
         if (llvmType instanceof PrimitiveType) {
@@ -1807,7 +1807,7 @@ public class BasicNodeFactory implements NodeFactory {
         }
     }
 
-    private static int getOverflowFieldOffset(LLVMParserRuntime runtime, FunctionDeclaration declaration) {
+    private static long getOverflowFieldOffset(LLVMParserRuntime runtime, FunctionDeclaration declaration) {
         return runtime.getContext().getIndexOffset(1, (AggregateType) declaration.getType().getReturnType());
     }
 

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
@@ -142,6 +142,7 @@ import com.oracle.truffle.llvm.nodes.literals.LLVMSimpleLiteralNode.LLVMTruffleO
 import com.oracle.truffle.llvm.nodes.literals.LLVMVectorLiteralNodeFactory.LLVMVectorAddressLiteralNodeGen;
 import com.oracle.truffle.llvm.nodes.literals.LLVMVectorLiteralNodeFactory.LLVMVectorDoubleLiteralNodeGen;
 import com.oracle.truffle.llvm.nodes.literals.LLVMVectorLiteralNodeFactory.LLVMVectorFloatLiteralNodeGen;
+import com.oracle.truffle.llvm.nodes.literals.LLVMVectorLiteralNodeFactory.LLVMVectorFunctionLiteralNodeGen;
 import com.oracle.truffle.llvm.nodes.literals.LLVMVectorLiteralNodeFactory.LLVMVectorI16LiteralNodeGen;
 import com.oracle.truffle.llvm.nodes.literals.LLVMVectorLiteralNodeFactory.LLVMVectorI1LiteralNodeGen;
 import com.oracle.truffle.llvm.nodes.literals.LLVMVectorLiteralNodeFactory.LLVMVectorI32LiteralNodeGen;
@@ -737,7 +738,11 @@ public class BasicNodeFactory implements NodeFactory {
                     throw new AssertionError();
             }
         } else if (llvmType instanceof PointerType) {
-            return LLVMVectorAddressLiteralNodeGen.create(vals);
+            if (((PointerType) llvmType).getPointeeType() instanceof FunctionType) {
+                return LLVMVectorFunctionLiteralNodeGen.create(vals);
+            } else {
+                return LLVMVectorAddressLiteralNodeGen.create(vals);
+            }
         } else {
             throw new AssertionError(llvmType + " not yet supported");
         }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMBitcodeInstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMBitcodeInstructionVisitor.java
@@ -677,7 +677,7 @@ final class LLVMBitcodeInstructionVisitor implements SymbolVisitor {
 
         final AggregateType aggregateType = (AggregateType) baseType;
 
-        int offset = runtime.getContext().getIndexOffset(targetIndex, aggregateType);
+        long offset = runtime.getContext().getIndexOffset(targetIndex, aggregateType);
 
         final Type targetType = aggregateType.getElementType(targetIndex);
         if (targetType != null && !((targetType instanceof StructureType) && (((StructureType) targetType).isPacked()))) {
@@ -743,7 +743,7 @@ final class LLVMBitcodeInstructionVisitor implements SymbolVisitor {
 
         final LLVMExpressionNode resultAggregate = nodeFactory.createAlloca(runtime, sourceType, size, alignment);
 
-        final int offset = runtime.getContext().getIndexOffset(targetIndex, sourceType);
+        final long offset = runtime.getContext().getIndexOffset(targetIndex, sourceType);
         final LLVMExpressionNode result = nodeFactory.createInsertValue(runtime, resultAggregate, sourceAggregate,
                         runtime.getContext().getByteSize(sourceType), offset, valueToInsert, valueType);
 

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactory.java
@@ -117,7 +117,7 @@ public interface NodeFactory {
 
     LLVMExpressionNode createExtractValue(LLVMParserRuntime runtime, Type type, LLVMExpressionNode targetAddress);
 
-    LLVMExpressionNode createTypedElementPointer(LLVMParserRuntime runtime, LLVMExpressionNode aggregateAddress, LLVMExpressionNode index, int indexedTypeLength,
+    LLVMExpressionNode createTypedElementPointer(LLVMParserRuntime runtime, LLVMExpressionNode aggregateAddress, LLVMExpressionNode index, long indexedTypeLength,
                     Type targetType);
 
     LLVMExpressionNode createSelect(LLVMParserRuntime runtime, Type type, LLVMExpressionNode condition, LLVMExpressionNode trueValue, LLVMExpressionNode falseValue);
@@ -150,7 +150,7 @@ public interface NodeFactory {
      */
     LLVMStackAllocationNode createStackAllocation(LLVMParserRuntime runtime);
 
-    LLVMExpressionNode createInsertValue(LLVMParserRuntime runtime, LLVMExpressionNode resultAggregate, LLVMExpressionNode sourceAggregate, int size, int offset, LLVMExpressionNode valueToInsert,
+    LLVMExpressionNode createInsertValue(LLVMParserRuntime runtime, LLVMExpressionNode resultAggregate, LLVMExpressionNode sourceAggregate, int size, long offset, LLVMExpressionNode valueToInsert,
                     Type llvmType);
 
     LLVMExpressionNode createZeroNode(LLVMParserRuntime runtime, LLVMExpressionNode addressNode, int size);

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/nodes/LLVMSymbolReadResolver.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/nodes/LLVMSymbolReadResolver.java
@@ -451,11 +451,24 @@ public final class LLVMSymbolReadResolver {
 
     public static Integer evaluateIntegerConstant(SymbolImpl constant) {
         if (constant instanceof IntegerConstant) {
+            assert ((IntegerConstant) constant).getValue() == (int) ((IntegerConstant) constant).getValue();
             return (int) ((IntegerConstant) constant).getValue();
         } else if (constant instanceof BigIntegerConstant) {
             return ((BigIntegerConstant) constant).getValue().intValueExact();
         } else if (constant instanceof NullConstant) {
             return 0;
+        } else {
+            return null;
+        }
+    }
+
+    public static Long evaluateLongIntegerConstant(SymbolImpl constant) {
+        if (constant instanceof IntegerConstant) {
+            return ((IntegerConstant) constant).getValue();
+        } else if (constant instanceof BigIntegerConstant) {
+            return ((BigIntegerConstant) constant).getValue().longValueExact();
+        } else if (constant instanceof NullConstant) {
+            return 0L;
         } else {
             return null;
         }
@@ -469,7 +482,7 @@ public final class LLVMSymbolReadResolver {
             final SymbolImpl indexSymbol = indices.get(i);
             final Type indexType = indexSymbol.getType();
 
-            final Integer indexInteger = evaluateIntegerConstant(indexSymbol);
+            final Long indexInteger = evaluateLongIntegerConstant(indexSymbol);
             if (indexInteger == null) {
                 // the index is determined at runtime
                 if (currentType instanceof StructureType) {
@@ -477,14 +490,14 @@ public final class LLVMSymbolReadResolver {
                     throw new IllegalStateException("Indices on structs must be constant integers!");
                 }
                 AggregateType aggregate = (AggregateType) currentType;
-                final int indexedTypeLength = runtime.getContext().getIndexOffset(1, aggregate);
+                final long indexedTypeLength = runtime.getContext().getIndexOffset(1, aggregate);
                 currentType = aggregate.getElementType(1);
                 final LLVMExpressionNode indexNode = resolve(indexSymbol);
                 currentAddress = runtime.getNodeFactory().createTypedElementPointer(runtime, currentAddress, indexNode, indexedTypeLength, currentType);
             } else {
                 // the index is a constant integer
                 AggregateType aggregate = (AggregateType) currentType;
-                final int addressOffset = runtime.getContext().getIndexOffset(indexInteger, aggregate);
+                final long addressOffset = runtime.getContext().getIndexOffset(indexInteger, aggregate);
                 currentType = aggregate.getElementType(indexInteger);
 
                 // creating a pointer inserts type information, this needs to happen for the address

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMContext.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMContext.java
@@ -266,11 +266,11 @@ public final class LLVMContext {
         return type.getSize(targetDataLayout);
     }
 
-    public int getBytePadding(int offset, Type type) {
+    public int getBytePadding(long offset, Type type) {
         return Type.getPadding(offset, type, targetDataLayout);
     }
 
-    public int getIndexOffset(int index, AggregateType type) {
+    public long getIndexOffset(long index, AggregateType type) {
         return type.getOffsetOf(index, targetDataLayout);
     }
 

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/memory/LLVMMemory.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/memory/LLVMMemory.java
@@ -43,6 +43,7 @@ import com.oracle.truffle.llvm.runtime.floating.LLVM80BitFloat;
 import com.oracle.truffle.llvm.runtime.vector.LLVMAddressVector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMDoubleVector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMFloatVector;
+import com.oracle.truffle.llvm.runtime.vector.LLVMFunctionVector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMI16Vector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMI1Vector;
 import com.oracle.truffle.llvm.runtime.vector.LLVMI32Vector;
@@ -424,6 +425,16 @@ public final class LLVMMemory {
         return LLVMAddressVector.create(vector);
     }
 
+    public LLVMFunctionVector getFunctionVector(LLVMAddress address, int size) {
+        long[] vector = new long[size];
+        long currentPtr = address.getVal();
+        for (int i = 0; i < size; i++) {
+            vector[i] = getAddress(currentPtr).getVal();
+            currentPtr += ADDRESS_LENGTH;
+        }
+        return LLVMFunctionVector.create(vector);
+    }
+
     // watch out for casts such as I32* to I32Vector* when changing the way how vectors are
     // implemented
     public void putVector(LLVMAddress address, LLVMDoubleVector vector) {
@@ -483,6 +494,14 @@ public final class LLVMMemory {
     }
 
     public void putVector(LLVMAddress address, LLVMAddressVector vector) {
+        long currentPtr = address.getVal();
+        for (int i = 0; i < vector.getLength(); i++) {
+            putAddress(currentPtr, vector.getValue(i));
+            currentPtr += ADDRESS_LENGTH;
+        }
+    }
+
+    public void putVector(LLVMAddress address, LLVMFunctionVector vector) {
         long currentPtr = address.getVal();
         for (int i = 0; i < vector.getLength(); i++) {
             putAddress(currentPtr, vector.getValue(i));

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/AggregateType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/AggregateType.java
@@ -32,7 +32,7 @@ package com.oracle.truffle.llvm.runtime.types;
 public abstract class AggregateType extends Type {
     public abstract int getNumberOfElements();
 
-    public abstract Type getElementType(int index);
+    public abstract Type getElementType(long index);
 
-    public abstract int getOffsetOf(int index, DataSpecConverter targetDataLayout);
+    public abstract long getOffsetOf(long index, DataSpecConverter targetDataLayout);
 }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/ArrayType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/ArrayType.java
@@ -79,7 +79,7 @@ public final class ArrayType extends AggregateType {
     }
 
     @Override
-    public Type getElementType(int index) {
+    public Type getElementType(long index) {
         return getElementType();
     }
 
@@ -101,7 +101,7 @@ public final class ArrayType extends AggregateType {
     }
 
     @Override
-    public int getOffsetOf(int index, DataSpecConverter targetDataLayout) {
+    public long getOffsetOf(long index, DataSpecConverter targetDataLayout) {
         return getElementType().getSize(targetDataLayout) * index;
     }
 

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/PointerType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/PointerType.java
@@ -83,12 +83,12 @@ public final class PointerType extends AggregateType {
     }
 
     @Override
-    public int getOffsetOf(int index, DataSpecConverter targetDataLayout) {
+    public long getOffsetOf(long index, DataSpecConverter targetDataLayout) {
         return getPointeeType().getSize(targetDataLayout) * index;
     }
 
     @Override
-    public Type getElementType(int index) {
+    public Type getElementType(long index) {
         return getPointeeType();
     }
 

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/StructureType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/StructureType.java
@@ -85,8 +85,9 @@ public final class StructureType extends AggregateType {
     }
 
     @Override
-    public Type getElementType(int index) {
-        return types[index];
+    public Type getElementType(long index) {
+        assert index == (int) index;
+        return types[(int) index];
     }
 
     @Override
@@ -120,7 +121,7 @@ public final class StructureType extends AggregateType {
     }
 
     @Override
-    public int getOffsetOf(int index, DataSpecConverter targetDataLayout) {
+    public long getOffsetOf(long index, DataSpecConverter targetDataLayout) {
         int offset = 0;
         for (int i = 0; i < index; i++) {
             final Type elementType = types[i];
@@ -130,7 +131,8 @@ public final class StructureType extends AggregateType {
             offset += elementType.getSize(targetDataLayout);
         }
         if (!isPacked && getSize(targetDataLayout) > offset) {
-            offset += Type.getPadding(offset, types[index], targetDataLayout);
+            assert index == (int) index;
+            offset += Type.getPadding(offset, types[(int) index], targetDataLayout);
         }
         return offset;
     }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/Type.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/Type.java
@@ -166,11 +166,12 @@ public abstract class Type {
         return FrameSlotKind.Object;
     }
 
-    public static int getPadding(int offset, int alignment) {
-        return alignment == 0 ? 0 : (alignment - (offset % alignment)) % alignment;
+    public static int getPadding(long offset, int alignment) {
+        assert (alignment == 0 ? 0 : (alignment - (offset % alignment)) % alignment) == (int) (alignment == 0 ? 0 : (alignment - (offset % alignment)) % alignment);
+        return (int) (alignment == 0 ? 0 : (alignment - (offset % alignment)) % alignment);
     }
 
-    public static int getPadding(int offset, Type type, DataSpecConverter targetDataLayout) {
+    public static int getPadding(long offset, Type type, DataSpecConverter targetDataLayout) {
         final int alignment = type.getAlignment(targetDataLayout);
         return getPadding(offset, alignment);
     }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/VectorType.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/types/VectorType.java
@@ -78,7 +78,7 @@ public final class VectorType extends AggregateType {
     }
 
     @Override
-    public Type getElementType(int index) {
+    public Type getElementType(long index) {
         if (index >= length) {
             CompilerDirectives.transferToInterpreter();
             throw new ArrayIndexOutOfBoundsException();
@@ -109,7 +109,7 @@ public final class VectorType extends AggregateType {
     }
 
     @Override
-    public int getOffsetOf(int index, DataSpecConverter targetDataLayout) {
+    public long getOffsetOf(long index, DataSpecConverter targetDataLayout) {
         return getElementType().getSize(targetDataLayout) * index;
     }
 

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/vector/LLVMFunctionVector.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/vector/LLVMFunctionVector.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.runtime.vector;
+
+import java.util.Arrays;
+import java.util.function.BiFunction;
+
+import com.oracle.truffle.llvm.runtime.LLVMAddress;
+import com.oracle.truffle.llvm.runtime.LLVMFunctionDescriptor;
+
+public final class LLVMFunctionVector {
+    private final long[] vector;    // no LLVMAddress stored to improve performance
+
+    public static LLVMFunctionVector create(LLVMFunctionDescriptor[] vector) {
+        return new LLVMFunctionVector(vector);
+    }
+
+    public static LLVMFunctionVector create(long[] vector) {
+        return new LLVMFunctionVector(vector);
+    }
+
+    public static LLVMFunctionVector createNullVector() {
+        return new LLVMFunctionVector();
+    }
+
+    private LLVMFunctionVector(LLVMFunctionDescriptor[] vector) {
+        this.vector = new long[vector.length];
+        for (int i = 0; i < vector.length; i++) {
+            this.vector[i] = vector[i].toNative().asPointer();
+        }
+
+    }
+
+    private LLVMFunctionVector(long[] vector) {
+        this.vector = vector;
+    }
+
+    private LLVMFunctionVector() {
+        this.vector = null;
+    }
+
+    // We do not want to use lambdas because of bad startup
+    private interface Operation {
+        long eval(long a, long b);
+    }
+
+    private static LLVMFunctionVector doOperation(LLVMFunctionVector lhs, LLVMFunctionVector rhs, Operation op) {
+        long[] left = lhs.vector;
+        long[] right = rhs.vector;
+
+        // not sure if this assert is true for llvm ir in general
+        // this implementation however assumes it
+        assert left.length == right.length;
+
+        long[] result = new long[left.length];
+
+        for (int i = 0; i < left.length; i++) {
+            result[i] = op.eval(left[i], right[i]);
+        }
+        return create(result);
+    }
+
+    public LLVMFunctionVector add(LLVMFunctionVector rightValue) {
+        return doOperation(this, rightValue, new Operation() {
+            @Override
+            public long eval(long a, long b) {
+                return a + b;
+            }
+        });
+    }
+
+    public LLVMFunctionVector mul(LLVMFunctionVector rightValue) {
+        return doOperation(this, rightValue, new Operation() {
+            @Override
+            public long eval(long a, long b) {
+                return a * b;
+            }
+        });
+    }
+
+    public LLVMFunctionVector sub(LLVMFunctionVector rightValue) {
+        return doOperation(this, rightValue, new Operation() {
+            @Override
+            public long eval(long a, long b) {
+                return a - b;
+            }
+        });
+    }
+
+    public LLVMFunctionVector div(LLVMFunctionVector rightValue) {
+        return doOperation(this, rightValue, new Operation() {
+            @Override
+            public long eval(long a, long b) {
+                return a / b;
+            }
+        });
+    }
+
+    public LLVMFunctionVector divUnsigned(LLVMFunctionVector rightValue) {
+        return doOperation(this, rightValue, new Operation() {
+            @Override
+            public long eval(long a, long b) {
+                return Long.divideUnsigned(a, b);
+            }
+        });
+    }
+
+    public LLVMFunctionVector rem(LLVMFunctionVector rightValue) {
+        return doOperation(this, rightValue, new Operation() {
+            @Override
+            public long eval(long a, long b) {
+                return a % b;
+            }
+        });
+    }
+
+    public LLVMFunctionVector remUnsigned(LLVMFunctionVector rightValue) {
+        return doOperation(this, rightValue, new Operation() {
+            @Override
+            public long eval(long a, long b) {
+                return Long.remainderUnsigned(a, b);
+            }
+        });
+    }
+
+    public LLVMFunctionVector and(LLVMFunctionVector rightValue) {
+        return doOperation(this, rightValue, new Operation() {
+            @Override
+            public long eval(long a, long b) {
+                return a & b;
+            }
+        });
+    }
+
+    public LLVMFunctionVector or(LLVMFunctionVector rightValue) {
+        return doOperation(this, rightValue, new Operation() {
+            @Override
+            public long eval(long a, long b) {
+                return a | b;
+            }
+        });
+    }
+
+    public LLVMFunctionVector leftShift(LLVMFunctionVector rightValue) {
+        return doOperation(this, rightValue, new Operation() {
+            @Override
+            public long eval(long a, long b) {
+                return a << b;
+            }
+        });
+    }
+
+    public LLVMFunctionVector logicalRightShift(LLVMFunctionVector rightValue) {
+        return doOperation(this, rightValue, new Operation() {
+            @Override
+            public long eval(long a, long b) {
+                return a >>> b;
+            }
+        });
+    }
+
+    public LLVMFunctionVector arithmeticRightShift(LLVMFunctionVector rightValue) {
+        return doOperation(this, rightValue, new Operation() {
+            @Override
+            public long eval(long a, long b) {
+                return a >> b;
+            }
+        });
+    }
+
+    public LLVMFunctionVector xor(LLVMFunctionVector rightValue) {
+        return doOperation(this, rightValue, new Operation() {
+            @Override
+            public long eval(long a, long b) {
+                return a ^ b;
+            }
+        });
+    }
+
+    public long[] getValues() {
+        return vector;
+    }
+
+    public LLVMAddress[] getAddresses() {
+        LLVMAddress[] addresses = new LLVMAddress[vector.length];
+        for (int i = 0; i < vector.length; i++) {
+            addresses[i] = LLVMAddress.fromLong(vector[i]);
+        }
+        return addresses;
+    }
+
+    public long getValue(int index) {
+        return vector[index];
+    }
+
+    public LLVMAddress getAddress(int index) {
+        return LLVMAddress.fromLong(vector[index]);
+    }
+
+    public LLVMFunctionVector insert(LLVMAddress element, int index) {
+        long[] copyOf = Arrays.copyOf(vector, vector.length);
+        copyOf[index] = element.getVal();
+        return create(copyOf);
+    }
+
+    public LLVMFunctionVector insert(long element, int index) {
+        long[] copyOf = Arrays.copyOf(vector, vector.length);
+        copyOf[index] = element;
+        return create(copyOf);
+    }
+
+    public int getLength() {
+        return vector.length;
+    }
+
+    public LLVMI1Vector doCompare(LLVMFunctionVector other, BiFunction<Long, Long, Boolean> compare) {
+        int length = other.getLength();
+        boolean[] values = new boolean[length];
+
+        for (int i = 0; i < length; i++) {
+            values[i] = compare.apply(getValue(i), other.getValue(i));
+        }
+
+        return LLVMI1Vector.create(values);
+    }
+}

--- a/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/Runner.java
+++ b/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/Runner.java
@@ -239,11 +239,13 @@ public final class Runner {
     }
 
     public static void disposeContext(LLVMMemory memory, LLVMContext context) {
-        LLVMFunctionDescriptor atexitDescriptor = context.getGlobalScope().getFunctionDescriptor("@__sulong_funcs_on_exit");
-        if (atexitDescriptor != null) {
-            RootCallTarget atexit = atexitDescriptor.getLLVMIRFunction();
-            try (StackPointer stackPointer = context.getThreadingStack().getStack(memory).takeStackPointer()) {
-                atexit.call(stackPointer.get());
+        if (context.getGlobalScope().functionExists("@__sulong_funcs_on_exit")) {
+            LLVMFunctionDescriptor atexitDescriptor = context.getGlobalScope().getFunctionDescriptor("@__sulong_funcs_on_exit");
+            if (atexitDescriptor != null) {
+                RootCallTarget atexit = atexitDescriptor.getLLVMIRFunction();
+                try (StackPointer stackPointer = context.getThreadingStack().getStack(memory).takeStackPointer()) {
+                    atexit.call(stackPointer.get());
+                }
             }
         }
         for (RootCallTarget destructorFunction : context.getDestructorFunctions()) {


### PR DESCRIPTION
Check if `__sulong_funcs_on_exit` is defined and only then call it. This avoids a problem if the parser itself throws an exception, because in this case there is no `__sulong_funcs_on_exit` and the exception about the missing function would mask the parser exception.