### PR TITLE
Optimize allocation of uniques regions

### DIFF
--- a/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/control/LLVMDispatchBasicBlockNode.java
+++ b/projects/com.oracle.truffle.llvm.nodes/src/com/oracle/truffle/llvm/nodes/control/LLVMDispatchBasicBlockNode.java
@@ -56,7 +56,7 @@ public final class LLVMDispatchBasicBlockNode extends LLVMExpressionNode {
     private final FrameSlot exceptionValueSlot;
     private final LLVMSourceLocation source;
     @Children private final LLVMBasicBlockNode[] bodyNodes;
-    @Child LLVMUniquesRegionAllocNode uniquesRegionAllocNode;
+    @Child private LLVMUniquesRegionAllocNode uniquesRegionAllocNode;
     @CompilationFinal(dimensions = 2) private final FrameSlot[][] beforeBlockNuller;
     @CompilationFinal(dimensions = 2) private final FrameSlot[][] afterBlockNuller;
     @Children private final LLVMStatementNode[] copyArgumentsToFrame;

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
@@ -1324,7 +1324,7 @@ public class BasicNodeFactory implements NodeFactory {
     }
 
     @Override
-    public LLVMExpressionNode createGetStackSpace(LLVMContext context, Type type, UniquesRegion uniquesRegion) {
+    public LLVMExpressionNode createGetUniqueStackSpace(LLVMContext context, Type type, UniquesRegion uniquesRegion) {
         int alignment = context.getByteAlignment(type);
         int byteSize = context.getByteSize(type);
         UniqueSlot slot = uniquesRegion.addSlot(byteSize, alignment);

--- a/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser.factories/src/com/oracle/truffle/llvm/parser/factories/BasicNodeFactory.java
@@ -369,6 +369,7 @@ import com.oracle.truffle.llvm.runtime.memory.LLVMAllocateStructNode;
 import com.oracle.truffle.llvm.runtime.memory.LLVMMemMoveNode;
 import com.oracle.truffle.llvm.runtime.memory.LLVMMemSetNode;
 import com.oracle.truffle.llvm.runtime.memory.LLVMStack.UniquesRegion;
+import com.oracle.truffle.llvm.runtime.memory.LLVMStack.UniquesRegion.UniquesRegionAllocator;
 import com.oracle.truffle.llvm.runtime.memory.LLVMStack.UniquesRegion.UniqueSlot;
 import com.oracle.truffle.llvm.runtime.memory.LLVMUniquesRegionAllocNode;
 import com.oracle.truffle.llvm.runtime.memory.LLVMUniquesRegionAllocNodeGen;
@@ -1465,9 +1466,10 @@ public class BasicNodeFactory implements NodeFactory {
     }
 
     @Override
-    public LLVMExpressionNode createFunctionBlockNode(FrameSlot exceptionValueSlot, List<? extends LLVMStatementNode> allFunctionNodes, UniquesRegion uniquesRegion, FrameSlot[][] beforeBlockNuller,
+    public LLVMExpressionNode createFunctionBlockNode(FrameSlot exceptionValueSlot, List<? extends LLVMStatementNode> allFunctionNodes, UniquesRegionAllocator uniquesRegionAllocator,
+                    FrameSlot[][] beforeBlockNuller,
                     FrameSlot[][] afterBlockNuller, LLVMSourceLocation location, LLVMStatementNode[] copyArgumentsToFrame) {
-        LLVMUniquesRegionAllocNode uniquesRegionAllocNode = LLVMUniquesRegionAllocNodeGen.create(uniquesRegion);
+        LLVMUniquesRegionAllocNode uniquesRegionAllocNode = LLVMUniquesRegionAllocNodeGen.create(uniquesRegionAllocator);
         return new LLVMDispatchBasicBlockNode(exceptionValueSlot, allFunctionNodes.toArray(new LLVMBasicBlockNode[allFunctionNodes.size()]), uniquesRegionAllocNode, beforeBlockNuller,
                         afterBlockNuller, location,
                         copyArgumentsToFrame);

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/GetStackSpaceFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/GetStackSpaceFactory.java
@@ -42,8 +42,8 @@ public interface GetStackSpaceFactory {
         return (nodeFactory, context, type) -> nodeFactory.createAlloca(context, type);
     }
 
-    static GetStackSpaceFactory createGetStackSpaceFactory(UniquesRegion uniquesRegion) {
-        return (nodeFactory, context, type) -> nodeFactory.createGetStackSpace(context, type, uniquesRegion);
+    static GetStackSpaceFactory createGetUniqueStackSpaceFactory(UniquesRegion uniquesRegion) {
+        return (nodeFactory, context, type) -> nodeFactory.createGetUniqueStackSpace(context, type, uniquesRegion);
     }
 
 }

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMBitcodeInstructionVisitor.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMBitcodeInstructionVisitor.java
@@ -241,7 +241,7 @@ final class LLVMBitcodeInstructionVisitor implements SymbolVisitor {
 
         if (targetType instanceof StructureType) {
             argTypes[argIndex] = new PointerType(targetType);
-            argNodes[argIndex] = nodeFactory.createGetStackSpace(context, targetType, uniquesRegion);
+            argNodes[argIndex] = nodeFactory.createGetUniqueStackSpace(context, targetType, uniquesRegion);
             argIndex++;
         }
         for (int i = 0; argIndex < argumentCount; i++) {
@@ -275,7 +275,7 @@ final class LLVMBitcodeInstructionVisitor implements SymbolVisitor {
     @Override
     public void visit(LandingpadInstruction landingpadInstruction) {
         Type type = landingpadInstruction.getType();
-        LLVMExpressionNode allocateLandingPadValue = nodeFactory.createGetStackSpace(context, type, uniquesRegion);
+        LLVMExpressionNode allocateLandingPadValue = nodeFactory.createGetUniqueStackSpace(context, type, uniquesRegion);
         LLVMExpressionNode[] entries = new LLVMExpressionNode[landingpadInstruction.getClauseSymbols().length];
         for (int i = 0; i < entries.length; i++) {
             entries[i] = symbols.resolve(landingpadInstruction.getClauseSymbols()[i]);
@@ -385,7 +385,7 @@ final class LLVMBitcodeInstructionVisitor implements SymbolVisitor {
         argIndex++;
         if (targetType instanceof StructureType) {
             argTypes[argIndex] = new PointerType(targetType);
-            argNodes[argIndex] = nodeFactory.createGetStackSpace(context, targetType, uniquesRegion);
+            argNodes[argIndex] = nodeFactory.createGetUniqueStackSpace(context, targetType, uniquesRegion);
             argIndex++;
         }
         for (int i = 0; argIndex < argumentCount; i++, argIndex++) {
@@ -634,7 +634,7 @@ final class LLVMBitcodeInstructionVisitor implements SymbolVisitor {
         final Type valueType = insert.getValue().getType();
         final int targetIndex = insert.getIndex();
 
-        final LLVMExpressionNode resultAggregate = nodeFactory.createGetStackSpace(context, sourceType, uniquesRegion);
+        final LLVMExpressionNode resultAggregate = nodeFactory.createGetUniqueStackSpace(context, sourceType, uniquesRegion);
 
         final long offset = context.getIndexOffset(targetIndex, sourceType);
         final LLVMExpressionNode result = nodeFactory.createInsertValue(resultAggregate, sourceAggregate,

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LazyToTruffleConverterImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LazyToTruffleConverterImpl.java
@@ -115,8 +115,8 @@ public class LazyToTruffleConverterImpl implements LazyToTruffleConverter {
 
         List<LLVMStatementNode> copyArgumentsToFrame = copyArgumentsToFrame(frame);
         LLVMStatementNode[] copyArgumentsToFrameArray = copyArgumentsToFrame.toArray(new LLVMStatementNode[copyArgumentsToFrame.size()]);
-        LLVMExpressionNode body = runtime.getNodeFactory().createFunctionBlockNode(frame.findFrameSlot(LLVMUserException.FRAME_SLOT_ID), visitor.getBlocks(), uniquesRegion, nullableBeforeBlock,
-                        nullableAfterBlock, location, copyArgumentsToFrameArray);
+        LLVMExpressionNode body = runtime.getNodeFactory().createFunctionBlockNode(frame.findFrameSlot(LLVMUserException.FRAME_SLOT_ID), visitor.getBlocks(), uniquesRegion.build(),
+                        nullableBeforeBlock, nullableAfterBlock, location, copyArgumentsToFrameArray);
 
         RootNode rootNode = runtime.getNodeFactory().createFunctionStartNode(runtime.getContext(), body, method.getSourceSection(), frame, method, source, location);
         method.onAfterParse();

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LazyToTruffleConverterImpl.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LazyToTruffleConverterImpl.java
@@ -96,7 +96,7 @@ public class LazyToTruffleConverterImpl implements LazyToTruffleConverter {
 
         // setup the uniquesRegion
         UniquesRegion uniquesRegion = new UniquesRegion();
-        GetStackSpaceFactory getStackSpaceFactory = GetStackSpaceFactory.createGetStackSpaceFactory(uniquesRegion);
+        GetStackSpaceFactory getStackSpaceFactory = GetStackSpaceFactory.createGetUniqueStackSpaceFactory(uniquesRegion);
 
         LLVMLivenessAnalysisResult liveness = LLVMLivenessAnalysis.computeLiveness(frame, runtime.getContext(), phis, method);
         LLVMSymbolReadResolver symbols = new LLVMSymbolReadResolver(runtime, frame, getStackSpaceFactory);

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactory.java
@@ -55,6 +55,7 @@ import com.oracle.truffle.llvm.runtime.memory.LLVMAllocateStructNode;
 import com.oracle.truffle.llvm.runtime.memory.LLVMMemMoveNode;
 import com.oracle.truffle.llvm.runtime.memory.LLVMMemSetNode;
 import com.oracle.truffle.llvm.runtime.memory.LLVMStack.UniquesRegion;
+import com.oracle.truffle.llvm.runtime.memory.LLVMStack.UniquesRegion.UniquesRegionAllocator;
 import com.oracle.truffle.llvm.runtime.memory.VarargsAreaStackAllocationNode;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMControlFlowNode;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode;
@@ -170,8 +171,8 @@ public interface NodeFactory extends InteropNodeFactory {
 
     LLVMStatementNode createBasicBlockNode(LLVMStatementNode[] statementNodes, LLVMControlFlowNode terminatorNode, int blockId, String blockName);
 
-    LLVMExpressionNode createFunctionBlockNode(FrameSlot exceptionValueSlot, List<? extends LLVMStatementNode> basicBlockNodes, UniquesRegion uniquesRegion, FrameSlot[][] beforeBlockNuller,
-                    FrameSlot[][] afterBlockNuller, LLVMSourceLocation sourceSection, LLVMStatementNode[] copyArgumentsToFrame);
+    LLVMExpressionNode createFunctionBlockNode(FrameSlot exceptionValueSlot, List<? extends LLVMStatementNode> basicBlockNodes, UniquesRegionAllocator uniquesRegionAllocator,
+                    FrameSlot[][] beforeBlockNuller, FrameSlot[][] afterBlockNuller, LLVMSourceLocation sourceSection, LLVMStatementNode[] copyArgumentsToFrame);
 
     RootNode createFunctionStartNode(LLVMContext context, LLVMExpressionNode functionBodyNode, SourceSection sourceSection, FrameDescriptor frameDescriptor, FunctionDefinition functionHeader,
                     Source bcSource, LLVMSourceLocation location);

--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactory.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/NodeFactory.java
@@ -152,7 +152,7 @@ public interface NodeFactory extends InteropNodeFactory {
 
     LLVMExpressionNode createAlloca(LLVMContext context, Type type, int alignment);
 
-    LLVMExpressionNode createGetStackSpace(LLVMContext context, Type type, UniquesRegion uniquesRegion);
+    LLVMExpressionNode createGetUniqueStackSpace(LLVMContext context, Type type, UniquesRegion uniquesRegion);
 
     LLVMExpressionNode createAllocaArray(LLVMContext context, Type elementType, LLVMExpressionNode numElements, int alignment);
 

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/memory/LLVMStack.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/memory/LLVMStack.java
@@ -30,6 +30,8 @@
 package com.oracle.truffle.llvm.runtime.memory;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameUtil;
@@ -63,7 +65,7 @@ public final class LLVMStack {
     }
 
     public final class StackPointer implements AutoCloseable {
-        private long basePointer;
+        @CompilationFinal private long basePointer;
         private final long uniquesRegionBasePointer;
 
         private StackPointer(long basePointer, long uniquesRegionBasePointer) {
@@ -73,6 +75,7 @@ public final class LLVMStack {
 
         public long get(LLVMMemory memory) {
             if (basePointer == 0) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
                 basePointer = getStackPointer(memory);
                 stackPointer = basePointer;
             }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/memory/LLVMStack.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/memory/LLVMStack.java
@@ -30,8 +30,6 @@
 package com.oracle.truffle.llvm.runtime.memory;
 
 import com.oracle.truffle.api.CompilerAsserts;
-import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameUtil;
@@ -65,7 +63,7 @@ public final class LLVMStack {
     }
 
     public final class StackPointer implements AutoCloseable {
-        @CompilationFinal private long basePointer;
+        private long basePointer;
         private final long uniquesRegionBasePointer;
 
         private StackPointer(long basePointer, long uniquesRegionBasePointer) {
@@ -75,7 +73,6 @@ public final class LLVMStack {
 
         public long get(LLVMMemory memory) {
             if (basePointer == 0) {
-                CompilerDirectives.transferToInterpreterAndInvalidate();
                 basePointer = getStackPointer(memory);
                 stackPointer = basePointer;
             }

--- a/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/memory/LLVMUniquesRegionAllocNode.java
+++ b/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/memory/LLVMUniquesRegionAllocNode.java
@@ -35,16 +35,16 @@ import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.llvm.runtime.memory.LLVMStack.UniquesRegion;
+import com.oracle.truffle.llvm.runtime.memory.LLVMStack.UniquesRegion.UniquesRegionAllocator;
 import com.oracle.truffle.llvm.runtime.nodes.api.LLVMNode;
 
 public abstract class LLVMUniquesRegionAllocNode extends LLVMNode {
-    private final UniquesRegion uniquesRegion;
+    private final UniquesRegionAllocator allocator;
 
     @CompilationFinal private FrameSlot stackPointer;
 
-    public LLVMUniquesRegionAllocNode(UniquesRegion uniquesRegion) {
-        this.uniquesRegion = uniquesRegion;
+    public LLVMUniquesRegionAllocNode(UniquesRegionAllocator allocator) {
+        this.allocator = allocator;
     }
 
     public abstract void execute(VirtualFrame frame);
@@ -59,7 +59,7 @@ public abstract class LLVMUniquesRegionAllocNode extends LLVMNode {
 
     @Specialization
     protected void doOp(VirtualFrame frame, @Cached("getLLVMMemory()") LLVMMemory memory) {
-        uniquesRegion.allocate(frame, memory, getStackPointerSlot());
+        allocator.allocate(frame, memory, getStackPointerSlot());
     }
 
 }


### PR DESCRIPTION
When running Rust benchmarks on O0 (emitted IR contains many short functions) I measured a significant performance impact caused by allocations of the newly introduced uniques regions. I identified two major factors which should be addressed by this PR:

- Alignment and size of the uniques regions are not final or compilation final
- Allocation of empty uniques regions

Resolving unique slots to pointers is already a bit faster compared to allocations via `alloca`. I don't know if the fact that pointers to unique slots stay valid until the current frame is closed could be exploited to improve the performance further (it would be enough to resolve unique slots once per active stack frame).