### PR TITLE
Add Support for Protected Main Functions

### DIFF
--- a/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/functions/FunctionDefinition.java
+++ b/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/functions/FunctionDefinition.java
@@ -265,7 +265,9 @@ public final class FunctionDefinition implements Constant, FunctionSymbol, Metad
 
     @Override
     public boolean isExported() {
-        return Linkage.isExported(linkage, visibility);
+        return Linkage.isExported(linkage, visibility) || /*
+                                                           * Swift compiler generates protected main
+                                                           */(name.equals("@main") && visibility == Visibility.PROTECTED);
     }
 
     @Override


### PR DESCRIPTION
Compilers like the Swift one generates main in the form of
`define protected i32 @main`
which is currently not identified as main entry by Sulong but is visible by LLVM lli.