### PR TITLE
Support call to intrinsic from native code

### DIFF
--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/interop/LLVMForeignCallNode.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/interop/LLVMForeignCallNode.java
@@ -167,7 +167,14 @@ abstract class LLVMForeignCallNode extends Node {
     }
 
     protected CallTarget getCallTarget(LLVMFunctionDescriptor function) {
-        return function.getLLVMIRFunction();
+        if (function.isLLVMIRFunction()) {
+            return function.getLLVMIRFunction();
+        } else if (function.isNativeIntrinsicFunction()) {
+            return function.getNativeIntrinsic().cachedCallTarget(function.getType());
+        } else {
+            CompilerDirectives.transferToInterpreter();
+            throw new AssertionError("native function not supported at this point");
+        }
     }
 
     private static void checkArgLength(int minLength, int actualLength) {

--- a/projects/com.oracle.truffle.llvm.test.native/src/caller.c
+++ b/projects/com.oracle.truffle.llvm.test.native/src/caller.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+
+char caller_i8(char (*callback)(char), char value)
+{
+	printf("calling i8 callback\n");
+	return callback(value);
+}
+
+long caller_i64(long (*callback)(long), long value)
+{
+	printf("calling i64 callback\n");
+	return callback(value);
+}
+
+float caller_f32(float (*callback)(float), float value)
+{
+	printf("calling f32 callback\n");
+	return callback(value);
+}
+
+double caller_f64(double (*callback)(double), double value)
+{
+	printf("calling f64 callback\n");
+	return callback(value);
+}

--- a/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/CallbackTest.java
+++ b/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/CallbackTest.java
@@ -72,6 +72,8 @@ public final class CallbackTest extends BaseSulongOnlyHarness {
                         new RunConfiguration(0, null));
         runs.put(new File(OTHER_DIR + "/callbackTest007/callbackTest007" + testSuffix).toPath(),
                         new RunConfiguration(0, null));
+        runs.put(new File(OTHER_DIR + "/callbackIntrinsic/callbackIntrinsic" + testSuffix).toPath(),
+                        new RunConfiguration(0, "calling f64 callback\n-0.416147\n"));
 
         return runs.keySet().stream().map(k -> new Object[]{k, runs.get(k), k.getFileName().toString()}).collect(Collectors.toList());
     }

--- a/tests/other/callbackIntrinsic.c
+++ b/tests/other/callbackIntrinsic.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <math.h>
+
+double caller_f64(double (*)(double), double);
+
+int main(void) {
+  printf("%f\n", caller_f64(cos, 2.0));
+  return 0;
+}


### PR DESCRIPTION
Support something like this:
```c
/* in bitcode: */
#include <math.h>
#include <stdio.h>

double call_native_code(double (*)(double));

int main(void)
{
	printf("%f\n", call_native_code(cos)); /* cos is a sulong intrinsic */
}

/* in native code */
double call_native_code(double (*f)(double))
{
	return f(3.0);
}
```
