### PR TITLE
setjmp/longjmp

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/base/LLVMBasicBlockNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/base/LLVMBasicBlockNode.java
@@ -319,8 +319,8 @@ public class LLVMBasicBlockNode extends LLVMExpressionNode {
          * It is possible to get race conditions (compiler and AST interpeter thread). This avoids a
          * probability > 1.
          *
-         * We make sure that we read each element only once. We also make sure that the compiler reduces the
-         * conditions to constants.
+         * We make sure that we read each element only once. We also make sure that the compiler
+         * reduces the conditions to constants.
          */
         long succCount = 0;
         long totalExecutionCount = 0;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/control/LLVMDispatchBasicBlockNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/control/LLVMDispatchBasicBlockNode.java
@@ -65,7 +65,16 @@ public final class LLVMDispatchBasicBlockNode extends LLVMExpressionNode {
         this.source = source;
     }
 
+    @CompilationFinal private FrameSlot programCounter;
     @CompilationFinal private FrameSlot setjmpReturnValue;
+
+    private FrameSlot getPCSlot() {
+        if (programCounter == null) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            programCounter = getRootNode().getFrameDescriptor().findFrameSlot(LLVMLongjmpException.CURRENT_INSTRUCTION_FRAME_SLOT_ID);
+        }
+        return programCounter;
+    }
 
     private FrameSlot getSetjmpReturnValueSlot() {
         if (setjmpReturnValue == null) {
@@ -79,6 +88,7 @@ public final class LLVMDispatchBasicBlockNode extends LLVMExpressionNode {
     @ExplodeLoop(kind = LoopExplosionKind.MERGE_EXPLODE)
     public Object executeGeneric(VirtualFrame frame) {
         Object returnValue = null;
+        frame.setObject(getPCSlot(), null);
 
         CompilerAsserts.compilationConstant(bodyNodes.length);
         int basicBlockIndex = 0;

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/c/LLVMLongjmp.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/c/LLVMLongjmp.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.intrinsics.c;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.LLVMIntrinsic;
+import com.oracle.truffle.llvm.nodes.memory.load.LLVMI64LoadNodeGen;
+import com.oracle.truffle.llvm.nodes.memory.load.LLVMLoadNode;
+import com.oracle.truffle.llvm.runtime.LLVMLongjmpException;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+@NodeChildren({@NodeChild(value = "env", type = LLVMExpressionNode.class), @NodeChild(value = "val", type = LLVMExpressionNode.class)})
+public abstract class LLVMLongjmp extends LLVMIntrinsic {
+    @Child private LLVMLoadNode loadI64 = LLVMI64LoadNodeGen.create();
+
+    @Specialization
+    protected int doOp(VirtualFrame frame, Object env, int val) {
+        long hash = (long) loadI64.executeWithTarget(frame, env);
+        throw new LLVMLongjmpException(hash, val);
+    }
+}

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/c/LLVMSetjmp.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/c/LLVMSetjmp.java
@@ -63,7 +63,7 @@ public abstract class LLVMSetjmp extends LLVMIntrinsic {
 
     private static int getReturnAndResetValue() {
         CompilerDirectives.transferToInterpreter();
-        Frame frame = Truffle.getRuntime().getCallerFrame().getFrame(FrameAccess.READ_ONLY);
+        Frame frame = Truffle.getRuntime().getCallerFrame().getFrame(FrameAccess.READ_WRITE);
         FrameSlot slot = frame.getFrameDescriptor().findFrameSlot(LLVMLongjmpException.SETJMP_RETURN_VALUE_FRAME_SLOT_ID);
         int value = FrameUtil.getIntSafe(frame, slot);
         frame.setInt(slot, 0);
@@ -72,7 +72,7 @@ public abstract class LLVMSetjmp extends LLVMIntrinsic {
 
     private void storeFrame(long id) {
         CompilerDirectives.transferToInterpreter();
-        Frame frame = Truffle.getRuntime().getCallerFrame().getFrame(FrameAccess.READ_ONLY);
+        Frame frame = Truffle.getRuntime().getCallerFrame().getFrame(FrameAccess.READ_WRITE);
         MaterializedFrame materialized = frame.materialize();
         FrameDescriptor descriptor = materialized.getFrameDescriptor();
         List<? extends FrameSlot> slots = descriptor.getSlots();

--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/c/LLVMSetjmp.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/intrinsics/c/LLVMSetjmp.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.nodes.intrinsics.c;
+
+import java.util.List;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.Frame;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.FrameInstance.FrameAccess;
+import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.frame.FrameUtil;
+import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.llvm.nodes.intrinsics.llvm.LLVMIntrinsic;
+import com.oracle.truffle.llvm.nodes.memory.store.LLVMI64StoreNodeGen;
+import com.oracle.truffle.llvm.nodes.memory.store.LLVMStoreNode;
+import com.oracle.truffle.llvm.runtime.LLVMLongjmpException;
+import com.oracle.truffle.llvm.runtime.LLVMLongjmpTarget;
+import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
+
+@NodeChild(value = "jmpbuf", type = LLVMExpressionNode.class)
+public abstract class LLVMSetjmp extends LLVMIntrinsic {
+    @Child private LLVMStoreNode storeI64 = LLVMI64StoreNodeGen.create();
+
+    private static LLVMLongjmpTarget getPC() {
+        CompilerDirectives.transferToInterpreter();
+        Frame frame = Truffle.getRuntime().getCallerFrame().getFrame(FrameAccess.READ_ONLY);
+        FrameSlot slot = frame.getFrameDescriptor().findFrameSlot(LLVMLongjmpException.CURRENT_INSTRUCTION_FRAME_SLOT_ID);
+        return (LLVMLongjmpTarget) FrameUtil.getObjectSafe(frame, slot);
+    }
+
+    private static int getReturnValue() {
+        CompilerDirectives.transferToInterpreter();
+        Frame frame = Truffle.getRuntime().getCallerFrame().getFrame(FrameAccess.READ_ONLY);
+        FrameSlot slot = frame.getFrameDescriptor().findFrameSlot(LLVMLongjmpException.SETJMP_RETURN_VALUE_FRAME_SLOT_ID);
+        return FrameUtil.getIntSafe(frame, slot);
+    }
+
+    private void storeFrame(long id) {
+        CompilerDirectives.transferToInterpreter();
+        Frame frame = Truffle.getRuntime().getCallerFrame().getFrame(FrameAccess.READ_ONLY);
+        MaterializedFrame materialized = frame.materialize();
+        FrameDescriptor descriptor = materialized.getFrameDescriptor();
+        List<? extends FrameSlot> slots = descriptor.getSlots();
+        Object[] data = new Object[slots.size()];
+        FrameDescriptor newfd = descriptor.copy();
+        for (FrameSlot slot : slots) {
+            newfd.findFrameSlot(slot.getIdentifier()).setKind(slot.getKind());
+            int i = slot.getIndex();
+            switch (slot.getKind()) {
+                case Boolean:
+                    data[i] = FrameUtil.getBooleanSafe(materialized, slot);
+                    break;
+                case Byte:
+                    data[i] = FrameUtil.getByteSafe(materialized, slot);
+                    break;
+                case Int:
+                    data[i] = FrameUtil.getIntSafe(materialized, slot);
+                    break;
+                case Long:
+                    data[i] = FrameUtil.getLongSafe(materialized, slot);
+                    break;
+                case Float:
+                    data[i] = FrameUtil.getFloatSafe(materialized, slot);
+                    break;
+                case Double:
+                    data[i] = FrameUtil.getDoubleSafe(materialized, slot);
+                    break;
+                case Object:
+                    data[i] = FrameUtil.getObjectSafe(materialized, slot);
+                    break;
+                case Illegal:
+                    data[i] = null;
+            }
+        }
+        getContextReference().get().storeSetjmpEnvironment(id, newfd, data);
+    }
+
+    @Specialization
+    protected int doOp(VirtualFrame frame, Object env) {
+        int returnValue = getReturnValue();
+        if (returnValue == 0) {
+            LLVMLongjmpTarget target = getPC();
+            storeFrame(target.getHash());
+            storeI64.executeWithTarget(frame, env, target.getHash());
+        }
+        return returnValue;
+    }
+}

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NFIIntrinsicsProvider.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/NFIIntrinsicsProvider.java
@@ -84,8 +84,10 @@ import com.oracle.truffle.llvm.nodes.intrinsics.c.LLVMCTypeIntrinsicsFactory.LLV
 import com.oracle.truffle.llvm.nodes.intrinsics.c.LLVMCTypeIntrinsicsFactory.LLVMToUpperNodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.c.LLVMCTypeIntrinsicsFactory.LLVMTolowerNodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.c.LLVMExitNodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.c.LLVMLongjmpNodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.c.LLVMMemIntrinsicFactory.LLVMLibcMemcpyNodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.c.LLVMMemIntrinsicFactory.LLVMLibcMemsetNodeGen;
+import com.oracle.truffle.llvm.nodes.intrinsics.c.LLVMSetjmpNodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.c.LLVMSignalNodeGen;
 import com.oracle.truffle.llvm.nodes.intrinsics.c.LLVMSyscall;
 import com.oracle.truffle.llvm.nodes.intrinsics.c.LLVMTruffleReadBytesNodeGen;
@@ -304,6 +306,7 @@ public class NFIIntrinsicsProvider implements NativeIntrinsicProvider, ContextEx
         registerComplexNumberIntrinsics();
         registerCTypeIntrinsics();
         registerManagedAllocationIntrinsics();
+        registerSetjmpIntrinsics();
         return this;
     }
 
@@ -1492,6 +1495,39 @@ public class NFIIntrinsicsProvider implements NativeIntrinsicProvider, ContextEx
             @Override
             protected RootCallTarget generate(FunctionType type) {
                 return wrap("@__muldc3", new LLVMComplexMul(LLVMArgNodeGen.create(1), LLVMArgNodeGen.create(2), LLVMArgNodeGen.create(3), LLVMArgNodeGen.create(4), LLVMArgNodeGen.create(5)));
+            }
+        });
+    }
+
+    protected void registerSetjmpIntrinsics() {
+        factories.put("@_setjmp", new LLVMNativeIntrinsicFactory(true, false) {
+            @Override
+            protected RootCallTarget generate(FunctionType type) {
+                return wrap("@_setjmp", LLVMSetjmpNodeGen.create(LLVMArgNodeGen.create(1)));
+            }
+        });
+        factories.put("@__sigsetjmp", new LLVMNativeIntrinsicFactory(true, false) {
+            @Override
+            protected RootCallTarget generate(FunctionType type) {
+                return wrap("@__sigsetjmp", LLVMSetjmpNodeGen.create(LLVMArgNodeGen.create(1)));
+            }
+        });
+        factories.put("@longjmp", new LLVMNativeIntrinsicFactory(true, false) {
+            @Override
+            protected RootCallTarget generate(FunctionType type) {
+                return wrap("@longjmp", LLVMLongjmpNodeGen.create(LLVMArgNodeGen.create(1), LLVMArgNodeGen.create(2)));
+            }
+        });
+        factories.put("@_longjmp", new LLVMNativeIntrinsicFactory(true, false) {
+            @Override
+            protected RootCallTarget generate(FunctionType type) {
+                return wrap("@_longjmp", LLVMLongjmpNodeGen.create(LLVMArgNodeGen.create(1), LLVMArgNodeGen.create(2)));
+            }
+        });
+        factories.put("@siglongjmp", new LLVMNativeIntrinsicFactory(true, false) {
+            @Override
+            protected RootCallTarget generate(FunctionType type) {
+                return wrap("@siglongjmp", LLVMLongjmpNodeGen.create(LLVMArgNodeGen.create(1), LLVMArgNodeGen.create(2)));
             }
         });
     }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/StackAllocation.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/StackAllocation.java
@@ -43,8 +43,10 @@ import com.oracle.truffle.llvm.parser.model.visitors.FunctionVisitor;
 import com.oracle.truffle.llvm.parser.model.visitors.ModelVisitor;
 import com.oracle.truffle.llvm.parser.model.visitors.ValueInstructionVisitor;
 import com.oracle.truffle.llvm.runtime.LLVMException;
+import com.oracle.truffle.llvm.runtime.LLVMLongjmpException;
 import com.oracle.truffle.llvm.runtime.memory.LLVMStack;
 import com.oracle.truffle.llvm.runtime.types.PointerType;
+import com.oracle.truffle.llvm.runtime.types.PrimitiveType;
 import com.oracle.truffle.llvm.runtime.types.Type;
 import com.oracle.truffle.llvm.runtime.types.VoidType;
 
@@ -87,6 +89,8 @@ public final class StackAllocation {
             final FrameDescriptor frame = new FrameDescriptor();
             frame.addFrameSlot(LLVMException.FRAME_SLOT_ID, null, FrameSlotKind.Object);
             frame.addFrameSlot(LLVMStack.FRAME_ID, new PointerType(VoidType.INSTANCE), FrameSlotKind.Object);
+            frame.addFrameSlot(LLVMLongjmpException.CURRENT_INSTRUCTION_FRAME_SLOT_ID, null, FrameSlotKind.Object);
+            frame.addFrameSlot(LLVMLongjmpException.SETJMP_RETURN_VALUE_FRAME_SLOT_ID, PrimitiveType.I32, FrameSlotKind.Int);
             for (FunctionParameter parameter : functionDefinition.getParameters()) {
                 Type type = parameter.getType();
                 if (parameter.isSourceVariable()) {

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMLongjmpException.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMLongjmpException.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.runtime;
+
+import com.oracle.truffle.api.nodes.ControlFlowException;
+
+public class LLVMLongjmpException extends ControlFlowException {
+    private static final long serialVersionUID = 1L;
+
+    public static final String CURRENT_INSTRUCTION_FRAME_SLOT_ID = "<block-local pc>";
+    public static final String SETJMP_RETURN_VALUE_FRAME_SLOT_ID = "<setjmp return value>";
+
+    private final LLVMLongjmpTarget target;
+    private final int val;
+
+    public LLVMLongjmpException(long target, int val) {
+        this.target = new LLVMLongjmpTarget(target);
+        this.val = val;
+    }
+
+    public LLVMLongjmpException(LLVMLongjmpTarget target, int val) {
+        this.target = target;
+        this.val = val;
+    }
+
+    public LLVMLongjmpTarget getTarget() {
+        return target;
+    }
+
+    public int getValue() {
+        return val;
+    }
+}

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMLongjmpTarget.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMLongjmpTarget.java
@@ -27,21 +27,54 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <stdio.h>
-#include <stdlib.h>
-#include <setjmp.h>
-#include "unsupported.h"
+package com.oracle.truffle.llvm.runtime;
 
-__attribute__((weak)) int setjmp(jmp_buf env) {
-  WARN_UNSUPPORTED(setjmp);
-  return 0;
+import com.oracle.truffle.api.CompilerDirectives.ValueType;
+
+@ValueType
+public final class LLVMLongjmpTarget {
+    public final long node;
+    public final int pc;
+    public final long hash;
+
+    public LLVMLongjmpTarget(long node, int pc) {
+        this.node = node;
+        this.pc = pc;
+        this.hash = hash(node, pc);
+        assert getNode() == node;
+    }
+
+    public LLVMLongjmpTarget(long hash) {
+        this.node = getNode(hash);
+        this.pc = getPC(hash);
+        this.hash = hash;
+    }
+
+    public long getNode() {
+        return node;
+    }
+
+    public int getPC() {
+        return pc;
+    }
+
+    public long getHash() {
+        return hash;
+    }
+
+    public boolean is(long n) {
+        return node == n;
+    }
+
+    public static long hash(long node, long pc) {
+        return node << 31 | pc;
+    }
+
+    public static long getNode(long hash) {
+        return hash >>> 31;
+    }
+
+    public static int getPC(long hash) {
+        return (int) (hash & 0x7FFFFFFF);
+    }
 }
-
-__attribute__((weak)) int sigsetjmp(sigjmp_buf env, int savesigs) {
-  WARN_UNSUPPORTED(sigsetjmp);
-  return 0;
-}
-
-__attribute__((weak)) void longjmp(jmp_buf env, int val) { ERR_UNSUPPORTED(longjmp); }
-
-__attribute__((weak)) void siglongjmp(sigjmp_buf env, int val) { ERR_UNSUPPORTED(siglongjmp); }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMSetjmpException.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMSetjmpException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.runtime;
+
+import com.oracle.truffle.api.nodes.ControlFlowException;
+
+public class LLVMSetjmpException extends ControlFlowException {
+    private static final long serialVersionUID = 1L;
+}


### PR DESCRIPTION
Implement `setjmp`/`longjmp`. This should resolve #51.

With this PR it is possible to run `ex`/`vi` as well as Busybox' `ash` (however `fork` is still not supported, therefore both `ex`/`vi` and Busybox' `ash` are not really useful).