### PR TITLE
Use O3 optimization level for native libsulong.so

### DIFF
--- a/projects/com.oracle.truffle.llvm.libraries.native/Makefile
+++ b/projects/com.oracle.truffle.llvm.libraries.native/Makefile
@@ -41,7 +41,7 @@ LLVM_GE_38 := $(shell expr ${LLVM_VERSION} \>= 308)
 LDFLAGS=-shared -g
 endif
 
-CFLAGS=-g -fPIC -DPIC -O0
+CFLAGS=-g -fPIC -DPIC -O3
 CXXFLAGS=${CFLAGS} -DLLVM_VERSION=${LLVM_VERSION}
 
 ifeq (${LLVM_GE_38},1)


### PR DESCRIPTION
Since `libsulong.so` is a native function, optimizations should be used.