### PR TITLE
Fix memory issue concerning the "insertvalue" instruction

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMBitcodeInstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMBitcodeInstructionVisitor.java
@@ -620,11 +620,10 @@ final class LLVMBitcodeInstructionVisitor implements SymbolVisitor {
         }
         final AggregateType sourceType = (AggregateType) insert.getAggregate().getType();
         final LLVMExpressionNode sourceAggregate = symbols.resolve(insert.getAggregate());
+        final LLVMExpressionNode resultAggregate = symbols.resolve(insert.getAggregate());
         final LLVMExpressionNode valueToInsert = symbols.resolve(insert.getValue());
         final Type valueType = insert.getValue().getType();
         final int targetIndex = insert.getIndex();
-
-        final LLVMExpressionNode resultAggregate = nodeFactory.createAlloca(runtime, sourceType);
 
         final long offset = runtime.getContext().getIndexOffset(targetIndex, sourceType);
         final LLVMExpressionNode result = nodeFactory.createInsertValue(runtime, resultAggregate, sourceAggregate,


### PR DESCRIPTION
This PR should fix a bug in the implementation of the `insertvalue` instruction which causes segmentation faults under certain conditions. More specifically, this bug concerns the allocation of the result aggregate. The LLVM reference ([insertvalue instruction](https://llvm.org/docs/LangRef.html#insertvalue-instruction)) does not indicate that `insertvalue` should behave like `alloca` with regards to its return value. Here is a minimal program which reproduces the observed issue (target: Ubuntu 64-bit): 

```LLVM
target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-unknown-linux-gnu"

define i32 @main()  {
start:
  %agg = alloca { i64 }
  br label %bb1
bb1:
  %0 = load { i64 }, { i64 }* %agg
  %1 = insertvalue { i64 } %0, i64 0, 0
  br label %bb1
  ret i32 0
}
```

Executing this program on Sulong yields a segfault after a few seconds (after several loop iterations). I suspect what happens is basically a stack overflow. 

Note: Replacing `%0` with `undef` in `insertvalue` in the IR shown above will still cause a segfault with the fix enabled. However, this is a different issue concerning `undef` and struct literals. This other issue is not restricted to the `insertvalue` instruction, but also occurs, when `undef` or struct literals are used on `extractvalue` or `store` instructions.